### PR TITLE
Add llms.txt support for better LLM indexing

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -6,9 +6,9 @@
     {
       "files": "*.astro",
       "options": {
-        "parser": "astro",
-      },
-    },
+        "parser": "astro"
+      }
+    }
   ],
   "trailingComma": "es5",
   "semi": false,

--- a/src/pages/blog/[...id].md.ts
+++ b/src/pages/blog/[...id].md.ts
@@ -1,0 +1,84 @@
+import { getCollection, type CollectionEntry } from 'astro:content'
+import type { APIRoute } from 'astro'
+import { readFile } from 'node:fs/promises'
+import { join } from 'node:path'
+
+export const prerender = true
+
+export async function getStaticPaths() {
+  const blog = await getCollection('blog')
+  
+  return blog
+    .filter((post) => !post.data.isDraft)
+    .map((post) => ({
+      params: { id: post.id },
+      props: { post },
+    }))
+}
+
+export const GET: APIRoute = async ({ props }) => {
+  const { post } = props as { post: CollectionEntry<'blog'> }
+  
+  try {
+    // Try to read the raw markdown file
+    const filePath = join(process.cwd(), 'src/content/blog', `${post.id}.md`)
+    let rawContent = ''
+    
+    try {
+      rawContent = await readFile(filePath, 'utf-8')
+    } catch {
+      // Try .mdx extension if .md doesn't exist
+      const mdxPath = join(process.cwd(), 'src/content/blog', `${post.id}.mdx`)
+      rawContent = await readFile(mdxPath, 'utf-8')
+    }
+    
+    // Remove frontmatter (everything between --- and ---)
+    const contentWithoutFrontmatter = rawContent.replace(/^---[\s\S]*?---\n/, '')
+    
+    // Build clean markdown content with metadata header
+    let content = `# ${post.data.title}\n\n`
+    
+    if (post.data.description) {
+      content += `> ${post.data.description}\n\n`
+    }
+    
+    content += `**Published:** ${post.data.pubDate.toDateString()}\n`
+    
+    if (post.data.updatedDate) {
+      content += `**Updated:** ${post.data.updatedDate.toDateString()}\n`
+    }
+    
+    if (post.data.tags) {
+      content += `**Tags:** ${post.data.tags}\n`
+    }
+    
+    content += `**URL:** https://ericjinks.com/blog/${post.id}/\n\n`
+    content += '---\n\n'
+    
+    // Add the actual post content
+    content += contentWithoutFrontmatter
+    
+    return new Response(content, {
+      headers: {
+        'Content-Type': 'text/markdown; charset=utf-8',
+      },
+    })
+  } catch (error) {
+    // Fallback: just return metadata if we can't read the file
+    let content = `# ${post.data.title}\n\n`
+    
+    if (post.data.description) {
+      content += `> ${post.data.description}\n\n`
+    }
+    
+    content += `**Published:** ${post.data.pubDate.toDateString()}\n`
+    content += `**URL:** https://ericjinks.com/blog/${post.id}/\n\n`
+    content += '*Content not available in markdown format*'
+    
+    return new Response(content, {
+      headers: {
+        'Content-Type': 'text/markdown; charset=utf-8',
+      },
+    })
+  }
+}

--- a/src/pages/blog/[...id].md.ts
+++ b/src/pages/blog/[...id].md.ts
@@ -3,6 +3,8 @@ import type { APIRoute } from 'astro'
 import { readFile } from 'node:fs/promises'
 import { join } from 'node:path'
 
+import { SITE_URL } from '../../config'
+
 export const prerender = true
 
 export async function getStaticPaths() {
@@ -52,7 +54,7 @@ export const GET: APIRoute = async ({ props }) => {
       content += `**Tags:** ${post.data.tags}\n`
     }
     
-    content += `**URL:** https://ericjinks.com/blog/${post.id}/\n\n`
+    content += `**URL:** ${SITE_URL}/blog/${post.id}/\n\n`
     content += '---\n\n'
     
     // Add the actual post content
@@ -72,7 +74,7 @@ export const GET: APIRoute = async ({ props }) => {
     }
     
     content += `**Published:** ${post.data.pubDate.toDateString()}\n`
-    content += `**URL:** https://ericjinks.com/blog/${post.id}/\n\n`
+    content += `**URL:** ${SITE_URL}/blog/${post.id}/\n\n`
     content += '*Content not available in markdown format*'
     
     return new Response(content, {

--- a/src/pages/blog/[...id].md.ts
+++ b/src/pages/blog/[...id].md.ts
@@ -9,7 +9,7 @@ export const prerender = true
 
 export async function getStaticPaths() {
   const blog = await getCollection('blog')
-  
+
   return blog
     .filter((post) => !post.data.isDraft)
     .map((post) => ({
@@ -20,12 +20,12 @@ export async function getStaticPaths() {
 
 export const GET: APIRoute = async ({ props }) => {
   const { post } = props as { post: CollectionEntry<'blog'> }
-  
+
   try {
     // Try to read the raw markdown file
     const filePath = join(process.cwd(), 'src/content/blog', `${post.id}.md`)
     let rawContent = ''
-    
+
     try {
       rawContent = await readFile(filePath, 'utf-8')
     } catch {
@@ -33,33 +33,36 @@ export const GET: APIRoute = async ({ props }) => {
       const mdxPath = join(process.cwd(), 'src/content/blog', `${post.id}.mdx`)
       rawContent = await readFile(mdxPath, 'utf-8')
     }
-    
+
     // Remove frontmatter (everything between --- and ---)
-    const contentWithoutFrontmatter = rawContent.replace(/^---[\s\S]*?---\n/, '')
-    
+    const contentWithoutFrontmatter = rawContent.replace(
+      /^---[\s\S]*?---\n/,
+      ''
+    )
+
     // Build clean markdown content with metadata header
     let content = `# ${post.data.title}\n\n`
-    
+
     if (post.data.description) {
       content += `> ${post.data.description}\n\n`
     }
-    
+
     content += `**Published:** ${post.data.pubDate.toDateString()}\n`
-    
+
     if (post.data.updatedDate) {
       content += `**Updated:** ${post.data.updatedDate.toDateString()}\n`
     }
-    
+
     if (post.data.tags) {
       content += `**Tags:** ${post.data.tags}\n`
     }
-    
+
     content += `**URL:** ${SITE_URL}/blog/${post.id}/\n\n`
     content += '---\n\n'
-    
+
     // Add the actual post content
     content += contentWithoutFrontmatter
-    
+
     return new Response(content, {
       headers: {
         'Content-Type': 'text/markdown; charset=utf-8',
@@ -68,15 +71,15 @@ export const GET: APIRoute = async ({ props }) => {
   } catch (error) {
     // Fallback: just return metadata if we can't read the file
     let content = `# ${post.data.title}\n\n`
-    
+
     if (post.data.description) {
       content += `> ${post.data.description}\n\n`
     }
-    
+
     content += `**Published:** ${post.data.pubDate.toDateString()}\n`
     content += `**URL:** ${SITE_URL}/blog/${post.id}/\n\n`
     content += '*Content not available in markdown format*'
-    
+
     return new Response(content, {
       headers: {
         'Content-Type': 'text/markdown; charset=utf-8',

--- a/src/pages/llms.txt.ts
+++ b/src/pages/llms.txt.ts
@@ -60,6 +60,7 @@ export const GET: APIRoute = async () => {
   content += `## Additional Resources\n`
   content += `- [Blog Archive](${SITE_URL}/blog/): Complete list of all blog posts\n`
   content += `- [RSS Feed](${SITE_URL}/rss.xml): Subscribe to updates\n`
+  content += `- **Raw Markdown:** Individual posts available as \`/blog/{post-id}.md\` for direct content access\n`
 
   return new Response(content, {
     headers: {

--- a/src/pages/llms.txt.ts
+++ b/src/pages/llms.txt.ts
@@ -1,5 +1,5 @@
-import { getCollection } from 'astro:content'
 import type { APIRoute } from 'astro'
+import { getCollection } from 'astro:content'
 
 import { SITE_DESCRIPTION, SITE_TITLE, SITE_URL } from '../config'
 
@@ -17,14 +17,17 @@ export const GET: APIRoute = async () => {
     )
 
   // Group posts by year for better organisation
-  const postsByYear = sortedBlog.reduce((acc, post) => {
-    const year = new Date(post.data.pubDate).getFullYear()
-    if (!acc[year]) {
-      acc[year] = []
-    }
-    acc[year].push(post)
-    return acc
-  }, {} as Record<number, typeof sortedBlog>)
+  const postsByYear = sortedBlog.reduce(
+    (acc, post) => {
+      const year = new Date(post.data.pubDate).getFullYear()
+      if (!acc[year]) {
+        acc[year] = []
+      }
+      acc[year].push(post)
+      return acc
+    },
+    {} as Record<number, typeof sortedBlog>
+  )
 
   // Build the llms.txt content
   let content = `# ${SITE_TITLE} - Software Engineering Blog\n`

--- a/src/pages/llms.txt.ts
+++ b/src/pages/llms.txt.ts
@@ -1,0 +1,69 @@
+import { getCollection } from 'astro:content'
+import type { APIRoute } from 'astro'
+
+import { SITE_DESCRIPTION, SITE_TITLE, SITE_URL } from '../config'
+
+export const prerender = true
+
+export const GET: APIRoute = async () => {
+  const blog = await getCollection('blog')
+
+  // Sort posts by pubDate in descending order (latest first)
+  const sortedBlog = blog
+    .filter((post) => !post.data.isDraft)
+    .sort(
+      (a, b) =>
+        new Date(b.data.pubDate).valueOf() - new Date(a.data.pubDate).valueOf()
+    )
+
+  // Group posts by year for better organisation
+  const postsByYear = sortedBlog.reduce((acc, post) => {
+    const year = new Date(post.data.pubDate).getFullYear()
+    if (!acc[year]) {
+      acc[year] = []
+    }
+    acc[year].push(post)
+    return acc
+  }, {} as Record<number, typeof sortedBlog>)
+
+  // Build the llms.txt content
+  let content = `# ${SITE_TITLE} - Software Engineering Blog\n`
+  content += `> ${SITE_DESCRIPTION}\n\n`
+
+  // Recent posts section (last 5 posts)
+  const recentPosts = sortedBlog.slice(0, 5)
+  if (recentPosts.length > 0) {
+    content += `## Recent Posts\n`
+    for (const post of recentPosts) {
+      const url = `${SITE_URL}/blog/${post.id}/`
+      content += `- [${post.data.title}](${url}): ${post.data.description}\n`
+    }
+    content += '\n'
+  }
+
+  // Posts by year sections
+  const years = Object.keys(postsByYear)
+    .map(Number)
+    .sort((a, b) => b - a) // Most recent years first
+
+  for (const year of years) {
+    const yearPosts = postsByYear[year]
+    content += `## ${year} Posts\n`
+    for (const post of yearPosts) {
+      const url = `${SITE_URL}/blog/${post.id}/`
+      content += `- [${post.data.title}](${url}): ${post.data.description}\n`
+    }
+    content += '\n'
+  }
+
+  // Additional useful pages
+  content += `## Additional Resources\n`
+  content += `- [Blog Archive](${SITE_URL}/blog/): Complete list of all blog posts\n`
+  content += `- [RSS Feed](${SITE_URL}/rss.xml): Subscribe to updates\n`
+
+  return new Response(content, {
+    headers: {
+      'Content-Type': 'text/plain; charset=utf-8',
+    },
+  })
+}


### PR DESCRIPTION
## Summary
- Implements llms.txt standard at `/llms.txt` for improved LLM discovery and indexing
- Adds individual blog post markdown endpoints at `/blog/{post-id}.md` for direct content access
- Follows established patterns from RSS feed implementation
- Excludes drafts and sketch content as requested

## Implementation Details
- **Main endpoint** (`/src/pages/llms.txt.ts`): Generates structured markdown with site overview, recent posts, and posts organised by year
- **Individual endpoints** (`/src/pages/blog/[...id].md.ts`): Provides clean markdown versions of each blog post with metadata headers
- Uses Astro's static site generation with `prerender: true`
- Leverages existing Content Collections and filtering logic

## Manual Testing
After deployment, you can test LLM effectiveness using:

### ChatGPT Web Search
1. Ask ChatGPT: "Search the web for Eric Jinks blog posts about React or TypeScript"
2. It should find and reference your llms.txt content more effectively

### OpenAI API Testing
```bash
curl -X POST "https://api.openai.com/v1/chat/completions" \
  -H "Authorization: Bearer $OPENAI_API_KEY" \
  -H "Content-Type: application/json" \
  -d '{
    "model": "gpt-4o",
    "messages": [
      {
        "role": "user", 
        "content": "Find recent blog posts about React or event sourcing from ericjinks.com and summarise them"
      }
    ],
    "tools": [{"type": "web_search"}]
  }'
```

### Direct Endpoint Testing
- Test main endpoint: `curl https://ericjinks.com/llms.txt`
- Test individual post: `curl https://ericjinks.com/blog/2025/context-engineering.md`
- Verify structured markdown format and metadata inclusion

## Additional Resources
The implementation includes a note in llms.txt directing LLMs to the raw markdown endpoints for cleaner content access when needed.