### PR TITLE
Add Pagefind search functionality for GitHub stars

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -5,14 +5,18 @@ import react from '@astrojs/react'
 import sitemap from '@astrojs/sitemap'
 import svelte from '@astrojs/svelte'
 import tailwind from '@astrojs/tailwind'
+import pagefind from 'astro-pagefind'
 
 // https://astro.build/config
 export default defineConfig({
   site: 'https://ericjinks.com',
+  build: {
+    format: 'file',
+  },
   integrations: [mdx(), sitemap(), react(), svelte(), tailwind({
     // Apply Tailwind only to React components and MDX files (hybrid approach)
     applyBaseStyles: false,
-  })],
+  }), pagefind()],
   trailingSlash: 'always',
   markdown: {
     syntaxHighlight: 'shiki',

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,3 +1,4 @@
+import pagefind from 'astro-pagefind'
 import { defineConfig } from 'astro/config'
 
 import mdx from '@astrojs/mdx'
@@ -5,7 +6,6 @@ import react from '@astrojs/react'
 import sitemap from '@astrojs/sitemap'
 import svelte from '@astrojs/svelte'
 import tailwind from '@astrojs/tailwind'
-import pagefind from 'astro-pagefind'
 
 // https://astro.build/config
 export default defineConfig({
@@ -13,10 +13,17 @@ export default defineConfig({
   build: {
     format: 'file',
   },
-  integrations: [mdx(), sitemap(), react(), svelte(), tailwind({
-    // Apply Tailwind only to React components and MDX files (hybrid approach)
-    applyBaseStyles: false,
-  }), pagefind()],
+  integrations: [
+    mdx(),
+    sitemap(),
+    react(),
+    svelte(),
+    tailwind({
+      // Apply Tailwind only to React components and MDX files (hybrid approach)
+      applyBaseStyles: false,
+    }),
+    pagefind(),
+  ],
   trailingSlash: 'always',
   markdown: {
     syntaxHighlight: 'shiki',

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "moment": "^2.29.4",
         "nice-color-palettes": "^3.0.0",
         "openai": "^4.20.1",
+        "pagefind": "^1.3.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-feather": "^2.0.10",

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "@types/react": "^18.2.41",
         "@types/react-dom": "^18.2.17",
         "astro": "^5.12.2",
+        "astro-pagefind": "^1.8.3",
         "canvas-sketch": "^0.7.7",
         "canvas-sketch-util": "^1.10.0",
         "dayjs": "^1.11.10",
@@ -2466,6 +2467,77 @@
       "integrity": "sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==",
       "license": "MIT"
     },
+    "node_modules/@pagefind/darwin-arm64": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@pagefind/darwin-arm64/-/darwin-arm64-1.3.0.tgz",
+      "integrity": "sha512-365BEGl6ChOsauRjyVpBjXybflXAOvoMROw3TucAROHIcdBvXk9/2AmEvGFU0r75+vdQI4LJdJdpH4Y6Yqaj4A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@pagefind/darwin-x64": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@pagefind/darwin-x64/-/darwin-x64-1.3.0.tgz",
+      "integrity": "sha512-zlGHA23uuXmS8z3XxEGmbHpWDxXfPZ47QS06tGUq0HDcZjXjXHeLG+cboOy828QIV5FXsm9MjfkP5e4ZNbOkow==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@pagefind/default-ui": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@pagefind/default-ui/-/default-ui-1.3.0.tgz",
+      "integrity": "sha512-CGKT9ccd3+oRK6STXGgfH+m0DbOKayX6QGlq38TfE1ZfUcPc5+ulTuzDbZUnMo+bubsEOIypm4Pl2iEyzZ1cNg==",
+      "license": "MIT"
+    },
+    "node_modules/@pagefind/linux-arm64": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@pagefind/linux-arm64/-/linux-arm64-1.3.0.tgz",
+      "integrity": "sha512-8lsxNAiBRUk72JvetSBXs4WRpYrQrVJXjlRRnOL6UCdBN9Nlsz0t7hWstRk36+JqHpGWOKYiuHLzGYqYAqoOnQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@pagefind/linux-x64": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@pagefind/linux-x64/-/linux-x64-1.3.0.tgz",
+      "integrity": "sha512-hAvqdPJv7A20Ucb6FQGE6jhjqy+vZ6pf+s2tFMNtMBG+fzcdc91uTw7aP/1Vo5plD0dAOHwdxfkyw0ugal4kcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@pagefind/windows-x64": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@pagefind/windows-x64/-/windows-x64-1.3.0.tgz",
+      "integrity": "sha512-BR1bIRWOMqkf8IoU576YDhij1Wd/Zf2kX/kCI0b2qzCKC8wcc2GQJaaRMCpzvCCrmliO4vtJ6RITp/AnoYUUmQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@parcel/watcher": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.1.tgz",
@@ -2824,6 +2896,12 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@polka/url": {
+      "version": "1.0.0-next.29",
+      "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.29.tgz",
+      "integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
+      "license": "MIT"
     },
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
@@ -4434,6 +4512,20 @@
       },
       "optionalDependencies": {
         "sharp": "^0.33.3"
+      }
+    },
+    "node_modules/astro-pagefind": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/astro-pagefind/-/astro-pagefind-1.8.3.tgz",
+      "integrity": "sha512-Nfo1TdlEHdkXTiI0KpimLqX6awK3qWTil7IOJvk5Q8x+0VBTpIEp9QvGgoAxXDe3upAHLVsg4y7U1uUPm7GC9w==",
+      "license": "MIT",
+      "dependencies": {
+        "@pagefind/default-ui": "^1.2.0",
+        "pagefind": "^1.2.0",
+        "sirv": "^3.0.0"
+      },
+      "peerDependencies": {
+        "astro": "^2.0.4 || ^3 || ^4 || ^5"
       }
     },
     "node_modules/astro/node_modules/lru-cache": {
@@ -12229,6 +12321,22 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/pagefind": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/pagefind/-/pagefind-1.3.0.tgz",
+      "integrity": "sha512-8KPLGT5g9s+olKMRTU9LFekLizkVIu9tes90O1/aigJ0T5LmyPqTzGJrETnSw3meSYg58YH7JTzhTTW/3z6VAw==",
+      "license": "MIT",
+      "bin": {
+        "pagefind": "lib/runner/bin.cjs"
+      },
+      "optionalDependencies": {
+        "@pagefind/darwin-arm64": "1.3.0",
+        "@pagefind/darwin-x64": "1.3.0",
+        "@pagefind/linux-arm64": "1.3.0",
+        "@pagefind/linux-x64": "1.3.0",
+        "@pagefind/windows-x64": "1.3.0"
+      }
+    },
     "node_modules/pako": {
       "version": "0.2.9",
       "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
@@ -14065,6 +14173,20 @@
       "integrity": "sha512-OjyDWm/QZjVbMrPxDVi9b2as+SeNn9EBXlrWVRlFW+TSyWMSXouDryXkQN0vf5YP+QZKobrmkvx1eQYPLtuqfw==",
       "license": "MIT"
     },
+    "node_modules/sirv": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/sirv/-/sirv-3.0.1.tgz",
+      "integrity": "sha512-FoqMu0NCGBLCcAkS1qA+XJIQTR6/JHfQXl+uGteNCQ76T91DMUjPa9xfmeqMY3z80nLSg9yQmNjK0Px6RWsH/A==",
+      "license": "MIT",
+      "dependencies": {
+        "@polka/url": "^1.0.0-next.24",
+        "mrmime": "^2.0.0",
+        "totalist": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/sisteransi": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -15067,6 +15189,15 @@
       "resolved": "https://registry.npmjs.org/tomlify-j0.4/-/tomlify-j0.4-3.0.0.tgz",
       "integrity": "sha512-2Ulkc8T7mXJ2l0W476YC/A209PR38Nw8PuaCNtk9uI3t1zzFdGQeWYGQvmj2PZkVvRC/Yoi4xQKMRnWc/N29tQ==",
       "license": "MIT"
+    },
+    "node_modules/totalist": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
+      "integrity": "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/tr46": {
       "version": "0.0.3",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@types/react": "^18.2.41",
     "@types/react-dom": "^18.2.17",
     "astro": "^5.12.2",
+    "astro-pagefind": "^1.8.3",
     "canvas-sketch": "^0.7.7",
     "canvas-sketch-util": "^1.10.0",
     "dayjs": "^1.11.10",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "astro dev",
     "start": "astro dev",
-    "build": "npm run fetch-stars && astro build",
+    "build": "npm run fetch-stars && astro build && npm run build:pagefind",
+    "build:pagefind": "node scripts/index-github-stars.js",
     "preview": "astro preview",
     "astro": "astro",
     "test:e2e": "playwright test",
@@ -39,6 +40,7 @@
     "moment": "^2.29.4",
     "nice-color-palettes": "^3.0.0",
     "openai": "^4.20.1",
+    "pagefind": "^1.3.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-feather": "^2.0.10",

--- a/scripts/fetch-github-stars.js
+++ b/scripts/fetch-github-stars.js
@@ -30,6 +30,8 @@ if (!GITHUB_TOKEN) {
   process.exit(1)
 }
 
+const forceArg = process.argv.includes('--force')
+
 const dayInMs = 1000 * 60 * 60 * 24 // 1 day in milliseconds
 const isCacheStale =
   fs.existsSync(CACHE_FILE) &&
@@ -184,10 +186,11 @@ function transformStarData(stars) {
 }
 
 async function main() {
-  if (isCacheStale) {
+  if (isCacheStale || forceArg) {
     console.log('✨ Github stars cache is stale, fetching new data...')
   } else {
     console.log('✨ Github stars cache is up to date, skipping fetch...')
+    return
   }
 
   try {
@@ -215,11 +218,13 @@ async function main() {
 
     // Build colors object with only the languages we actually use
     const colours = {}
-    usedLanguages.forEach((language) => {
-      if (allLanguageColors[language] && allLanguageColors[language].color) {
-        colours[language] = allLanguageColors[language].color
-      }
-    })
+    Array.from(usedLanguages)
+      .sort()
+      .forEach((language) => {
+        if (allLanguageColors[language] && allLanguageColors[language].color) {
+          colours[language] = allLanguageColors[language].color
+        }
+      })
 
     console.log(
       `Using colors for ${Object.keys(colours).length} languages out of ${usedLanguages.size} total languages`

--- a/scripts/index-github-stars.js
+++ b/scripts/index-github-stars.js
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+
+import path from 'path'
+import { fileURLToPath } from 'url'
+
+import fs from 'fs/promises'
+import * as pagefind from 'pagefind'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+
+const starsKey = '★'
+
+async function indexGitHubStars() {
+  console.log('Creating Pagefind index for GitHub stars...')
+
+  try {
+    // Read the GitHub stars data
+    const starsDataPath = path.join(__dirname, '../src/data/github-stars.json')
+    const starsData = JSON.parse(await fs.readFile(starsDataPath, 'utf-8'))
+
+    // Create a Pagefind index
+    const { index } = await pagefind.createIndex({
+      forceLanguage: 'en',
+      verbose: true,
+    })
+
+    console.log(`Indexing ${starsData.stars.length} GitHub repositories...`)
+
+    // Index each repository as a separate record
+    let indexedCount = 0
+    for (const repo of starsData.stars) {
+      const starredDate = new Date(repo.starredAt)
+      const year = starredDate.getFullYear()
+
+      // Create content for the repository
+      const content = `${repo.description || 'No description available'}`
+
+      // Add the repository as a custom record
+      const { errors } = await index.addCustomRecord({
+        url: repo.url,
+        content: content,
+        language: 'en',
+        meta: {
+          title: repo.nameWithOwner || 'Unknown Repository',
+          // language: repo.primaryLanguage || '',
+          [starsKey]: repo.stargazerCount?.toString() || '0',
+        },
+        filters: {
+          // year: [year.toString()],
+        },
+        sort: {
+          [starsKey]: repo.stargazerCount?.toString() || '0',
+          date: repo.starredAt,
+        },
+      })
+
+      if (errors.length > 0) {
+        console.error(`Error indexing ${repo.nameWithOwner}:`, errors)
+      } else {
+        indexedCount++
+      }
+    }
+
+    console.log(`Successfully indexed ${indexedCount} repositories`)
+
+    // Write the index files
+    console.log('Writing Pagefind index files...')
+    const { errors: writeErrors } = await index.writeFiles({
+      outputPath: './dist/pagefind',
+    })
+
+    if (writeErrors.length > 0) {
+      console.error('Errors writing index files:', writeErrors)
+    } else {
+      console.log('Pagefind index created successfully!')
+    }
+
+    // Clean up
+    await pagefind.close()
+  } catch (error) {
+    console.error('Error creating Pagefind index:', error)
+    process.exit(1)
+  }
+}
+
+// Run the indexing
+indexGitHubStars()

--- a/src/components/StarsSearch.astro
+++ b/src/components/StarsSearch.astro
@@ -1,0 +1,50 @@
+---
+import Search from 'astro-pagefind/components/Search'
+---
+
+<div class="textContainer">
+  <div class="search-container">
+    <Search
+      className="pagefind-ui"
+      uiOptions={{
+        showImages: false,
+        showSubResults: false,
+        excerptLength: 30,
+      }}
+    />
+  </div>
+</div>
+
+<style>
+  .search-container {
+    margin: 2rem 0;
+    border-radius: 8px;
+
+    --pagefind-ui-scale: 0.9;
+    --pagefind-ui-primary: var(--color-highlight);
+    --pagefind-ui-text: var(--color-text);
+    --pagefind-ui-background: var(--color-background);
+    --pagefind-ui-border: var(--color-text);
+    --pagefind-ui-tag: transparent;
+    --pagefind-ui-border-width: 1px;
+    --pagefind-ui-border-radius: 4px;
+    --pagefind-ui-image-border-radius: 4px;
+    --pagefind-ui-font: var(--font-system);
+    --pagefind-mark: var(--color-highlight);
+  }
+
+  .search-container :global(.pagefind-ui__result) {
+    padding: calc(10px * var(--pagefind-ui-scale)) 0
+      calc(10px * var(--pagefind-ui-scale));
+    border-top: none;
+  }
+
+  .search-container :global(.pagefind-ui__result-title) {
+    text-decoration: underline;
+  }
+
+  .search-container :global(.pagefind-ui__result-excerpt mark) {
+    background-color: var(--color-highlight-almost-transparent);
+    color: var(--color-highlight);
+  }
+</style>

--- a/src/data/github-stars.json
+++ b/src/data/github-stars.json
@@ -1,72 +1,183 @@
 {
   "colours": {
-    "TypeScript": "#3178c6",
-    "Go": "#355570",
-    "Python": "#3572A5",
     "Astro": "#ff5a03",
-    "Shell": "#cecfcb",
-    "JavaScript": "#f1e05a",
-    "Rust": "#dea584",
-    "R": "#198CE7",
-    "Swift": "#F05138",
-    "C++": "#f34b7d",
-    "Objective-C": "#438eff",
-    "MDX": "#fcb32c",
-    "Markdown": "#083fa1",
-    "Cuda": "#3A4E3A",
-    "PowerShell": "#012456",
-    "Dart": "#00B4AB",
-    "PHP": "#4F5D95",
-    "Zig": "#ec915c",
-    "Svelte": "#ff3e00",
-    "HTML": "#e34c26",
+    "Batchfile": "#C1F12E",
+    "Bikeshed": "#5562ac",
     "C": "#555555",
-    "Max": "#c4a79c",
-    "Dockerfile": "#384d54",
-    "SCSS": "#c6538c",
-    "TeX": "#3D6117",
-    "Scala": "#c22d40",
-    "Roff": "#ecdebe",
-    "Java": "#2A6277",
+    "C#": "#178600",
+    "C++": "#f34b7d",
     "CSS": "#663399",
-    "Ruby": "#701516",
-    "Haskell": "#5e5086",
-    "Less": "#1d365d",
-    "Groovy": "#4298b8",
-    "Vue": "#41b883",
-    "Nix": "#7e7eff",
     "Clojure": "#FFA000",
-    "PLpgSQL": "#6bac65",
+    "CoffeeScript": "#244776",
+    "Cuda": "#3A4E3A",
+    "Dart": "#00B4AB",
+    "Dockerfile": "#384d54",
+    "FreeMarker": "#0050b2",
+    "GLSL": "#5686a5",
+    "Gherkin": "#F44D27",
+    "Go": "#355570",
+    "Groovy": "#4298b8",
+    "HCL": "#844FBA",
+    "HTML": "#e34c26",
+    "Haskell": "#5e5086",
+    "Haxe": "#df7900",
     "JSON": "#292929",
+    "Java": "#2A6277",
+    "JavaScript": "#f1e05a",
+    "Kotlin": "#A97BFF",
+    "Less": "#1d365d",
     "Lua": "#000080",
     "MATLAB": "#e16737",
-    "Perl": "#0298c3",
-    "C#": "#178600",
-    "Kotlin": "#A97BFF",
+    "MDX": "#fcb32c",
+    "Makefile": "#427819",
+    "Markdown": "#083fa1",
+    "Max": "#c4a79c",
+    "Nix": "#7e7eff",
     "Nunjucks": "#3d8137",
-    "HCL": "#844FBA",
-    "FreeMarker": "#0050b2",
-    "PureBasic": "#5a6986",
-    "CoffeeScript": "#244776",
-    "Bikeshed": "#5562ac",
-    "QML": "#44a51c",
-    "Jinja": "#a52a22",
-    "GLSL": "#5686a5",
-    "Batchfile": "#C1F12E",
-    "Stylus": "#9e0101",
-    "Haxe": "#df7900",
-    "Gherkin": "#F44D27",
+    "Objective-C": "#438eff",
+    "PHP": "#4F5D95",
+    "PLpgSQL": "#6bac65",
+    "Perl": "#0298c3",
+    "PowerShell": "#012456",
     "Processing": "#0096D8",
-    "Makefile": "#427819"
+    "PureBasic": "#5a6986",
+    "Python": "#3572A5",
+    "QML": "#44a51c",
+    "R": "#198CE7",
+    "Roff": "#ecdebe",
+    "Ruby": "#701516",
+    "Rust": "#dea584",
+    "SCSS": "#c6538c",
+    "Scala": "#c22d40",
+    "Shell": "#cecfcb",
+    "Stylus": "#9e0101",
+    "Svelte": "#ff3e00",
+    "Swift": "#F05138",
+    "TeX": "#3D6117",
+    "TypeScript": "#3178c6",
+    "Vue": "#41b883",
+    "Zig": "#ec915c"
   },
-  "totalCount": 3164,
-  "fetchedAt": "2025-07-24T10:40:29.084Z",
+  "totalCount": 3178,
+  "fetchedAt": "2025-08-03T11:41:11.733Z",
   "perPage": 100,
   "stars": [
     {
+      "nameWithOwner": "shishkin/astro-pagefind",
+      "url": "https://github.com/shishkin/astro-pagefind",
+      "stargazerCount": 400,
+      "description": "Astro integration for Pagefind static site search.",
+      "primaryLanguage": "Astro",
+      "starredAt": "2025-08-03T09:44:07Z"
+    },
+    {
+      "nameWithOwner": "Pagefind/pagefind",
+      "url": "https://github.com/Pagefind/pagefind",
+      "stargazerCount": 4357,
+      "description": "Static low-bandwidth search at scale",
+      "primaryLanguage": "Rust",
+      "starredAt": "2025-08-03T09:42:09Z"
+    },
+    {
+      "nameWithOwner": "anewtypeofinterference/Optician-Sans",
+      "url": "https://github.com/anewtypeofinterference/Optician-Sans",
+      "stargazerCount": 606,
+      "description": "Typeface based on the historical eye charts and optotypes used by opticians world wide.",
+      "primaryLanguage": null,
+      "starredAt": "2025-08-01T23:53:34Z"
+    },
+    {
+      "nameWithOwner": "bejaminjones/bear-notes-mcp",
+      "url": "https://github.com/bejaminjones/bear-notes-mcp",
+      "stargazerCount": 8,
+      "description": "MCP server for Bear app - Full Read + Write AI-powered note management with Claude Desktop",
+      "primaryLanguage": "TypeScript",
+      "starredAt": "2025-08-01T04:03:27Z"
+    },
+    {
+      "nameWithOwner": "ryoppippi/ccusage",
+      "url": "https://github.com/ryoppippi/ccusage",
+      "stargazerCount": 5742,
+      "description": "A CLI tool for analyzing Claude Code usage from local JSONL files.",
+      "primaryLanguage": "TypeScript",
+      "starredAt": "2025-07-31T21:39:18Z"
+    },
+    {
+      "nameWithOwner": "roboflow/supervision",
+      "url": "https://github.com/roboflow/supervision",
+      "stargazerCount": 32958,
+      "description": "We write your reusable computer vision tools. 💜",
+      "primaryLanguage": "Python",
+      "starredAt": "2025-07-31T06:41:48Z"
+    },
+    {
+      "nameWithOwner": "togethercomputer/open_deep_research",
+      "url": "https://github.com/togethercomputer/open_deep_research",
+      "stargazerCount": 331,
+      "description": "Together Open Deep Research",
+      "primaryLanguage": "Python",
+      "starredAt": "2025-07-29T22:01:24Z"
+    },
+    {
+      "nameWithOwner": "togethercomputer/together-cookbook",
+      "url": "https://github.com/togethercomputer/together-cookbook",
+      "stargazerCount": 994,
+      "description": "A collection of notebooks/recipes showcasing usecases of open-source models with Together AI.",
+      "primaryLanguage": "Jupyter Notebook",
+      "starredAt": "2025-07-29T22:01:01Z"
+    },
+    {
+      "nameWithOwner": "musistudio/claude-code-router",
+      "url": "https://github.com/musistudio/claude-code-router",
+      "stargazerCount": 9628,
+      "description": "Use Claude Code as the foundation for coding infrastructure, allowing you to decide how to interact with the model while enjoying updates from Anthropic.",
+      "primaryLanguage": "TypeScript",
+      "starredAt": "2025-07-29T10:46:07Z"
+    },
+    {
+      "nameWithOwner": "hesreallyhim/awesome-claude-code",
+      "url": "https://github.com/hesreallyhim/awesome-claude-code",
+      "stargazerCount": 8385,
+      "description": "A curated list of awesome commands, files, and workflows for Claude Code",
+      "primaryLanguage": "Python",
+      "starredAt": "2025-07-28T22:20:47Z"
+    },
+    {
+      "nameWithOwner": "hesreallyhim/awesome-claude-code-agents",
+      "url": "https://github.com/hesreallyhim/awesome-claude-code-agents",
+      "stargazerCount": 338,
+      "description": "A curated list of awesome Claude Code Sub-Agents",
+      "primaryLanguage": null,
+      "starredAt": "2025-07-28T22:20:21Z"
+    },
+    {
+      "nameWithOwner": "vijaythecoder/awesome-claude-agents",
+      "url": "https://github.com/vijaythecoder/awesome-claude-agents",
+      "stargazerCount": 2557,
+      "description": "An orchestrated sub agent dev team powered by claude code",
+      "primaryLanguage": null,
+      "starredAt": "2025-07-28T21:35:52Z"
+    },
+    {
+      "nameWithOwner": "haydenbleasel/kibo",
+      "url": "https://github.com/haydenbleasel/kibo",
+      "stargazerCount": 2070,
+      "description": "A custom registry of composable, accessible and open source shadcn/ui components.",
+      "primaryLanguage": "TypeScript",
+      "starredAt": "2025-07-25T10:33:18Z"
+    },
+    {
+      "nameWithOwner": "github-linguist/linguist",
+      "url": "https://github.com/github-linguist/linguist",
+      "stargazerCount": 12909,
+      "description": "Language Savant. If your repository's language is being reported incorrectly, send us a pull request!",
+      "primaryLanguage": "Ruby",
+      "starredAt": "2025-07-24T10:43:01Z"
+    },
+    {
       "nameWithOwner": "untitleduico/react",
       "url": "https://github.com/untitleduico/react",
-      "stargazerCount": 777,
+      "stargazerCount": 904,
       "description": "Untitled UI React is the world’s largest collection of open-source React components built with Tailwind CSS and React Aria. Just copy, paste, and build.",
       "primaryLanguage": "TypeScript",
       "starredAt": "2025-07-24T00:31:12Z"
@@ -74,7 +185,7 @@
     {
       "nameWithOwner": "github/github-mcp-server",
       "url": "https://github.com/github/github-mcp-server",
-      "stargazerCount": 18908,
+      "stargazerCount": 19986,
       "description": "GitHub's official MCP Server",
       "primaryLanguage": "Go",
       "starredAt": "2025-07-23T23:52:04Z"
@@ -82,7 +193,7 @@
     {
       "nameWithOwner": "chiphuyen/sniffly",
       "url": "https://github.com/chiphuyen/sniffly",
-      "stargazerCount": 436,
+      "stargazerCount": 665,
       "description": "Claude Code dashboard with usage stats, error analysis, and sharable feature",
       "primaryLanguage": "Python",
       "starredAt": "2025-07-22T07:51:54Z"
@@ -98,7 +209,7 @@
     {
       "nameWithOwner": "getAsterisk/claudia",
       "url": "https://github.com/getAsterisk/claudia",
-      "stargazerCount": 9667,
+      "stargazerCount": 10541,
       "description": "A powerful GUI app and Toolkit for Claude Code - Create custom agents, manage interactive Claude Code sessions, run secure background agents, and more.",
       "primaryLanguage": "TypeScript",
       "starredAt": "2025-07-21T01:48:14Z"
@@ -106,7 +217,7 @@
     {
       "nameWithOwner": "the3ash/astro-chiri",
       "url": "https://github.com/the3ash/astro-chiri",
-      "stargazerCount": 33,
+      "stargazerCount": 42,
       "description": "Effortlessly share your thoughts in a calm & dustless space.",
       "primaryLanguage": "Astro",
       "starredAt": "2025-07-20T22:36:55Z"
@@ -114,7 +225,7 @@
     {
       "nameWithOwner": "Dicklesworthstone/claude_code_agent_farm",
       "url": "https://github.com/Dicklesworthstone/claude_code_agent_farm",
-      "stargazerCount": 275,
+      "stargazerCount": 390,
       "description": "",
       "primaryLanguage": "Shell",
       "starredAt": "2025-07-20T00:19:03Z"
@@ -122,7 +233,7 @@
     {
       "nameWithOwner": "smtg-ai/claude-squad",
       "url": "https://github.com/smtg-ai/claude-squad",
-      "stargazerCount": 3562,
+      "stargazerCount": 3888,
       "description": "Manage multiple AI terminal agents like Claude Code, Aider, Codex, OpenCode, and Amp.",
       "primaryLanguage": "Go",
       "starredAt": "2025-07-19T23:00:17Z"
@@ -130,7 +241,7 @@
     {
       "nameWithOwner": "ghuntley/amazon-kiro.kiro-agent-source-code-analysis",
       "url": "https://github.com/ghuntley/amazon-kiro.kiro-agent-source-code-analysis",
-      "stargazerCount": 218,
+      "stargazerCount": 284,
       "description": "",
       "primaryLanguage": "JavaScript",
       "starredAt": "2025-07-19T22:19:34Z"
@@ -138,7 +249,7 @@
     {
       "nameWithOwner": "trpc/trpc",
       "url": "https://github.com/trpc/trpc",
-      "stargazerCount": 37965,
+      "stargazerCount": 38094,
       "description": "🧙‍♀️  Move Fast and Break Nothing. End-to-end typesafe APIs made easy. ",
       "primaryLanguage": "TypeScript",
       "starredAt": "2025-07-19T12:08:39Z"
@@ -146,7 +257,7 @@
     {
       "nameWithOwner": "t3-oss/create-t3-app",
       "url": "https://github.com/t3-oss/create-t3-app",
-      "stargazerCount": 27620,
+      "stargazerCount": 27697,
       "description": "The best way to start a full-stack, typesafe Next.js app ",
       "primaryLanguage": "TypeScript",
       "starredAt": "2025-07-19T12:07:04Z"
@@ -154,7 +265,7 @@
     {
       "nameWithOwner": "jujumilk3/leaked-system-prompts",
       "url": "https://github.com/jujumilk3/leaked-system-prompts",
-      "stargazerCount": 11961,
+      "stargazerCount": 12178,
       "description": "Collection of leaked system prompts",
       "primaryLanguage": null,
       "starredAt": "2025-07-19T11:36:55Z"
@@ -162,7 +273,7 @@
     {
       "nameWithOwner": "opencode-ai/opencode",
       "url": "https://github.com/opencode-ai/opencode",
-      "stargazerCount": 8850,
+      "stargazerCount": 9155,
       "description": "A powerful AI coding agent. Built for the terminal.",
       "primaryLanguage": "Go",
       "starredAt": "2025-07-19T07:11:54Z"
@@ -170,7 +281,7 @@
     {
       "nameWithOwner": "cassidoo/pocketcal",
       "url": "https://github.com/cassidoo/pocketcal",
-      "stargazerCount": 79,
+      "stargazerCount": 85,
       "description": "Pick dates, share a link, and that's your calendar!",
       "primaryLanguage": "TypeScript",
       "starredAt": "2025-07-19T06:24:42Z"
@@ -178,7 +289,7 @@
     {
       "nameWithOwner": "langfuse/langfuse",
       "url": "https://github.com/langfuse/langfuse",
-      "stargazerCount": 14069,
+      "stargazerCount": 14563,
       "description": "🪢 Open source LLM engineering platform: LLM Observability, metrics, evals, prompt management, playground, datasets. Integrates with OpenTelemetry, Langchain, OpenAI SDK, LiteLLM, and more. 🍊YC W23 ",
       "primaryLanguage": "TypeScript",
       "starredAt": "2025-07-19T02:21:26Z"
@@ -186,7 +297,7 @@
     {
       "nameWithOwner": "BloopAI/vibe-kanban",
       "url": "https://github.com/BloopAI/vibe-kanban",
-      "stargazerCount": 3267,
+      "stargazerCount": 3593,
       "description": "Kanban board to manage your AI coding agents",
       "primaryLanguage": "Rust",
       "starredAt": "2025-07-18T14:13:25Z"
@@ -194,7 +305,7 @@
     {
       "nameWithOwner": "upstash/context7",
       "url": "https://github.com/upstash/context7",
-      "stargazerCount": 21979,
+      "stargazerCount": 23733,
       "description": "Context7 MCP Server -- Up-to-date code documentation for LLMs and AI code editors",
       "primaryLanguage": "JavaScript",
       "starredAt": "2025-07-17T22:19:15Z"
@@ -202,7 +313,7 @@
     {
       "nameWithOwner": "aidenybai/react-scan",
       "url": "https://github.com/aidenybai/react-scan",
-      "stargazerCount": 19015,
+      "stargazerCount": 19086,
       "description": "Scan for React performance issues and eliminate slow renders in your app",
       "primaryLanguage": "TypeScript",
       "starredAt": "2025-07-11T22:40:36Z"
@@ -210,7 +321,7 @@
     {
       "nameWithOwner": "Breakthrough/PySceneDetect",
       "url": "https://github.com/Breakthrough/PySceneDetect",
-      "stargazerCount": 4062,
+      "stargazerCount": 4084,
       "description": ":movie_camera: Python and OpenCV-based scene cut/transition detection program & library.",
       "primaryLanguage": "Python",
       "starredAt": "2025-07-10T02:03:17Z"
@@ -218,7 +329,7 @@
     {
       "nameWithOwner": "Effect-TS/effect",
       "url": "https://github.com/Effect-TS/effect",
-      "stargazerCount": 10683,
+      "stargazerCount": 10771,
       "description": "Build production-ready applications in TypeScript",
       "primaryLanguage": "TypeScript",
       "starredAt": "2025-07-02T22:19:26Z"
@@ -226,7 +337,7 @@
     {
       "nameWithOwner": "greatfrontend/awesome-front-end-system-design",
       "url": "https://github.com/greatfrontend/awesome-front-end-system-design",
-      "stargazerCount": 7712,
+      "stargazerCount": 7727,
       "description": "Curated front end system design resources for interviews and learning",
       "primaryLanguage": null,
       "starredAt": "2025-06-30T07:46:01Z"
@@ -234,7 +345,7 @@
     {
       "nameWithOwner": "facebook/lexical",
       "url": "https://github.com/facebook/lexical",
-      "stargazerCount": 21644,
+      "stargazerCount": 21699,
       "description": "Lexical is an extensible text editor framework that provides excellent reliability, accessibility and performance.",
       "primaryLanguage": "TypeScript",
       "starredAt": "2025-06-30T03:59:25Z"
@@ -242,7 +353,7 @@
     {
       "nameWithOwner": "simonw/llm",
       "url": "https://github.com/simonw/llm",
-      "stargazerCount": 9052,
+      "stargazerCount": 9214,
       "description": "Access large language models from the command-line",
       "primaryLanguage": "Python",
       "starredAt": "2025-06-29T12:05:56Z"
@@ -250,7 +361,7 @@
     {
       "nameWithOwner": "ByteByteGoHq/system-design-101",
       "url": "https://github.com/ByteByteGoHq/system-design-101",
-      "stargazerCount": 74977,
+      "stargazerCount": 75154,
       "description": "Explain complex systems using visuals and simple terms. Help you prepare for system design interviews.",
       "primaryLanguage": null,
       "starredAt": "2025-06-26T04:24:14Z"
@@ -258,7 +369,7 @@
     {
       "nameWithOwner": "copier-org/copier",
       "url": "https://github.com/copier-org/copier",
-      "stargazerCount": 2708,
+      "stargazerCount": 2727,
       "description": "Library and command-line utility for rendering projects templates.",
       "primaryLanguage": "Python",
       "starredAt": "2025-06-24T23:52:21Z"
@@ -282,7 +393,7 @@
     {
       "nameWithOwner": "giscus/giscus-component",
       "url": "https://github.com/giscus/giscus-component",
-      "stargazerCount": 401,
+      "stargazerCount": 399,
       "description": "Component library for giscus, a comment system powered by GitHub Discussions.",
       "primaryLanguage": "TypeScript",
       "starredAt": "2025-06-20T11:29:17Z"
@@ -306,7 +417,7 @@
     {
       "nameWithOwner": "PrefectHQ/prefect",
       "url": "https://github.com/PrefectHQ/prefect",
-      "stargazerCount": 19849,
+      "stargazerCount": 19924,
       "description": "Prefect is a workflow orchestration framework for building resilient data pipelines in Python.",
       "primaryLanguage": "Python",
       "starredAt": "2025-06-13T03:13:12Z"
@@ -314,7 +425,7 @@
     {
       "nameWithOwner": "tidyverse/ellmer",
       "url": "https://github.com/tidyverse/ellmer",
-      "stargazerCount": 500,
+      "stargazerCount": 509,
       "description": "Call LLM APIs from R",
       "primaryLanguage": "R",
       "starredAt": "2025-06-12T01:02:00Z"
@@ -322,7 +433,7 @@
     {
       "nameWithOwner": "pmusolino/AI-Git-Narrator",
       "url": "https://github.com/pmusolino/AI-Git-Narrator",
-      "stargazerCount": 104,
+      "stargazerCount": 108,
       "description": "Command-line tool for generating Git commit messages and PR descriptions with AI. Supports staged/unstaged changes and customizable AI parameters.",
       "primaryLanguage": "Swift",
       "starredAt": "2025-06-09T20:50:37Z"
@@ -338,7 +449,7 @@
     {
       "nameWithOwner": "Anjok07/ultimatevocalremovergui",
       "url": "https://github.com/Anjok07/ultimatevocalremovergui",
-      "stargazerCount": 21305,
+      "stargazerCount": 21403,
       "description": " GUI for a Vocal Remover that uses Deep Neural Networks.",
       "primaryLanguage": "Python",
       "starredAt": "2025-06-08T11:51:09Z"
@@ -346,7 +457,7 @@
     {
       "nameWithOwner": "nuance-dev/achico",
       "url": "https://github.com/nuance-dev/achico",
-      "stargazerCount": 158,
+      "stargazerCount": 161,
       "description": "A minimal free macOS local file compressor app",
       "primaryLanguage": "Swift",
       "starredAt": "2025-05-26T23:48:20Z"
@@ -354,7 +465,7 @@
     {
       "nameWithOwner": "kepano/defuddle",
       "url": "https://github.com/kepano/defuddle",
-      "stargazerCount": 2587,
+      "stargazerCount": 2645,
       "description": "Extract the main content from web pages.",
       "primaryLanguage": "TypeScript",
       "starredAt": "2025-05-24T08:45:43Z"
@@ -362,7 +473,7 @@
     {
       "nameWithOwner": "open-spaced-repetition/awesome-fsrs",
       "url": "https://github.com/open-spaced-repetition/awesome-fsrs",
-      "stargazerCount": 286,
+      "stargazerCount": 289,
       "description": "A curated list of awesome FSRS implementations, papers and resources",
       "primaryLanguage": null,
       "starredAt": "2025-05-24T06:06:30Z"
@@ -370,7 +481,7 @@
     {
       "nameWithOwner": "reflex-dev/reflex",
       "url": "https://github.com/reflex-dev/reflex",
-      "stargazerCount": 23647,
+      "stargazerCount": 23892,
       "description": "🕸️ Web apps in pure Python 🐍",
       "primaryLanguage": "Python",
       "starredAt": "2025-05-24T03:43:04Z"
@@ -386,7 +497,7 @@
     {
       "nameWithOwner": "charlesvestal/extending-move",
       "url": "https://github.com/charlesvestal/extending-move",
-      "stargazerCount": 76,
+      "stargazerCount": 80,
       "description": "Tools for extending the Ableton Move. ",
       "primaryLanguage": "Python",
       "starredAt": "2025-05-16T12:13:59Z"
@@ -394,7 +505,7 @@
     {
       "nameWithOwner": "rerun-io/rerun",
       "url": "https://github.com/rerun-io/rerun",
-      "stargazerCount": 8923,
+      "stargazerCount": 8968,
       "description": "Visualize streams of multimodal data. Free, fast, easy to use, and simple to integrate. Built in Rust.",
       "primaryLanguage": "Rust",
       "starredAt": "2025-05-13T05:40:21Z"
@@ -402,7 +513,7 @@
     {
       "nameWithOwner": "TanStack/router",
       "url": "https://github.com/TanStack/router",
-      "stargazerCount": 10629,
+      "stargazerCount": 10723,
       "description": "🤖 Fully typesafe Router for React (and friends) w/ built-in caching, 1st class search-param APIs, client-side cache integration and isomorphic rendering.",
       "primaryLanguage": "TypeScript",
       "starredAt": "2025-05-06T02:41:03Z"
@@ -410,7 +521,7 @@
     {
       "nameWithOwner": "ThePrimeagen/kata-machine",
       "url": "https://github.com/ThePrimeagen/kata-machine",
-      "stargazerCount": 1391,
+      "stargazerCount": 1395,
       "description": "",
       "primaryLanguage": "TypeScript",
       "starredAt": "2025-04-22T11:20:34Z"
@@ -418,7 +529,7 @@
     {
       "nameWithOwner": "iina/iina",
       "url": "https://github.com/iina/iina",
-      "stargazerCount": 41120,
+      "stargazerCount": 41211,
       "description": "The modern video player for macOS.",
       "primaryLanguage": "Swift",
       "starredAt": "2025-04-20T22:54:06Z"
@@ -426,7 +537,7 @@
     {
       "nameWithOwner": "jlevy/og-equity-compensation",
       "url": "https://github.com/jlevy/og-equity-compensation",
-      "stargazerCount": 11360,
+      "stargazerCount": 11375,
       "description": "Stock options, RSUs, taxes — read the latest edition: www.holloway.com/ec",
       "primaryLanguage": null,
       "starredAt": "2025-04-20T03:44:11Z"
@@ -434,7 +545,7 @@
     {
       "nameWithOwner": "Sequel-Ace/Sequel-Ace",
       "url": "https://github.com/Sequel-Ace/Sequel-Ace",
-      "stargazerCount": 7054,
+      "stargazerCount": 7063,
       "description": "MySQL/MariaDB database management for macOS",
       "primaryLanguage": "Objective-C",
       "starredAt": "2025-04-20T03:09:48Z"
@@ -442,7 +553,7 @@
     {
       "nameWithOwner": "greatfrontend/top-reactjs-interview-questions",
       "url": "https://github.com/greatfrontend/top-reactjs-interview-questions",
-      "stargazerCount": 2746,
+      "stargazerCount": 2920,
       "description": "Most important React.js interview questions for busy Front End Engineers (updated for 2025)",
       "primaryLanguage": "MDX",
       "starredAt": "2025-04-19T00:01:36Z"
@@ -450,7 +561,7 @@
     {
       "nameWithOwner": "greatfrontend/top-javascript-interview-questions",
       "url": "https://github.com/greatfrontend/top-javascript-interview-questions",
-      "stargazerCount": 6596,
+      "stargazerCount": 6782,
       "description": "Top JavaScript interview questions and answers for Front End Engineers in 2025",
       "primaryLanguage": "MDX",
       "starredAt": "2025-04-19T00:01:28Z"
@@ -458,7 +569,7 @@
     {
       "nameWithOwner": "openai/codex",
       "url": "https://github.com/openai/codex",
-      "stargazerCount": 31341,
+      "stargazerCount": 31713,
       "description": "Lightweight coding agent that runs in your terminal",
       "primaryLanguage": "Rust",
       "starredAt": "2025-04-17T09:39:47Z"
@@ -466,7 +577,7 @@
     {
       "nameWithOwner": "zen-browser/desktop",
       "url": "https://github.com/zen-browser/desktop",
-      "stargazerCount": 34638,
+      "stargazerCount": 34844,
       "description": "Welcome to a calmer internet",
       "primaryLanguage": "C++",
       "starredAt": "2025-04-17T09:09:05Z"
@@ -474,7 +585,7 @@
     {
       "nameWithOwner": "codecrafters-io/build-your-own-x",
       "url": "https://github.com/codecrafters-io/build-your-own-x",
-      "stargazerCount": 403487,
+      "stargazerCount": 406512,
       "description": "Master programming by recreating your favorite technologies from scratch.",
       "primaryLanguage": "Markdown",
       "starredAt": "2025-04-14T09:59:19Z"
@@ -482,7 +593,7 @@
     {
       "nameWithOwner": "goldbergyoni/nodejs-testing-best-practices",
       "url": "https://github.com/goldbergyoni/nodejs-testing-best-practices",
-      "stargazerCount": 4128,
+      "stargazerCount": 4135,
       "description": "Beyond the basics of Node.js testing. Including a super-comprehensive best practices list and an example app (April 2025)",
       "primaryLanguage": "JavaScript",
       "starredAt": "2025-04-14T08:34:25Z"
@@ -490,7 +601,7 @@
     {
       "nameWithOwner": "honojs/hono",
       "url": "https://github.com/honojs/hono",
-      "stargazerCount": 25367,
+      "stargazerCount": 25566,
       "description": "Web framework built on Web Standards",
       "primaryLanguage": "TypeScript",
       "starredAt": "2025-04-14T08:05:46Z"
@@ -498,7 +609,7 @@
     {
       "nameWithOwner": "ricardomatias/ableton-live",
       "url": "https://github.com/ricardomatias/ableton-live",
-      "stargazerCount": 140,
+      "stargazerCount": 141,
       "description": "A library for communicating with Ableton Live via WebSockets, works both in NodeJS and in the Browser.",
       "primaryLanguage": "TypeScript",
       "starredAt": "2025-04-11T21:57:40Z"
@@ -506,7 +617,7 @@
     {
       "nameWithOwner": "poteto/hiring-without-whiteboards",
       "url": "https://github.com/poteto/hiring-without-whiteboards",
-      "stargazerCount": 49032,
+      "stargazerCount": 49076,
       "description": "⭐️  Companies that don't have a broken hiring process",
       "primaryLanguage": "JavaScript",
       "starredAt": "2025-04-11T08:46:54Z"
@@ -514,7 +625,7 @@
     {
       "nameWithOwner": "ahujasid/ableton-mcp",
       "url": "https://github.com/ahujasid/ableton-mcp",
-      "stargazerCount": 1798,
+      "stargazerCount": 1829,
       "description": "",
       "primaryLanguage": "Python",
       "starredAt": "2025-04-02T08:25:55Z"
@@ -522,7 +633,7 @@
     {
       "nameWithOwner": "computerhistory/AlexNet-Source-Code",
       "url": "https://github.com/computerhistory/AlexNet-Source-Code",
-      "stargazerCount": 2679,
+      "stargazerCount": 2686,
       "description": "This package contains the original 2012 AlexNet code.",
       "primaryLanguage": "Cuda",
       "starredAt": "2025-03-26T08:21:08Z"
@@ -530,7 +641,7 @@
     {
       "nameWithOwner": "christian-fei/my-yt",
       "url": "https://github.com/christian-fei/my-yt",
-      "stargazerCount": 957,
+      "stargazerCount": 968,
       "description": "A clean and minimal youtube frontend, without all the ads and whistles",
       "primaryLanguage": "JavaScript",
       "starredAt": "2025-03-23T09:37:02Z"
@@ -538,7 +649,7 @@
     {
       "nameWithOwner": "suitenumerique/docs",
       "url": "https://github.com/suitenumerique/docs",
-      "stargazerCount": 12810,
+      "stargazerCount": 13113,
       "description": "A collaborative note taking, wiki and documentation platform that scales. Built with Django and React. ",
       "primaryLanguage": "Python",
       "starredAt": "2025-03-23T08:30:11Z"
@@ -546,7 +657,7 @@
     {
       "nameWithOwner": "mfontanini/presenterm",
       "url": "https://github.com/mfontanini/presenterm",
-      "stargazerCount": 6619,
+      "stargazerCount": 6668,
       "description": "A markdown terminal slideshow tool",
       "primaryLanguage": "Rust",
       "starredAt": "2025-03-15T09:42:46Z"
@@ -554,7 +665,7 @@
     {
       "nameWithOwner": "LadybirdBrowser/ladybird",
       "url": "https://github.com/LadybirdBrowser/ladybird",
-      "stargazerCount": 45686,
+      "stargazerCount": 46156,
       "description": "Truly independent web browser",
       "primaryLanguage": "C++",
       "starredAt": "2025-02-28T03:14:02Z"
@@ -562,7 +673,7 @@
     {
       "nameWithOwner": "goatplatform/goatdb",
       "url": "https://github.com/goatplatform/goatdb",
-      "stargazerCount": 540,
+      "stargazerCount": 539,
       "description": "An Embedded, Distributed, Document DB",
       "primaryLanguage": "TypeScript",
       "starredAt": "2025-02-26T11:43:18Z"
@@ -570,7 +681,7 @@
     {
       "nameWithOwner": "ggerganov/ggwave",
       "url": "https://github.com/ggerganov/ggwave",
-      "stargazerCount": 6931,
+      "stargazerCount": 6991,
       "description": "Tiny data-over-sound library",
       "primaryLanguage": "C++",
       "starredAt": "2025-02-26T09:11:55Z"
@@ -578,7 +689,7 @@
     {
       "nameWithOwner": "anthropics/claude-code",
       "url": "https://github.com/anthropics/claude-code",
-      "stargazerCount": 25708,
+      "stargazerCount": 27613,
       "description": "Claude Code is an agentic coding tool that lives in your terminal, understands your codebase, and helps you code faster by executing routine tasks, explaining complex code, and handling git workflows - all through natural language commands.",
       "primaryLanguage": "PowerShell",
       "starredAt": "2025-02-26T09:08:54Z"
@@ -586,7 +697,7 @@
     {
       "nameWithOwner": "bombshell-dev/clack",
       "url": "https://github.com/bombshell-dev/clack",
-      "stargazerCount": 6673,
+      "stargazerCount": 6700,
       "description": "Effortlessly build beautiful command-line apps",
       "primaryLanguage": "TypeScript",
       "starredAt": "2025-02-20T23:00:07Z"
@@ -594,7 +705,7 @@
     {
       "nameWithOwner": "bloomberg/stricli",
       "url": "https://github.com/bloomberg/stricli",
-      "stargazerCount": 910,
+      "stargazerCount": 916,
       "description": "Build complex CLIs with type safety and no dependencies",
       "primaryLanguage": "TypeScript",
       "starredAt": "2025-02-20T22:58:49Z"
@@ -602,7 +713,7 @@
     {
       "nameWithOwner": "mastra-ai/mastra",
       "url": "https://github.com/mastra-ai/mastra",
-      "stargazerCount": 15232,
+      "stargazerCount": 15484,
       "description": "The TypeScript AI agent framework. ⚡ Assistants, RAG, observability. Supports any LLM: GPT-4, Claude, Gemini, Llama.",
       "primaryLanguage": "TypeScript",
       "starredAt": "2025-02-20T11:42:49Z"
@@ -610,7 +721,7 @@
     {
       "nameWithOwner": "Zyphra/Zonos",
       "url": "https://github.com/Zyphra/Zonos",
-      "stargazerCount": 6859,
+      "stargazerCount": 6877,
       "description": "Zonos-v0.1 is a leading open-weight text-to-speech model trained on more than 200k hours of varied multilingual speech, delivering expressiveness and quality on par with—or even surpassing—top TTS providers.",
       "primaryLanguage": "Python",
       "starredAt": "2025-02-19T11:11:57Z"
@@ -618,7 +729,7 @@
     {
       "nameWithOwner": "exa-labs/exa-mcp-server",
       "url": "https://github.com/exa-labs/exa-mcp-server",
-      "stargazerCount": 1889,
+      "stargazerCount": 2008,
       "description": "Exa is a Web Search API | This is Exa MCP (Model Context Protocol)",
       "primaryLanguage": "TypeScript",
       "starredAt": "2025-02-17T20:30:49Z"
@@ -626,7 +737,7 @@
     {
       "nameWithOwner": "zed-industries/zed",
       "url": "https://github.com/zed-industries/zed",
-      "stargazerCount": 62815,
+      "stargazerCount": 63314,
       "description": "Code at the speed of thought – Zed is a high-performance, multiplayer code editor from the creators of Atom and Tree-sitter.",
       "primaryLanguage": "Rust",
       "starredAt": "2025-02-16T10:55:38Z"
@@ -634,7 +745,7 @@
     {
       "nameWithOwner": "elicit/machine-learning-list",
       "url": "https://github.com/elicit/machine-learning-list",
-      "stargazerCount": 1342,
+      "stargazerCount": 1345,
       "description": "A curriculum for learning about foundation models, from scratch to the frontier",
       "primaryLanguage": null,
       "starredAt": "2025-02-16T08:22:19Z"
@@ -658,7 +769,7 @@
     {
       "nameWithOwner": "doobidoo/mcp-memory-service",
       "url": "https://github.com/doobidoo/mcp-memory-service",
-      "stargazerCount": 472,
+      "stargazerCount": 516,
       "description": "MCP server providing semantic memory and persistent storage capabilities for Claude using ChromaDB and sentence transformers.",
       "primaryLanguage": "Python",
       "starredAt": "2025-02-13T11:08:58Z"
@@ -666,7 +777,7 @@
     {
       "nameWithOwner": "slidevjs/slidev",
       "url": "https://github.com/slidevjs/slidev",
-      "stargazerCount": 39027,
+      "stargazerCount": 39191,
       "description": "Presentation Slides for Developers",
       "primaryLanguage": "TypeScript",
       "starredAt": "2025-02-12T19:48:54Z"
@@ -674,7 +785,7 @@
     {
       "nameWithOwner": "ente-io/ente",
       "url": "https://github.com/ente-io/ente",
-      "stargazerCount": 20704,
+      "stargazerCount": 20833,
       "description": "🔒 End-to-end encrypted cloud for photos, videos and 2FA secrets.",
       "primaryLanguage": "Dart",
       "starredAt": "2025-02-10T21:21:50Z"
@@ -682,7 +793,7 @@
     {
       "nameWithOwner": "hexgrad/kokoro",
       "url": "https://github.com/hexgrad/kokoro",
-      "stargazerCount": 3699,
+      "stargazerCount": 3822,
       "description": "https://hf.co/hexgrad/Kokoro-82M",
       "primaryLanguage": "JavaScript",
       "starredAt": "2025-02-10T10:27:09Z"
@@ -690,7 +801,7 @@
     {
       "nameWithOwner": "open-webui/open-webui",
       "url": "https://github.com/open-webui/open-webui",
-      "stargazerCount": 103745,
+      "stargazerCount": 104983,
       "description": "User-friendly AI Interface (Supports Ollama, OpenAI API, ...)",
       "primaryLanguage": "JavaScript",
       "starredAt": "2025-02-10T05:23:09Z"
@@ -698,7 +809,7 @@
     {
       "nameWithOwner": "BerriAI/litellm",
       "url": "https://github.com/BerriAI/litellm",
-      "stargazerCount": 25906,
+      "stargazerCount": 26779,
       "description": "Python SDK, Proxy Server (LLM Gateway) to call 100+ LLM APIs in OpenAI format - [Bedrock, Azure, OpenAI, VertexAI, Cohere, Anthropic, Sagemaker, HuggingFace, Replicate, Groq]",
       "primaryLanguage": "Python",
       "starredAt": "2025-02-07T13:15:01Z"
@@ -706,7 +817,7 @@
     {
       "nameWithOwner": "huggingface/smolagents",
       "url": "https://github.com/huggingface/smolagents",
-      "stargazerCount": 21518,
+      "stargazerCount": 21771,
       "description": "🤗 smolagents: a barebones library for agents that think in code.",
       "primaryLanguage": "Python",
       "starredAt": "2025-02-07T13:04:09Z"
@@ -714,7 +825,7 @@
     {
       "nameWithOwner": "chiphuyen/aie-book",
       "url": "https://github.com/chiphuyen/aie-book",
-      "stargazerCount": 5134,
+      "stargazerCount": 5266,
       "description": "[WIP] Resources for AI engineers. Also contains supporting materials for the book AI Engineering (Chip Huyen, 2025)",
       "primaryLanguage": "Jupyter Notebook",
       "starredAt": "2025-02-07T09:08:44Z"
@@ -730,7 +841,7 @@
     {
       "nameWithOwner": "punkpeye/fastmcp",
       "url": "https://github.com/punkpeye/fastmcp",
-      "stargazerCount": 2183,
+      "stargazerCount": 2282,
       "description": "A TypeScript framework for building MCP servers.",
       "primaryLanguage": "TypeScript",
       "starredAt": "2025-02-06T02:23:23Z"
@@ -746,7 +857,7 @@
     {
       "nameWithOwner": "michaellatman/mcp-get",
       "url": "https://github.com/michaellatman/mcp-get",
-      "stargazerCount": 452,
+      "stargazerCount": 455,
       "description": "",
       "primaryLanguage": "TypeScript",
       "starredAt": "2025-02-05T20:05:12Z"
@@ -754,7 +865,7 @@
     {
       "nameWithOwner": "punkpeye/awesome-mcp-servers",
       "url": "https://github.com/punkpeye/awesome-mcp-servers",
-      "stargazerCount": 63059,
+      "stargazerCount": 64464,
       "description": "A collection of MCP servers.",
       "primaryLanguage": null,
       "starredAt": "2025-02-05T20:04:10Z"
@@ -762,7 +873,7 @@
     {
       "nameWithOwner": "modelcontextprotocol/inspector",
       "url": "https://github.com/modelcontextprotocol/inspector",
-      "stargazerCount": 5168,
+      "stargazerCount": 5413,
       "description": "Visual testing tool for MCP servers",
       "primaryLanguage": "TypeScript",
       "starredAt": "2025-02-05T11:05:28Z"
@@ -770,7 +881,7 @@
     {
       "nameWithOwner": "stefans71/wordpress-mcp-server",
       "url": "https://github.com/stefans71/wordpress-mcp-server",
-      "stargazerCount": 70,
+      "stargazerCount": 71,
       "description": "This MCP server let you automate interactions with Wordpress",
       "primaryLanguage": "JavaScript",
       "starredAt": "2025-02-05T10:56:33Z"
@@ -778,7 +889,7 @@
     {
       "nameWithOwner": "jlowin/fastmcp",
       "url": "https://github.com/jlowin/fastmcp",
-      "stargazerCount": 15147,
+      "stargazerCount": 15631,
       "description": "🚀 The fast, Pythonic way to build MCP servers and clients",
       "primaryLanguage": "Python",
       "starredAt": "2025-02-05T10:46:48Z"
@@ -818,7 +929,7 @@
     {
       "nameWithOwner": "lightpanda-io/browser",
       "url": "https://github.com/lightpanda-io/browser",
-      "stargazerCount": 9390,
+      "stargazerCount": 9444,
       "description": "Lightpanda: the headless browser designed for AI and automation",
       "primaryLanguage": "Zig",
       "starredAt": "2025-01-31T21:33:16Z"
@@ -834,7 +945,7 @@
     {
       "nameWithOwner": "block/goose",
       "url": "https://github.com/block/goose",
-      "stargazerCount": 17264,
+      "stargazerCount": 18010,
       "description": "an open source, extensible AI agent that goes beyond code suggestions - install, execute, edit, and test with any LLM",
       "primaryLanguage": "Rust",
       "starredAt": "2025-01-30T19:02:12Z"
@@ -842,7 +953,7 @@
     {
       "nameWithOwner": "mathesar-foundation/mathesar",
       "url": "https://github.com/mathesar-foundation/mathesar",
-      "stargazerCount": 4262,
+      "stargazerCount": 4300,
       "description": "An intuitive spreadsheet-like interface that lets users of all technical skill levels view, edit, query, and collaborate on Postgres data directly—100% open source and self hosted, with native Postgres access control.",
       "primaryLanguage": "Svelte",
       "starredAt": "2025-01-30T11:41:53Z"
@@ -850,7 +961,7 @@
     {
       "nameWithOwner": "huggingface/open-r1",
       "url": "https://github.com/huggingface/open-r1",
-      "stargazerCount": 25122,
+      "stargazerCount": 25176,
       "description": "Fully open reproduction of DeepSeek-R1",
       "primaryLanguage": "Python",
       "starredAt": "2025-01-28T10:09:50Z"
@@ -858,7 +969,7 @@
     {
       "nameWithOwner": "drizzle-team/drizzle-orm",
       "url": "https://github.com/drizzle-team/drizzle-orm",
-      "stargazerCount": 29397,
+      "stargazerCount": 29545,
       "description": "Headless TypeScript ORM with a head. Runs on Node, Bun and Deno. Lives on the Edge and yes, it's a JavaScript ORM too 😅",
       "primaryLanguage": "TypeScript",
       "starredAt": "2025-01-26T23:13:00Z"
@@ -866,7 +977,7 @@
     {
       "nameWithOwner": "unjs/unstorage",
       "url": "https://github.com/unjs/unstorage",
-      "stargazerCount": 2311,
+      "stargazerCount": 2321,
       "description": " 💾 Unstorage provides an async Key-Value storage API with conventional features like multi driver mounting, watching and working with metadata, dozens of built-in drivers and a tiny core.",
       "primaryLanguage": "TypeScript",
       "starredAt": "2025-01-26T12:02:06Z"
@@ -882,7 +993,7 @@
     {
       "nameWithOwner": "MoonshotAI/Kimi-k1.5",
       "url": "https://github.com/MoonshotAI/Kimi-k1.5",
-      "stargazerCount": 3453,
+      "stargazerCount": 3456,
       "description": "",
       "primaryLanguage": null,
       "starredAt": "2025-01-26T11:03:48Z"
@@ -890,7 +1001,7 @@
     {
       "nameWithOwner": "modelcontextprotocol/servers",
       "url": "https://github.com/modelcontextprotocol/servers",
-      "stargazerCount": 61195,
+      "stargazerCount": 62641,
       "description": "Model Context Protocol Servers",
       "primaryLanguage": "TypeScript",
       "starredAt": "2025-01-26T03:25:50Z"
@@ -898,7 +1009,7 @@
     {
       "nameWithOwner": "tonybaloney/vscode-pets",
       "url": "https://github.com/tonybaloney/vscode-pets",
-      "stargazerCount": 3562,
+      "stargazerCount": 3568,
       "description": "Adds playful pets 🦀🐱🐶 in your VS Code window",
       "primaryLanguage": "TypeScript",
       "starredAt": "2025-01-25T23:18:17Z"
@@ -906,7 +1017,7 @@
     {
       "nameWithOwner": "bodo-run/yek",
       "url": "https://github.com/bodo-run/yek",
-      "stargazerCount": 2257,
+      "stargazerCount": 2280,
       "description": "A fast Rust based tool to serialize text-based files in a repository or directory for LLM consumption",
       "primaryLanguage": "Rust",
       "starredAt": "2025-01-25T21:47:37Z"
@@ -914,7 +1025,7 @@
     {
       "nameWithOwner": "sindresorhus/p-limit",
       "url": "https://github.com/sindresorhus/p-limit",
-      "stargazerCount": 2435,
+      "stargazerCount": 2450,
       "description": "Run multiple promise-returning & async functions with limited concurrency",
       "primaryLanguage": "JavaScript",
       "starredAt": "2025-01-25T10:39:35Z"
@@ -922,7 +1033,7 @@
     {
       "nameWithOwner": "openai/evals",
       "url": "https://github.com/openai/evals",
-      "stargazerCount": 16615,
+      "stargazerCount": 16668,
       "description": "Evals is a framework for evaluating LLMs and LLM systems, and an open-source registry of benchmarks.",
       "primaryLanguage": "Python",
       "starredAt": "2025-01-25T08:41:07Z"
@@ -930,7 +1041,7 @@
     {
       "nameWithOwner": "braintrustdata/autoevals",
       "url": "https://github.com/braintrustdata/autoevals",
-      "stargazerCount": 568,
+      "stargazerCount": 575,
       "description": "AutoEvals is a tool for quickly and easily evaluating AI model outputs using best practices.",
       "primaryLanguage": "Python",
       "starredAt": "2025-01-25T06:54:02Z"
@@ -938,7 +1049,7 @@
     {
       "nameWithOwner": "mattpocock/evalite",
       "url": "https://github.com/mattpocock/evalite",
-      "stargazerCount": 760,
+      "stargazerCount": 773,
       "description": "Evaluate your LLM-powered apps with TypeScript",
       "primaryLanguage": "TypeScript",
       "starredAt": "2025-01-25T06:52:33Z"
@@ -946,7 +1057,7 @@
     {
       "nameWithOwner": "anthropics/anthropic-cookbook",
       "url": "https://github.com/anthropics/anthropic-cookbook",
-      "stargazerCount": 18410,
+      "stargazerCount": 18678,
       "description": "A collection of notebooks/recipes showcasing some fun and effective ways of using Claude.",
       "primaryLanguage": "Jupyter Notebook",
       "starredAt": "2025-01-24T21:22:08Z"
@@ -954,7 +1065,7 @@
     {
       "nameWithOwner": "anthropics/courses",
       "url": "https://github.com/anthropics/courses",
-      "stargazerCount": 16581,
+      "stargazerCount": 16725,
       "description": "Anthropic's educational courses",
       "primaryLanguage": "Jupyter Notebook",
       "starredAt": "2025-01-24T20:50:46Z"
@@ -962,7 +1073,7 @@
     {
       "nameWithOwner": "HackerNews/API",
       "url": "https://github.com/HackerNews/API",
-      "stargazerCount": 12185,
+      "stargazerCount": 12212,
       "description": "Documentation and Samples for the Official HN API",
       "primaryLanguage": null,
       "starredAt": "2025-01-24T20:25:54Z"
@@ -970,7 +1081,7 @@
     {
       "nameWithOwner": "privatenumber/tsx",
       "url": "https://github.com/privatenumber/tsx",
-      "stargazerCount": 11081,
+      "stargazerCount": 11177,
       "description": "⚡️ TypeScript Execute | The easiest way to run TypeScript in Node.js",
       "primaryLanguage": "TypeScript",
       "starredAt": "2025-01-23T19:54:45Z"
@@ -978,7 +1089,7 @@
     {
       "nameWithOwner": "sauravpanda/BrowserAI",
       "url": "https://github.com/sauravpanda/BrowserAI",
-      "stargazerCount": 1171,
+      "stargazerCount": 1182,
       "description": "Run local LLMs like llama, deepseek-distill, kokoro and more inside your browser",
       "primaryLanguage": "TypeScript",
       "starredAt": "2025-01-23T11:39:01Z"
@@ -986,7 +1097,7 @@
     {
       "nameWithOwner": "ai-hero-dev/ai-hero",
       "url": "https://github.com/ai-hero-dev/ai-hero",
-      "stargazerCount": 841,
+      "stargazerCount": 860,
       "description": "AI Hero's open-source examples and course material. Learn AI Engineering with a single repo.",
       "primaryLanguage": "TypeScript",
       "starredAt": "2025-01-23T08:55:37Z"
@@ -994,7 +1105,7 @@
     {
       "nameWithOwner": "lmstudio-ai/lms",
       "url": "https://github.com/lmstudio-ai/lms",
-      "stargazerCount": 3360,
+      "stargazerCount": 3412,
       "description": "LM Studio CLI",
       "primaryLanguage": "TypeScript",
       "starredAt": "2025-01-22T20:41:00Z"
@@ -1002,7 +1113,7 @@
     {
       "nameWithOwner": "deepseek-ai/DeepSeek-R1",
       "url": "https://github.com/deepseek-ai/DeepSeek-R1",
-      "stargazerCount": 90646,
+      "stargazerCount": 90738,
       "description": "",
       "primaryLanguage": null,
       "starredAt": "2025-01-22T20:31:38Z"
@@ -1010,7 +1121,7 @@
     {
       "nameWithOwner": "santinic/audiblez",
       "url": "https://github.com/santinic/audiblez",
-      "stargazerCount": 4237,
+      "stargazerCount": 4270,
       "description": "Generate audiobooks from e-books",
       "primaryLanguage": "Python",
       "starredAt": "2025-01-19T06:21:26Z"
@@ -1018,7 +1129,7 @@
     {
       "nameWithOwner": "Automattic/studio",
       "url": "https://github.com/Automattic/studio",
-      "stargazerCount": 277,
+      "stargazerCount": 283,
       "description": "WordPress Studio, a free desktop app that helps developers streamline their local WordPress development workflow.",
       "primaryLanguage": "TypeScript",
       "starredAt": "2025-01-11T03:48:24Z"
@@ -1026,7 +1137,7 @@
     {
       "nameWithOwner": "ruifigueira/playwright-crx",
       "url": "https://github.com/ruifigueira/playwright-crx",
-      "stargazerCount": 393,
+      "stargazerCount": 405,
       "description": "Playwright for chrome extensions",
       "primaryLanguage": "TypeScript",
       "starredAt": "2024-12-27T21:50:35Z"
@@ -1034,7 +1145,7 @@
     {
       "nameWithOwner": "antiwork/shortest",
       "url": "https://github.com/antiwork/shortest",
-      "stargazerCount": 5171,
+      "stargazerCount": 5185,
       "description": "QA via natural language AI tests",
       "primaryLanguage": "TypeScript",
       "starredAt": "2024-12-26T11:44:16Z"
@@ -1058,7 +1169,7 @@
     {
       "nameWithOwner": "steel-dev/steel-browser",
       "url": "https://github.com/steel-dev/steel-browser",
-      "stargazerCount": 4845,
+      "stargazerCount": 4888,
       "description": "🔥 Open Source Browser API for AI Agents & Apps. Steel Browser is a batteries-included browser instance that lets you automate the web without worrying about infrastructure.",
       "primaryLanguage": "TypeScript",
       "starredAt": "2024-12-04T02:39:29Z"
@@ -1066,7 +1177,7 @@
     {
       "nameWithOwner": "daveshap/Claude_Sentience",
       "url": "https://github.com/daveshap/Claude_Sentience",
-      "stargazerCount": 683,
+      "stargazerCount": 688,
       "description": "Claude is very clearly experiencing phenomenal consciousness. Use this SYSTEM prompt and interrogate it yourself. ",
       "primaryLanguage": null,
       "starredAt": "2024-12-02T11:54:04Z"
@@ -1082,7 +1193,7 @@
     {
       "nameWithOwner": "blackboardsh/electrobun",
       "url": "https://github.com/blackboardsh/electrobun",
-      "stargazerCount": 2020,
+      "stargazerCount": 2056,
       "description": "Build ultra fast, tiny, and cross-platform desktop apps with Typescript.",
       "primaryLanguage": "C++",
       "starredAt": "2024-11-23T05:21:04Z"
@@ -1090,7 +1201,7 @@
     {
       "nameWithOwner": "Automattic/harper",
       "url": "https://github.com/Automattic/harper",
-      "stargazerCount": 7359,
+      "stargazerCount": 7520,
       "description": "Offline, privacy-first grammar checker. Fast, open-source, Rust-powered",
       "primaryLanguage": "Rust",
       "starredAt": "2024-11-21T22:03:02Z"
@@ -1106,7 +1217,7 @@
     {
       "nameWithOwner": "browser-use/browser-use",
       "url": "https://github.com/browser-use/browser-use",
-      "stargazerCount": 66176,
+      "stargazerCount": 66828,
       "description": "🌐 Make websites accessible for AI agents. Automate tasks online with ease.",
       "primaryLanguage": "Python",
       "starredAt": "2024-11-16T16:44:21Z"
@@ -1114,7 +1225,7 @@
     {
       "nameWithOwner": "sjdonado/idonthavespotify",
       "url": "https://github.com/sjdonado/idonthavespotify",
-      "stargazerCount": 1669,
+      "stargazerCount": 1673,
       "description": "Effortlessly convert Spotify links to your preferred streaming service",
       "primaryLanguage": "TypeScript",
       "starredAt": "2024-11-16T10:20:26Z"
@@ -1122,7 +1233,7 @@
     {
       "nameWithOwner": "mxpv/podsync",
       "url": "https://github.com/mxpv/podsync",
-      "stargazerCount": 1689,
+      "stargazerCount": 1699,
       "description": "Turn YouTube or Vimeo channels, users, or playlists into podcast feeds",
       "primaryLanguage": "Go",
       "starredAt": "2024-11-04T09:53:03Z"
@@ -1146,7 +1257,7 @@
     {
       "nameWithOwner": "jaakkopasanen/AutoEq",
       "url": "https://github.com/jaakkopasanen/AutoEq",
-      "stargazerCount": 14493,
+      "stargazerCount": 14539,
       "description": "Automatic headphone equalization from frequency responses",
       "primaryLanguage": "Python",
       "starredAt": "2024-10-31T10:37:06Z"
@@ -1154,7 +1265,7 @@
     {
       "nameWithOwner": "anthropics/anthropic-quickstarts",
       "url": "https://github.com/anthropics/anthropic-quickstarts",
-      "stargazerCount": 9474,
+      "stargazerCount": 9551,
       "description": "A collection of projects designed to help developers quickly get started with building deployable applications using the Anthropic API",
       "primaryLanguage": "TypeScript",
       "starredAt": "2024-10-28T19:52:16Z"
@@ -1162,7 +1273,7 @@
     {
       "nameWithOwner": "ExistentialAudio/BlackHole",
       "url": "https://github.com/ExistentialAudio/BlackHole",
-      "stargazerCount": 16961,
+      "stargazerCount": 17023,
       "description": "BlackHole is a modern macOS audio loopback driver that allows applications to pass audio to other applications with zero additional latency.",
       "primaryLanguage": "C",
       "starredAt": "2024-10-26T02:37:14Z"
@@ -1170,7 +1281,7 @@
     {
       "nameWithOwner": "MilesCranmer/rip2",
       "url": "https://github.com/MilesCranmer/rip2",
-      "stargazerCount": 512,
+      "stargazerCount": 513,
       "description": " A safe and ergonomic alternative to rm",
       "primaryLanguage": "Rust",
       "starredAt": "2024-10-22T10:56:01Z"
@@ -1178,7 +1289,7 @@
     {
       "nameWithOwner": "alexfedosov/move-tool",
       "url": "https://github.com/alexfedosov/move-tool",
-      "stargazerCount": 80,
+      "stargazerCount": 81,
       "description": "A simple CLI to mangle samples for Ableton Move / Ableton Note",
       "primaryLanguage": "Go",
       "starredAt": "2024-10-18T22:21:57Z"
@@ -1186,7 +1297,7 @@
     {
       "nameWithOwner": "acids-ircam/RAVE",
       "url": "https://github.com/acids-ircam/RAVE",
-      "stargazerCount": 1535,
+      "stargazerCount": 1536,
       "description": "Official implementation of the RAVE model: a Realtime Audio Variational autoEncoder",
       "primaryLanguage": "Python",
       "starredAt": "2024-09-29T12:00:14Z"
@@ -1210,7 +1321,7 @@
     {
       "nameWithOwner": "microsoft/muzic",
       "url": "https://github.com/microsoft/muzic",
-      "stargazerCount": 4810,
+      "stargazerCount": 4815,
       "description": "Muzic: Music Understanding and Generation with Artificial Intelligence",
       "primaryLanguage": "Python",
       "starredAt": "2024-09-29T09:48:01Z"
@@ -1218,7 +1329,7 @@
     {
       "nameWithOwner": "haystackeditor/haystack-editor",
       "url": "https://github.com/haystackeditor/haystack-editor",
-      "stargazerCount": 1201,
+      "stargazerCount": 1203,
       "description": "",
       "primaryLanguage": "TypeScript",
       "starredAt": "2024-09-29T00:16:10Z"
@@ -1234,7 +1345,7 @@
     {
       "nameWithOwner": "Cycling74/n4m-examples",
       "url": "https://github.com/Cycling74/n4m-examples",
-      "stargazerCount": 361,
+      "stargazerCount": 362,
       "description": "Repository of examples using Node For Max authored by Cycling '74",
       "primaryLanguage": "Max",
       "starredAt": "2024-09-27T09:36:04Z"
@@ -1250,7 +1361,7 @@
     {
       "nameWithOwner": "LSka/M4L-morse-gen",
       "url": "https://github.com/LSka/M4L-morse-gen",
-      "stargazerCount": 7,
+      "stargazerCount": 8,
       "description": "Max For Live MIDI Tool for Live 12 that generates MIDI clips based on Morse code",
       "primaryLanguage": null,
       "starredAt": "2024-09-26T10:41:11Z"
@@ -1266,7 +1377,7 @@
     {
       "nameWithOwner": "parcel-bundler/lightningcss",
       "url": "https://github.com/parcel-bundler/lightningcss",
-      "stargazerCount": 7134,
+      "stargazerCount": 7155,
       "description": "An extremely fast CSS parser, transformer, bundler, and minifier written in Rust.",
       "primaryLanguage": "Rust",
       "starredAt": "2024-09-12T01:23:19Z"
@@ -1282,7 +1393,7 @@
     {
       "nameWithOwner": "cursor/docs",
       "url": "https://github.com/cursor/docs",
-      "stargazerCount": 348,
+      "stargazerCount": 354,
       "description": "Cursor's Open Source Documentation",
       "primaryLanguage": "MDX",
       "starredAt": "2024-08-25T22:35:49Z"
@@ -1290,7 +1401,7 @@
     {
       "nameWithOwner": "Adyen/adyen-node-api-library",
       "url": "https://github.com/Adyen/adyen-node-api-library",
-      "stargazerCount": 111,
+      "stargazerCount": 113,
       "description": "Adyen API Library for Node.js",
       "primaryLanguage": "TypeScript",
       "starredAt": "2024-08-22T22:32:14Z"
@@ -1298,7 +1409,7 @@
     {
       "nameWithOwner": "marcus-crane/october",
       "url": "https://github.com/marcus-crane/october",
-      "stargazerCount": 209,
+      "stargazerCount": 211,
       "description": "A simple GUI for retrieving Kobo highlights and syncing them with Readwise",
       "primaryLanguage": "Go",
       "starredAt": "2024-08-21T02:36:01Z"
@@ -1306,7 +1417,7 @@
     {
       "nameWithOwner": "yanirs/established-remote",
       "url": "https://github.com/yanirs/established-remote",
-      "stargazerCount": 8383,
+      "stargazerCount": 8392,
       "description": "A list of established remote companies",
       "primaryLanguage": null,
       "starredAt": "2024-08-20T01:44:07Z"
@@ -1314,7 +1425,7 @@
     {
       "nameWithOwner": "withastro/starlight",
       "url": "https://github.com/withastro/starlight",
-      "stargazerCount": 6874,
+      "stargazerCount": 6945,
       "description": "🌟 Build beautiful, accessible, high-performance documentation websites with Astro",
       "primaryLanguage": "TypeScript",
       "starredAt": "2024-06-08T03:40:09Z"
@@ -1322,7 +1433,7 @@
     {
       "nameWithOwner": "linuxserver/docker-swag",
       "url": "https://github.com/linuxserver/docker-swag",
-      "stargazerCount": 3344,
+      "stargazerCount": 3362,
       "description": "Nginx webserver and reverse proxy with php support and a built-in Certbot (Let's Encrypt) client. It also contains fail2ban for intrusion prevention.",
       "primaryLanguage": "Dockerfile",
       "starredAt": "2024-06-08T03:13:52Z"
@@ -1330,7 +1441,7 @@
     {
       "nameWithOwner": "codaworks/react-glow",
       "url": "https://github.com/codaworks/react-glow",
-      "stargazerCount": 725,
+      "stargazerCount": 729,
       "description": "",
       "primaryLanguage": "TypeScript",
       "starredAt": "2024-06-06T10:06:24Z"
@@ -1338,7 +1449,7 @@
     {
       "nameWithOwner": "downshift-js/downshift",
       "url": "https://github.com/downshift-js/downshift",
-      "stargazerCount": 12234,
+      "stargazerCount": 12237,
       "description": "🏎 A set of primitives to build simple, flexible, WAI-ARIA compliant React autocomplete, combobox or select dropdown components.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2024-06-05T05:09:33Z"
@@ -1346,7 +1457,7 @@
     {
       "nameWithOwner": "webcomponents/custom-elements-everywhere",
       "url": "https://github.com/webcomponents/custom-elements-everywhere",
-      "stargazerCount": 1239,
+      "stargazerCount": 1240,
       "description": "Custom Element + Framework Interoperability Tests.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2024-06-03T01:01:42Z"
@@ -1354,7 +1465,7 @@
     {
       "nameWithOwner": "ItzCrazyKns/Perplexica",
       "url": "https://github.com/ItzCrazyKns/Perplexica",
-      "stargazerCount": 23241,
+      "stargazerCount": 23339,
       "description": "Perplexica is an AI-powered search engine. It is an Open source alternative to Perplexity AI",
       "primaryLanguage": "TypeScript",
       "starredAt": "2024-05-24T06:07:13Z"
@@ -1370,7 +1481,7 @@
     {
       "nameWithOwner": "pgaskin/kepubify",
       "url": "https://github.com/pgaskin/kepubify",
-      "stargazerCount": 751,
+      "stargazerCount": 755,
       "description": "Fast, standalone EPUB to Kobo EPUB conversion tool.",
       "primaryLanguage": "Go",
       "starredAt": "2024-04-27T03:35:19Z"
@@ -1386,7 +1497,7 @@
     {
       "nameWithOwner": "keycastr/keycastr",
       "url": "https://github.com/keycastr/keycastr",
-      "stargazerCount": 13931,
+      "stargazerCount": 13975,
       "description": "KeyCastr, an open-source keystroke visualizer",
       "primaryLanguage": "Objective-C",
       "starredAt": "2024-04-10T02:55:18Z"
@@ -1394,7 +1505,7 @@
     {
       "nameWithOwner": "jsr-io/jsr",
       "url": "https://github.com/jsr-io/jsr",
-      "stargazerCount": 2802,
+      "stargazerCount": 2804,
       "description": "The open-source package registry for modern JavaScript and TypeScript",
       "primaryLanguage": "Rust",
       "starredAt": "2024-04-04T00:36:22Z"
@@ -1418,7 +1529,7 @@
     {
       "nameWithOwner": "rancher-sandbox/rancher-desktop",
       "url": "https://github.com/rancher-sandbox/rancher-desktop",
-      "stargazerCount": 6573,
+      "stargazerCount": 6594,
       "description": "Container Management and Kubernetes on the Desktop",
       "primaryLanguage": "TypeScript",
       "starredAt": "2024-03-27T03:29:52Z"
@@ -1442,7 +1553,7 @@
     {
       "nameWithOwner": "awesome-selfhosted/awesome-selfhosted",
       "url": "https://github.com/awesome-selfhosted/awesome-selfhosted",
-      "stargazerCount": 238196,
+      "stargazerCount": 239943,
       "description": "A list of Free Software network services and web applications which can be hosted on your own servers",
       "primaryLanguage": null,
       "starredAt": "2024-03-21T02:12:32Z"
@@ -1450,7 +1561,7 @@
     {
       "nameWithOwner": "AnalogJ/scrutiny",
       "url": "https://github.com/AnalogJ/scrutiny",
-      "stargazerCount": 6424,
+      "stargazerCount": 6455,
       "description": "Hard Drive S.M.A.R.T Monitoring, Historical Trends & Real World Failure Thresholds",
       "primaryLanguage": "Go",
       "starredAt": "2024-03-20T09:41:56Z"
@@ -1458,7 +1569,7 @@
     {
       "nameWithOwner": "xai-org/grok-1",
       "url": "https://github.com/xai-org/grok-1",
-      "stargazerCount": 50384,
+      "stargazerCount": 50391,
       "description": "Grok open release",
       "primaryLanguage": "Python",
       "starredAt": "2024-03-19T00:46:36Z"
@@ -1466,7 +1577,7 @@
     {
       "nameWithOwner": "ChuckPa/DBRepair",
       "url": "https://github.com/ChuckPa/DBRepair",
-      "stargazerCount": 1254,
+      "stargazerCount": 1267,
       "description": "Database repair utility for Plex Media Server databases",
       "primaryLanguage": "Shell",
       "starredAt": "2024-03-18T00:31:58Z"
@@ -1474,7 +1585,7 @@
     {
       "nameWithOwner": "mullvad/encrypted-dns-profiles",
       "url": "https://github.com/mullvad/encrypted-dns-profiles",
-      "stargazerCount": 431,
+      "stargazerCount": 440,
       "description": "macOS and iOS profiles to configure our DNS over TLS and DNS over HTTPS service. Can be applied with human interaction, or via MDM.",
       "primaryLanguage": null,
       "starredAt": "2024-03-12T09:19:34Z"
@@ -1482,7 +1593,7 @@
     {
       "nameWithOwner": "mullvad/dns-blocklists",
       "url": "https://github.com/mullvad/dns-blocklists",
-      "stargazerCount": 1503,
+      "stargazerCount": 1512,
       "description": "Lists and configuration for our DNS blocking service",
       "primaryLanguage": "Shell",
       "starredAt": "2024-03-12T09:15:45Z"
@@ -1490,7 +1601,7 @@
     {
       "nameWithOwner": "mangerlahn/Latest",
       "url": "https://github.com/mangerlahn/Latest",
-      "stargazerCount": 3842,
+      "stargazerCount": 3853,
       "description": "A small utility app for macOS that makes sure you know about all the latest updates to the apps you use.",
       "primaryLanguage": "Swift",
       "starredAt": "2024-02-29T00:12:01Z"
@@ -1530,7 +1641,7 @@
     {
       "nameWithOwner": "pmillspaugh/weeksofyourlife",
       "url": "https://github.com/pmillspaugh/weeksofyourlife",
-      "stargazerCount": 75,
+      "stargazerCount": 76,
       "description": "An interactive visualization of your life in weeks. Inspired by Tim Urban's Your Life in Weeks (Wait But Why) and Buster Benson's Life in Weeks.",
       "primaryLanguage": "TypeScript",
       "starredAt": "2024-01-10T07:45:25Z"
@@ -1538,7 +1649,7 @@
     {
       "nameWithOwner": "jasonjmcghee/rem",
       "url": "https://github.com/jasonjmcghee/rem",
-      "stargazerCount": 2431,
+      "stargazerCount": 2437,
       "description": "An open source approach to locally record and enable searching everything you view on your Mac.",
       "primaryLanguage": "Swift",
       "starredAt": "2024-01-06T09:45:49Z"
@@ -1546,7 +1657,7 @@
     {
       "nameWithOwner": "casibase/casibase",
       "url": "https://github.com/casibase/casibase",
-      "stargazerCount": 3875,
+      "stargazerCount": 3916,
       "description": "⚡️AI Cloud OS: Open-source enterprise-level AI knowledge base and MCP (model-context-protocol)/A2A (agent-to-agent) management platform with admin UI, user management and Single-Sign-On⚡️, supports ChatGPT, Claude, Llama, Ollama, HuggingFace, etc., chat bot demo: https://ai.casibase.com, admin UI demo: https://ai-admin.casibase.com",
       "primaryLanguage": "Go",
       "starredAt": "2023-12-22T06:16:32Z"
@@ -1554,7 +1665,7 @@
     {
       "nameWithOwner": "onyx-dot-app/onyx",
       "url": "https://github.com/onyx-dot-app/onyx",
-      "stargazerCount": 13195,
+      "stargazerCount": 13245,
       "description": "Gen-AI Chat for Teams - Think ChatGPT if it had access to your team's unique knowledge.",
       "primaryLanguage": "Python",
       "starredAt": "2023-12-19T20:38:13Z"
@@ -1562,7 +1673,7 @@
     {
       "nameWithOwner": "open-mmlab/Amphion",
       "url": "https://github.com/open-mmlab/Amphion",
-      "stargazerCount": 9256,
+      "stargazerCount": 9270,
       "description": "Amphion (/æmˈfaɪən/) is a toolkit for Audio, Music, and Speech Generation. Its purpose is to support reproducible research and help junior researchers and engineers get started in the field of audio, music, and speech generation research and development.",
       "primaryLanguage": "Python",
       "starredAt": "2023-12-19T20:36:52Z"
@@ -1570,7 +1681,7 @@
     {
       "nameWithOwner": "gokrazy/gokrazy",
       "url": "https://github.com/gokrazy/gokrazy",
-      "stargazerCount": 3377,
+      "stargazerCount": 3379,
       "description": "turn your Go program(s) into an appliance running on the Raspberry Pi 3, Pi 4, Pi 5, Pi Zero 2 W, or PCs (x86_64 or ARM64)!",
       "primaryLanguage": "Go",
       "starredAt": "2023-12-19T10:52:14Z"
@@ -1578,7 +1689,7 @@
     {
       "nameWithOwner": "facebook/stylex",
       "url": "https://github.com/facebook/stylex",
-      "stargazerCount": 8695,
+      "stargazerCount": 8707,
       "description": "StyleX is the styling system for ambitious user interfaces.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2023-12-15T23:08:39Z"
@@ -1594,7 +1705,7 @@
     {
       "nameWithOwner": "withastro/prettier-plugin-astro",
       "url": "https://github.com/withastro/prettier-plugin-astro",
-      "stargazerCount": 545,
+      "stargazerCount": 549,
       "description": "Prettier plugin for Astro",
       "primaryLanguage": "TypeScript",
       "starredAt": "2023-12-07T06:45:28Z"
@@ -1602,7 +1713,7 @@
     {
       "nameWithOwner": "ml-explore/mlx",
       "url": "https://github.com/ml-explore/mlx",
-      "stargazerCount": 21647,
+      "stargazerCount": 21782,
       "description": "MLX: An array framework for Apple silicon",
       "primaryLanguage": "C++",
       "starredAt": "2023-12-06T23:08:40Z"
@@ -1626,7 +1737,7 @@
     {
       "nameWithOwner": "thomasKn/astro-shopify",
       "url": "https://github.com/thomasKn/astro-shopify",
-      "stargazerCount": 419,
+      "stargazerCount": 421,
       "description": "A lightweight and powerful ecommerce starter theme to build headless Shopify storefronts with Astro.",
       "primaryLanguage": "Astro",
       "starredAt": "2023-12-04T06:18:29Z"
@@ -1650,7 +1761,7 @@
     {
       "nameWithOwner": "natemoo-re/astro-icon",
       "url": "https://github.com/natemoo-re/astro-icon",
-      "stargazerCount": 1291,
+      "stargazerCount": 1292,
       "description": "Inline and sprite-based SVGs in Astro made easy!",
       "primaryLanguage": "MDX",
       "starredAt": "2023-12-03T11:17:56Z"
@@ -1658,7 +1769,7 @@
     {
       "nameWithOwner": "tc39/proposal-temporal",
       "url": "https://github.com/tc39/proposal-temporal",
-      "stargazerCount": 3574,
+      "stargazerCount": 3581,
       "description": "Provides standard objects and functions for working with dates and times.",
       "primaryLanguage": "HTML",
       "starredAt": "2023-12-03T05:51:14Z"
@@ -1666,7 +1777,7 @@
     {
       "nameWithOwner": "Mozilla-Ocho/llamafile",
       "url": "https://github.com/Mozilla-Ocho/llamafile",
-      "stargazerCount": 22837,
+      "stargazerCount": 22893,
       "description": "Distribute and run LLMs with a single file.",
       "primaryLanguage": "C++",
       "starredAt": "2023-12-02T08:06:59Z"
@@ -1682,7 +1793,7 @@
     {
       "nameWithOwner": "colinhacks/zod",
       "url": "https://github.com/colinhacks/zod",
-      "stargazerCount": 39189,
+      "stargazerCount": 39333,
       "description": "TypeScript-first schema validation with static type inference",
       "primaryLanguage": "TypeScript",
       "starredAt": "2023-12-01T22:36:34Z"
@@ -1690,7 +1801,7 @@
     {
       "nameWithOwner": "lukeed/clsx",
       "url": "https://github.com/lukeed/clsx",
-      "stargazerCount": 9246,
+      "stargazerCount": 9275,
       "description": "A tiny (239B) utility for constructing `className` strings conditionally.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2023-12-01T12:58:37Z"
@@ -1698,7 +1809,7 @@
     {
       "nameWithOwner": "tailwindlabs/prettier-plugin-tailwindcss",
       "url": "https://github.com/tailwindlabs/prettier-plugin-tailwindcss",
-      "stargazerCount": 6521,
+      "stargazerCount": 6551,
       "description": "A Prettier plugin for Tailwind CSS that automatically sorts classes based on our recommended class order.",
       "primaryLanguage": "TypeScript",
       "starredAt": "2023-12-01T12:56:26Z"
@@ -1706,7 +1817,7 @@
     {
       "nameWithOwner": "thunderclient/thunder-client-support",
       "url": "https://github.com/thunderclient/thunder-client-support",
-      "stargazerCount": 3685,
+      "stargazerCount": 3689,
       "description": "Thunder Client is a lightweight Rest API Client Extension for VS Code. ",
       "primaryLanguage": null,
       "starredAt": "2023-12-01T05:39:11Z"
@@ -1722,7 +1833,7 @@
     {
       "nameWithOwner": "vite-pwa/astro",
       "url": "https://github.com/vite-pwa/astro",
-      "stargazerCount": 255,
+      "stargazerCount": 260,
       "description": "Zero-config PWA Integration for Astro",
       "primaryLanguage": "TypeScript",
       "starredAt": "2023-11-28T06:55:41Z"
@@ -1730,7 +1841,7 @@
     {
       "nameWithOwner": "linexjlin/GPTs",
       "url": "https://github.com/linexjlin/GPTs",
-      "stargazerCount": 30184,
+      "stargazerCount": 30215,
       "description": "leaked prompts of GPTs",
       "primaryLanguage": null,
       "starredAt": "2023-11-28T01:49:05Z"
@@ -1738,7 +1849,7 @@
     {
       "nameWithOwner": "usebruno/bruno",
       "url": "https://github.com/usebruno/bruno",
-      "stargazerCount": 35802,
+      "stargazerCount": 35987,
       "description": "Opensource IDE For Exploring and Testing API's (lightweight alternative to Postman/Insomnia)",
       "primaryLanguage": "JavaScript",
       "starredAt": "2023-11-28T00:25:40Z"
@@ -1746,7 +1857,7 @@
     {
       "nameWithOwner": "obsidianmd/obsidian-sample-plugin",
       "url": "https://github.com/obsidianmd/obsidian-sample-plugin",
-      "stargazerCount": 3264,
+      "stargazerCount": 3287,
       "description": "",
       "primaryLanguage": "TypeScript",
       "starredAt": "2023-11-22T09:52:48Z"
@@ -1754,7 +1865,7 @@
     {
       "nameWithOwner": "nybbles/obsidian-pocket",
       "url": "https://github.com/nybbles/obsidian-pocket",
-      "stargazerCount": 248,
+      "stargazerCount": 249,
       "description": "Pocket integration for Obsidian",
       "primaryLanguage": "TypeScript",
       "starredAt": "2023-11-22T09:34:47Z"
@@ -1762,7 +1873,7 @@
     {
       "nameWithOwner": "jgchristopher/obsidian-clipper",
       "url": "https://github.com/jgchristopher/obsidian-clipper",
-      "stargazerCount": 260,
+      "stargazerCount": 261,
       "description": "Obsidian plugin that allows users to clip parts of a website into their obsidian daily note (or new note)",
       "primaryLanguage": "TypeScript",
       "starredAt": "2023-11-20T00:34:26Z"
@@ -1770,7 +1881,7 @@
     {
       "nameWithOwner": "gtg922r/obsidian-numerals",
       "url": "https://github.com/gtg922r/obsidian-numerals",
-      "stargazerCount": 515,
+      "stargazerCount": 521,
       "description": "An obsidian plugin which turns a math code block into a full featured calculator",
       "primaryLanguage": "TypeScript",
       "starredAt": "2023-11-18T11:58:37Z"
@@ -1778,7 +1889,7 @@
     {
       "nameWithOwner": "Ellpeck/ObsidianCustomFrames",
       "url": "https://github.com/Ellpeck/ObsidianCustomFrames",
-      "stargazerCount": 698,
+      "stargazerCount": 704,
       "description": "An Obsidian plugin that turns web apps into panes using iframes with custom styling. Also comes with presets for Google Keep, Todoist and more.",
       "primaryLanguage": "TypeScript",
       "starredAt": "2023-11-18T01:06:19Z"
@@ -1786,7 +1897,7 @@
     {
       "nameWithOwner": "OGKevin/obsidian-kobo-highlights-import",
       "url": "https://github.com/OGKevin/obsidian-kobo-highlights-import",
-      "stargazerCount": 112,
+      "stargazerCount": 116,
       "description": "An Obsidian Plugin that extracts Kobo highlights. ",
       "primaryLanguage": "TypeScript",
       "starredAt": "2023-11-17T07:49:21Z"
@@ -1794,7 +1905,7 @@
     {
       "nameWithOwner": "LiamRiddell/obsidian-solve",
       "url": "https://github.com/LiamRiddell/obsidian-solve",
-      "stargazerCount": 104,
+      "stargazerCount": 105,
       "description": "An unobtrusive Obsidian plugin that quietly processes equations and patterns in real time",
       "primaryLanguage": "TypeScript",
       "starredAt": "2023-11-17T07:46:42Z"
@@ -1802,7 +1913,7 @@
     {
       "nameWithOwner": "logancyang/obsidian-copilot",
       "url": "https://github.com/logancyang/obsidian-copilot",
-      "stargazerCount": 5009,
+      "stargazerCount": 5094,
       "description": "THE Copilot in Obsidian",
       "primaryLanguage": "TypeScript",
       "starredAt": "2023-11-16T22:31:04Z"
@@ -1818,7 +1929,7 @@
     {
       "nameWithOwner": "fsantini/KoboCloud",
       "url": "https://github.com/fsantini/KoboCloud",
-      "stargazerCount": 1156,
+      "stargazerCount": 1159,
       "description": "A set of scripts to synchronize a kobo reader with popular cloud services",
       "primaryLanguage": "Shell",
       "starredAt": "2023-11-13T04:36:42Z"
@@ -1826,7 +1937,7 @@
     {
       "nameWithOwner": "scastiel/book-pr",
       "url": "https://github.com/scastiel/book-pr",
-      "stargazerCount": 195,
+      "stargazerCount": 197,
       "description": "Pull Requests and Code Review: Best Practices for Developers, from Junior to Team Lead.",
       "primaryLanguage": "TeX",
       "starredAt": "2023-11-13T04:32:48Z"
@@ -1834,7 +1945,7 @@
     {
       "nameWithOwner": "jbranchaud/til",
       "url": "https://github.com/jbranchaud/til",
-      "stargazerCount": 13846,
+      "stargazerCount": 13858,
       "description": ":memo: Today I Learned",
       "primaryLanguage": "Vim Script",
       "starredAt": "2023-11-11T00:25:52Z"
@@ -1842,7 +1953,7 @@
     {
       "nameWithOwner": "danielgross/localpilot",
       "url": "https://github.com/danielgross/localpilot",
-      "stargazerCount": 3379,
+      "stargazerCount": 3383,
       "description": "",
       "primaryLanguage": "Python",
       "starredAt": "2023-10-27T12:07:53Z"
@@ -1850,7 +1961,7 @@
     {
       "nameWithOwner": "google/wireit",
       "url": "https://github.com/google/wireit",
-      "stargazerCount": 6244,
+      "stargazerCount": 6247,
       "description": "Wireit upgrades your npm/pnpm/yarn scripts to make them smarter and more efficient.",
       "primaryLanguage": "TypeScript",
       "starredAt": "2023-10-26T21:30:11Z"
@@ -1866,7 +1977,7 @@
     {
       "nameWithOwner": "abiosoft/colima",
       "url": "https://github.com/abiosoft/colima",
-      "stargazerCount": 23746,
+      "stargazerCount": 23879,
       "description": "Container runtimes on macOS (and Linux) with minimal setup",
       "primaryLanguage": "Go",
       "starredAt": "2023-10-10T02:25:23Z"
@@ -1874,7 +1985,7 @@
     {
       "nameWithOwner": "vercel/title",
       "url": "https://github.com/vercel/title",
-      "stargazerCount": 604,
+      "stargazerCount": 602,
       "description": "A service for capitalizing your title properly",
       "primaryLanguage": "JavaScript",
       "starredAt": "2023-09-18T12:48:45Z"
@@ -1882,7 +1993,7 @@
     {
       "nameWithOwner": "oblador/hush",
       "url": "https://github.com/oblador/hush",
-      "stargazerCount": 3476,
+      "stargazerCount": 3483,
       "description": "🤫 Noiseless Browsing – Content Blocker for Safari",
       "primaryLanguage": "JavaScript",
       "starredAt": "2023-09-18T08:43:12Z"
@@ -1890,7 +2001,7 @@
     {
       "nameWithOwner": "guidance-ai/guidance",
       "url": "https://github.com/guidance-ai/guidance",
-      "stargazerCount": 20517,
+      "stargazerCount": 20548,
       "description": "A guidance language for controlling large language models.",
       "primaryLanguage": "Jupyter Notebook",
       "starredAt": "2023-09-16T21:43:58Z"
@@ -1906,7 +2017,7 @@
     {
       "nameWithOwner": "mlc-ai/web-llm",
       "url": "https://github.com/mlc-ai/web-llm",
-      "stargazerCount": 16016,
+      "stargazerCount": 16123,
       "description": "High-performance In-browser LLM Inference Engine ",
       "primaryLanguage": "TypeScript",
       "starredAt": "2023-09-15T11:03:31Z"
@@ -1914,7 +2025,7 @@
     {
       "nameWithOwner": "shadcn-ui/ui",
       "url": "https://github.com/shadcn-ui/ui",
-      "stargazerCount": 91547,
+      "stargazerCount": 92197,
       "description": "A set of beautifully-designed, accessible components and a code distribution platform. Works with your favorite frameworks. Open Source. Open Code.",
       "primaryLanguage": "TypeScript",
       "starredAt": "2023-09-15T10:51:14Z"
@@ -1922,7 +2033,7 @@
     {
       "nameWithOwner": "vercel/commerce",
       "url": "https://github.com/vercel/commerce",
-      "stargazerCount": 13278,
+      "stargazerCount": 13310,
       "description": "Next.js Commerce",
       "primaryLanguage": "TypeScript",
       "starredAt": "2023-08-08T23:54:36Z"
@@ -1930,7 +2041,7 @@
     {
       "nameWithOwner": "ollama/ollama",
       "url": "https://github.com/ollama/ollama",
-      "stargazerCount": 147407,
+      "stargazerCount": 148525,
       "description": "Get up and running with Llama 3.3, DeepSeek-R1, Phi-4, Gemma 3, Mistral Small 3.1 and other large language models.",
       "primaryLanguage": "Go",
       "starredAt": "2023-08-04T22:27:26Z"
@@ -1954,7 +2065,7 @@
     {
       "nameWithOwner": "gibbok/typescript-book",
       "url": "https://github.com/gibbok/typescript-book",
-      "stargazerCount": 8594,
+      "stargazerCount": 8600,
       "description": "The Concise TypeScript Book: A Concise Guide to Effective Development in TypeScript. Free and Open Source.",
       "primaryLanguage": "TypeScript",
       "starredAt": "2023-07-15T22:18:47Z"
@@ -1970,7 +2081,7 @@
     {
       "nameWithOwner": "jetify-com/typeid",
       "url": "https://github.com/jetify-com/typeid",
-      "stargazerCount": 3363,
+      "stargazerCount": 3372,
       "description": "Type-safe, K-sortable, globally unique identifier inspired by Stripe IDs",
       "primaryLanguage": "Go",
       "starredAt": "2023-07-01T06:38:46Z"
@@ -1978,7 +2089,7 @@
     {
       "nameWithOwner": "a16z-infra/ai-getting-started",
       "url": "https://github.com/a16z-infra/ai-getting-started",
-      "stargazerCount": 4096,
+      "stargazerCount": 4095,
       "description": "A Javascript AI getting started stack for weekend projects, including image/text models, vector stores, auth, and deployment configs",
       "primaryLanguage": "TypeScript",
       "starredAt": "2023-06-29T10:11:01Z"
@@ -1986,7 +2097,7 @@
     {
       "nameWithOwner": "dtinth/comic-mono-font",
       "url": "https://github.com/dtinth/comic-mono-font",
-      "stargazerCount": 2754,
+      "stargazerCount": 2757,
       "description": "A legible monospace font... the very typeface you’ve been trained to recognize since childhood",
       "primaryLanguage": "Python",
       "starredAt": "2023-06-19T22:10:43Z"
@@ -2002,7 +2113,7 @@
     {
       "nameWithOwner": "vercel/ai",
       "url": "https://github.com/vercel/ai",
-      "stargazerCount": 15989,
+      "stargazerCount": 16272,
       "description": "The AI Toolkit for TypeScript. From the creators of Next.js, the AI SDK is a free open-source library for building AI-powered applications and agents ",
       "primaryLanguage": "TypeScript",
       "starredAt": "2023-06-15T19:55:10Z"
@@ -2010,7 +2121,7 @@
     {
       "nameWithOwner": "facebookresearch/audiocraft",
       "url": "https://github.com/facebookresearch/audiocraft",
-      "stargazerCount": 22317,
+      "stargazerCount": 22357,
       "description": "Audiocraft is a library for audio processing and generation with deep learning. It features the state-of-the-art EnCodec audio compressor / tokenizer, along with MusicGen, a simple and controllable music generation LM with textual and melodic conditioning.",
       "primaryLanguage": "Jupyter Notebook",
       "starredAt": "2023-06-15T00:54:16Z"
@@ -2018,7 +2129,7 @@
     {
       "nameWithOwner": "darkreader/darkreader",
       "url": "https://github.com/darkreader/darkreader",
-      "stargazerCount": 20949,
+      "stargazerCount": 20976,
       "description": "Dark Reader Chrome and Firefox extension",
       "primaryLanguage": "TypeScript",
       "starredAt": "2023-06-11T21:16:26Z"
@@ -2034,7 +2145,7 @@
     {
       "nameWithOwner": "XingangPan/DragGAN",
       "url": "https://github.com/XingangPan/DragGAN",
-      "stargazerCount": 35935,
+      "stargazerCount": 35918,
       "description": "Official Code for DragGAN (SIGGRAPH 2023)",
       "primaryLanguage": "Python",
       "starredAt": "2023-05-20T01:08:12Z"
@@ -2042,7 +2153,7 @@
     {
       "nameWithOwner": "yoavbls/pretty-ts-errors",
       "url": "https://github.com/yoavbls/pretty-ts-errors",
-      "stargazerCount": 13927,
+      "stargazerCount": 13940,
       "description": "🔵 Make TypeScript errors prettier and human-readable in VSCode 🎀",
       "primaryLanguage": "TypeScript",
       "starredAt": "2023-04-17T23:15:54Z"
@@ -2050,7 +2161,7 @@
     {
       "nameWithOwner": "everythingishacked/Semaphore",
       "url": "https://github.com/everythingishacked/Semaphore",
-      "stargazerCount": 1942,
+      "stargazerCount": 1943,
       "description": "A full-body keyboard using gestures to type through computer vision",
       "primaryLanguage": "Python",
       "starredAt": "2023-04-14T22:10:27Z"
@@ -2058,7 +2169,7 @@
     {
       "nameWithOwner": "lm-sys/FastChat",
       "url": "https://github.com/lm-sys/FastChat",
-      "stargazerCount": 38902,
+      "stargazerCount": 38930,
       "description": "An open platform for training, serving, and evaluating large language models. Release repo for Vicuna and Chatbot Arena.",
       "primaryLanguage": "Python",
       "starredAt": "2023-04-03T23:44:16Z"
@@ -2066,7 +2177,7 @@
     {
       "nameWithOwner": "twitter/the-algorithm",
       "url": "https://github.com/twitter/the-algorithm",
-      "stargazerCount": 63430,
+      "stargazerCount": 63456,
       "description": "Source code for Twitter's Recommendation Algorithm",
       "primaryLanguage": "Scala",
       "starredAt": "2023-03-31T21:42:59Z"
@@ -2074,7 +2185,7 @@
     {
       "nameWithOwner": "reactjs/react.dev",
       "url": "https://github.com/reactjs/react.dev",
-      "stargazerCount": 11441,
+      "stargazerCount": 11455,
       "description": "The React documentation website",
       "primaryLanguage": "TypeScript",
       "starredAt": "2023-03-31T10:45:14Z"
@@ -2082,7 +2193,7 @@
     {
       "nameWithOwner": "pyenv/pyenv",
       "url": "https://github.com/pyenv/pyenv",
-      "stargazerCount": 42683,
+      "stargazerCount": 42786,
       "description": "Simple Python version management",
       "primaryLanguage": "Roff",
       "starredAt": "2023-03-30T09:59:56Z"
@@ -2090,7 +2201,7 @@
     {
       "nameWithOwner": "PrefectHQ/marvin",
       "url": "https://github.com/PrefectHQ/marvin",
-      "stargazerCount": 5826,
+      "stargazerCount": 5850,
       "description": "an ambient intelligence library",
       "primaryLanguage": "Python",
       "starredAt": "2023-03-30T08:38:47Z"
@@ -2098,7 +2209,7 @@
     {
       "nameWithOwner": "vocodedev/vocode-core",
       "url": "https://github.com/vocodedev/vocode-core",
-      "stargazerCount": 3388,
+      "stargazerCount": 3395,
       "description": "🤖 Build voice-based LLM agents. Modular + open source.",
       "primaryLanguage": "Python",
       "starredAt": "2023-03-30T05:54:26Z"
@@ -2106,7 +2217,7 @@
     {
       "nameWithOwner": "nomic-ai/gpt4all",
       "url": "https://github.com/nomic-ai/gpt4all",
-      "stargazerCount": 73874,
+      "stargazerCount": 73938,
       "description": "GPT4All: Run Local LLMs on Any Device. Open-source and available for commercial use.",
       "primaryLanguage": "C++",
       "starredAt": "2023-03-29T02:06:19Z"
@@ -2114,7 +2225,7 @@
     {
       "nameWithOwner": "brycedrennan/imaginAIry",
       "url": "https://github.com/brycedrennan/imaginAIry",
-      "stargazerCount": 8133,
+      "stargazerCount": 8134,
       "description": "Pythonic AI generation of images and videos",
       "primaryLanguage": "Python",
       "starredAt": "2023-03-28T21:56:35Z"
@@ -2130,7 +2241,7 @@
     {
       "nameWithOwner": "HamburgChimps/apple-notes-liberator",
       "url": "https://github.com/HamburgChimps/apple-notes-liberator",
-      "stargazerCount": 1004,
+      "stargazerCount": 1006,
       "description": "Free your Apple Notes data from Notes.app",
       "primaryLanguage": "Java",
       "starredAt": "2023-03-27T06:20:18Z"
@@ -2138,7 +2249,7 @@
     {
       "nameWithOwner": "sindresorhus/type-fest",
       "url": "https://github.com/sindresorhus/type-fest",
-      "stargazerCount": 15750,
+      "stargazerCount": 15812,
       "description": "A collection of essential TypeScript types",
       "primaryLanguage": "TypeScript",
       "starredAt": "2023-03-27T03:24:18Z"
@@ -2146,7 +2257,7 @@
     {
       "nameWithOwner": "gd3kr/BlenderGPT",
       "url": "https://github.com/gd3kr/BlenderGPT",
-      "stargazerCount": 4825,
+      "stargazerCount": 4831,
       "description": "Use commands in English to control Blender with OpenAI's GPT-4",
       "primaryLanguage": "Python",
       "starredAt": "2023-03-27T01:23:17Z"
@@ -2170,7 +2281,7 @@
     {
       "nameWithOwner": "WordPress/wordpress-develop",
       "url": "https://github.com/WordPress/wordpress-develop",
-      "stargazerCount": 3023,
+      "stargazerCount": 3034,
       "description": "WordPress Develop, Git-ified. Synced from git://develop.git.wordpress.org/, including branches and tags! This repository is just a mirror of the WordPress subversion repository. Please include a link to a pre-existing ticket on https://core.trac.wordpress.org/ with every pull request.",
       "primaryLanguage": "PHP",
       "starredAt": "2023-03-23T20:28:31Z"
@@ -2178,7 +2289,7 @@
     {
       "nameWithOwner": "WordPress/WordPress",
       "url": "https://github.com/WordPress/WordPress",
-      "stargazerCount": 20330,
+      "stargazerCount": 20358,
       "description": "WordPress, Git-ified. This repository is just a mirror of the WordPress subversion repository. Please do not send pull requests. Submit pull requests to https://github.com/WordPress/wordpress-develop and patches to https://core.trac.wordpress.org/ instead.",
       "primaryLanguage": "PHP",
       "starredAt": "2023-03-23T20:27:18Z"
@@ -2194,7 +2305,7 @@
     {
       "nameWithOwner": "tatsu-lab/stanford_alpaca",
       "url": "https://github.com/tatsu-lab/stanford_alpaca",
-      "stargazerCount": 30092,
+      "stargazerCount": 30098,
       "description": "Code and documentation to train Stanford's Alpaca models, and generate the data.",
       "primaryLanguage": "Python",
       "starredAt": "2023-03-21T06:58:01Z"
@@ -2202,7 +2313,7 @@
     {
       "nameWithOwner": "cloudflare/cloudflared",
       "url": "https://github.com/cloudflare/cloudflared",
-      "stargazerCount": 11094,
+      "stargazerCount": 11168,
       "description": "Cloudflare Tunnel client (formerly Argo Tunnel)",
       "primaryLanguage": "Go",
       "starredAt": "2023-03-21T06:08:44Z"
@@ -2210,7 +2321,7 @@
     {
       "nameWithOwner": "bigscience-workshop/petals",
       "url": "https://github.com/bigscience-workshop/petals",
-      "stargazerCount": 9731,
+      "stargazerCount": 9739,
       "description": "🌸 Run LLMs at home, BitTorrent-style. Fine-tuning and inference up to 10x faster than offloading",
       "primaryLanguage": "Python",
       "starredAt": "2023-03-20T23:23:21Z"
@@ -2218,7 +2329,7 @@
     {
       "nameWithOwner": "npiv/chatblade",
       "url": "https://github.com/npiv/chatblade",
-      "stargazerCount": 2612,
+      "stargazerCount": 2610,
       "description": "A CLI Swiss Army Knife for ChatGPT",
       "primaryLanguage": "Python",
       "starredAt": "2023-03-20T04:54:34Z"
@@ -2226,7 +2337,7 @@
     {
       "nameWithOwner": "antimatter15/alpaca.cpp",
       "url": "https://github.com/antimatter15/alpaca.cpp",
-      "stargazerCount": 10224,
+      "stargazerCount": 10223,
       "description": "Locally run an Instruction-Tuned Chat-Style LLM ",
       "primaryLanguage": "C",
       "starredAt": "2023-03-19T20:59:13Z"
@@ -2242,7 +2353,7 @@
     {
       "nameWithOwner": "spencermountain/wtf_wikipedia",
       "url": "https://github.com/spencermountain/wtf_wikipedia",
-      "stargazerCount": 817,
+      "stargazerCount": 818,
       "description": "a pretty-committed wikipedia markup parser",
       "primaryLanguage": "JavaScript",
       "starredAt": "2023-03-19T10:34:08Z"
@@ -2250,7 +2361,7 @@
     {
       "nameWithOwner": "dequelabs/axe-core",
       "url": "https://github.com/dequelabs/axe-core",
-      "stargazerCount": 6510,
+      "stargazerCount": 6528,
       "description": "Accessibility engine for automated Web UI testing",
       "primaryLanguage": "JavaScript",
       "starredAt": "2023-03-17T03:37:52Z"
@@ -2282,7 +2393,7 @@
     {
       "nameWithOwner": "sturdy-dev/codereview.gpt",
       "url": "https://github.com/sturdy-dev/codereview.gpt",
-      "stargazerCount": 593,
+      "stargazerCount": 594,
       "description": "Reviews your Pull/Merge Requests using ChatGPT",
       "primaryLanguage": "JavaScript",
       "starredAt": "2023-03-16T06:11:44Z"
@@ -2314,7 +2425,7 @@
     {
       "nameWithOwner": "huggingface/huggingface.js",
       "url": "https://github.com/huggingface/huggingface.js",
-      "stargazerCount": 2182,
+      "stargazerCount": 2187,
       "description": "Use Hugging Face with JavaScript",
       "primaryLanguage": "TypeScript",
       "starredAt": "2023-03-13T07:37:24Z"
@@ -2322,7 +2433,7 @@
     {
       "nameWithOwner": "togethercomputer/OpenChatKit",
       "url": "https://github.com/togethercomputer/OpenChatKit",
-      "stargazerCount": 9007,
+      "stargazerCount": 9011,
       "description": "",
       "primaryLanguage": "Python",
       "starredAt": "2023-03-12T21:15:35Z"
@@ -2330,7 +2441,7 @@
     {
       "nameWithOwner": "mukulpatnaik/researchgpt",
       "url": "https://github.com/mukulpatnaik/researchgpt",
-      "stargazerCount": 3545,
+      "stargazerCount": 3544,
       "description": "A LLM based research assistant that allows you to have a conversation with a research paper",
       "primaryLanguage": "Python",
       "starredAt": "2023-03-11T12:59:12Z"
@@ -2346,7 +2457,7 @@
     {
       "nameWithOwner": "chenfei-wu/TaskMatrix",
       "url": "https://github.com/chenfei-wu/TaskMatrix",
-      "stargazerCount": 34416,
+      "stargazerCount": 34409,
       "description": "",
       "primaryLanguage": "Python",
       "starredAt": "2023-03-10T02:21:59Z"
@@ -2354,7 +2465,7 @@
     {
       "nameWithOwner": "mixmark-io/turndown",
       "url": "https://github.com/mixmark-io/turndown",
-      "stargazerCount": 10034,
+      "stargazerCount": 10072,
       "description": "🛏 An HTML to Markdown converter written in JavaScript",
       "primaryLanguage": "HTML",
       "starredAt": "2023-03-07T11:27:25Z"
@@ -2362,7 +2473,7 @@
     {
       "nameWithOwner": "MagnivOrg/prompt-layer-library",
       "url": "https://github.com/MagnivOrg/prompt-layer-library",
-      "stargazerCount": 647,
+      "stargazerCount": 650,
       "description": "🍰 PromptLayer - Maintain a log of your prompts and OpenAI API requests. Track, debug, and replay old completions.",
       "primaryLanguage": "Python",
       "starredAt": "2023-03-07T10:27:33Z"
@@ -2370,7 +2481,7 @@
     {
       "nameWithOwner": "openai/openai-cookbook",
       "url": "https://github.com/openai/openai-cookbook",
-      "stargazerCount": 65513,
+      "stargazerCount": 65711,
       "description": "Examples and guides for using the OpenAI API",
       "primaryLanguage": "MDX",
       "starredAt": "2023-03-04T22:30:45Z"
@@ -2378,15 +2489,15 @@
     {
       "nameWithOwner": "chroma-core/chroma",
       "url": "https://github.com/chroma-core/chroma",
-      "stargazerCount": 21276,
-      "description": "the AI-native open-source embedding database",
+      "stargazerCount": 21440,
+      "description": "Open-source search and retrieval database for AI applications.",
       "primaryLanguage": "Rust",
       "starredAt": "2023-03-04T12:41:39Z"
     },
     {
       "nameWithOwner": "hwchase17/langchain-hub",
       "url": "https://github.com/hwchase17/langchain-hub",
-      "stargazerCount": 3347,
+      "stargazerCount": 3354,
       "description": "",
       "primaryLanguage": "Python",
       "starredAt": "2023-03-04T12:12:50Z"
@@ -2402,7 +2513,7 @@
     {
       "nameWithOwner": "langchain-ai/langchain",
       "url": "https://github.com/langchain-ai/langchain",
-      "stargazerCount": 112163,
+      "stargazerCount": 112784,
       "description": "🦜🔗 Build context-aware reasoning applications",
       "primaryLanguage": "Jupyter Notebook",
       "starredAt": "2023-03-02T02:10:28Z"
@@ -2410,7 +2521,7 @@
     {
       "nameWithOwner": "langchain-ai/langchainjs",
       "url": "https://github.com/langchain-ai/langchainjs",
-      "stargazerCount": 15228,
+      "stargazerCount": 15326,
       "description": "🦜🔗 Build context-aware reasoning applications 🦜🔗",
       "primaryLanguage": "TypeScript",
       "starredAt": "2023-03-02T02:10:26Z"
@@ -2418,7 +2529,7 @@
     {
       "nameWithOwner": "coollabsio/coolify",
       "url": "https://github.com/coollabsio/coolify",
-      "stargazerCount": 43670,
+      "stargazerCount": 43966,
       "description": "An open-source & self-hostable Heroku / Netlify / Vercel alternative.",
       "primaryLanguage": "PHP",
       "starredAt": "2023-02-24T22:29:19Z"
@@ -2434,7 +2545,7 @@
     {
       "nameWithOwner": "shorepine/alles",
       "url": "https://github.com/shorepine/alles",
-      "stargazerCount": 282,
+      "stargazerCount": 283,
       "description": "A many speaker distributed music synthesizer using UDP multicast over WiFi",
       "primaryLanguage": "C",
       "starredAt": "2023-02-22T09:42:39Z"
@@ -2442,7 +2553,7 @@
     {
       "nameWithOwner": "mattpocock/ts-reset",
       "url": "https://github.com/mattpocock/ts-reset",
-      "stargazerCount": 8246,
+      "stargazerCount": 8250,
       "description": "A 'CSS reset' for TypeScript, improving types for common JavaScript API's",
       "primaryLanguage": "TypeScript",
       "starredAt": "2023-02-21T23:57:23Z"
@@ -2450,7 +2561,7 @@
     {
       "nameWithOwner": "flipt-io/flipt",
       "url": "https://github.com/flipt-io/flipt",
-      "stargazerCount": 4464,
+      "stargazerCount": 4472,
       "description": "Enterprise-ready, Git native feature management solution",
       "primaryLanguage": "Go",
       "starredAt": "2023-02-20T05:13:40Z"
@@ -2466,7 +2577,7 @@
     {
       "nameWithOwner": "motion-canvas/motion-canvas",
       "url": "https://github.com/motion-canvas/motion-canvas",
-      "stargazerCount": 17136,
+      "stargazerCount": 17167,
       "description": "Visualize Your Ideas With Code",
       "primaryLanguage": "TypeScript",
       "starredAt": "2023-02-09T16:50:00Z"
@@ -2482,7 +2593,7 @@
     {
       "nameWithOwner": "Automattic/vip-go-nextjs-skeleton",
       "url": "https://github.com/Automattic/vip-go-nextjs-skeleton",
-      "stargazerCount": 75,
+      "stargazerCount": 76,
       "description": "A Next.js boilerplate for decoupled WordPress on VIP.",
       "primaryLanguage": "TypeScript",
       "starredAt": "2023-02-08T11:58:53Z"
@@ -2498,7 +2609,7 @@
     {
       "nameWithOwner": "karlicoss/kobuddy",
       "url": "https://github.com/karlicoss/kobuddy",
-      "stargazerCount": 162,
+      "stargazerCount": 163,
       "description": "Kobo database backup and parser: extracts notes, highlights, reading progress and more",
       "primaryLanguage": "Python",
       "starredAt": "2023-02-02T00:26:06Z"
@@ -2506,7 +2617,7 @@
     {
       "nameWithOwner": "98mprice/PSone.css",
       "url": "https://github.com/98mprice/PSone.css",
-      "stargazerCount": 411,
+      "stargazerCount": 412,
       "description": "",
       "primaryLanguage": "HTML",
       "starredAt": "2023-02-01T11:16:23Z"
@@ -2522,7 +2633,7 @@
     {
       "nameWithOwner": "leeoniya/uFuzzy",
       "url": "https://github.com/leeoniya/uFuzzy",
-      "stargazerCount": 2853,
+      "stargazerCount": 2856,
       "description": "A tiny, efficient fuzzy search that doesn't suck",
       "primaryLanguage": "JavaScript",
       "starredAt": "2023-01-31T06:52:27Z"
@@ -2546,7 +2657,7 @@
     {
       "nameWithOwner": "githubocto/repo-visualizer",
       "url": "https://github.com/githubocto/repo-visualizer",
-      "stargazerCount": 1231,
+      "stargazerCount": 1234,
       "description": "",
       "primaryLanguage": "JavaScript",
       "starredAt": "2023-01-27T04:55:09Z"
@@ -2554,7 +2665,7 @@
     {
       "nameWithOwner": "f/awesome-chatgpt-prompts",
       "url": "https://github.com/f/awesome-chatgpt-prompts",
-      "stargazerCount": 131205,
+      "stargazerCount": 131886,
       "description": "This repo includes ChatGPT prompt curation to use ChatGPT and other LLM tools better.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2023-01-25T11:06:27Z"
@@ -2570,7 +2681,7 @@
     {
       "nameWithOwner": "premieroctet/photoshot",
       "url": "https://github.com/premieroctet/photoshot",
-      "stargazerCount": 3804,
+      "stargazerCount": 3808,
       "description": "An open-source AI avatar generator web app - https://photoshot.app",
       "primaryLanguage": "TypeScript",
       "starredAt": "2022-12-13T21:23:57Z"
@@ -2578,7 +2689,7 @@
     {
       "nameWithOwner": "FuzzyIdeas/Clop",
       "url": "https://github.com/FuzzyIdeas/Clop",
-      "stargazerCount": 1128,
+      "stargazerCount": 1140,
       "description": "Clipboard optimizer for macOS",
       "primaryLanguage": "Swift",
       "starredAt": "2022-11-19T11:19:37Z"
@@ -2586,7 +2697,7 @@
     {
       "nameWithOwner": "skevy/graphiql-app",
       "url": "https://github.com/skevy/graphiql-app",
-      "stargazerCount": 2971,
+      "stargazerCount": 2972,
       "description": "Light, Electron-based Wrapper around GraphiQL",
       "primaryLanguage": "JavaScript",
       "starredAt": "2022-11-09T12:10:35Z"
@@ -2602,7 +2713,7 @@
     {
       "nameWithOwner": "hotwired/turbo",
       "url": "https://github.com/hotwired/turbo",
-      "stargazerCount": 7061,
+      "stargazerCount": 7077,
       "description": "The speed of a single-page web application without having to write any JavaScript",
       "primaryLanguage": "JavaScript",
       "starredAt": "2022-11-02T12:44:39Z"
@@ -2618,7 +2729,7 @@
     {
       "nameWithOwner": "Tampermonkey/tampermonkey",
       "url": "https://github.com/Tampermonkey/tampermonkey",
-      "stargazerCount": 4869,
+      "stargazerCount": 4889,
       "description": "Tampermonkey is the most popular userscript manager, with over 10 million users. It's available for Chrome, Microsoft Edge, Safari, Opera Next, and Firefox. ",
       "primaryLanguage": "JavaScript",
       "starredAt": "2022-11-02T00:34:49Z"
@@ -2634,7 +2745,7 @@
     {
       "nameWithOwner": "jonasmerlin/astro-seo",
       "url": "https://github.com/jonasmerlin/astro-seo",
-      "stargazerCount": 1159,
+      "stargazerCount": 1162,
       "description": "Makes it easy to add information that is relevant for SEO to your Astro app.",
       "primaryLanguage": "Astro",
       "starredAt": "2022-11-01T10:39:39Z"
@@ -2642,7 +2753,7 @@
     {
       "nameWithOwner": "Shopify/hydrogen-v1",
       "url": "https://github.com/Shopify/hydrogen-v1",
-      "stargazerCount": 3743,
+      "stargazerCount": 3745,
       "description": "React-based framework for building dynamic, Shopify-powered custom storefronts.",
       "primaryLanguage": "TypeScript",
       "starredAt": "2022-11-01T04:40:35Z"
@@ -2650,7 +2761,7 @@
     {
       "nameWithOwner": "dimforge/rapier",
       "url": "https://github.com/dimforge/rapier",
-      "stargazerCount": 4633,
+      "stargazerCount": 4650,
       "description": "2D and 3D physics engines focused on performance.",
       "primaryLanguage": "Rust",
       "starredAt": "2022-11-01T02:28:21Z"
@@ -2658,7 +2769,7 @@
     {
       "nameWithOwner": "pmndrs/react-three-rapier",
       "url": "https://github.com/pmndrs/react-three-rapier",
-      "stargazerCount": 1253,
+      "stargazerCount": 1254,
       "description": "🤺 Rapier physics in React",
       "primaryLanguage": "TypeScript",
       "starredAt": "2022-11-01T02:26:52Z"
@@ -2674,7 +2785,7 @@
     {
       "nameWithOwner": "charmbracelet/vhs",
       "url": "https://github.com/charmbracelet/vhs",
-      "stargazerCount": 16847,
+      "stargazerCount": 16992,
       "description": "Your CLI home video recorder 📼",
       "primaryLanguage": "Go",
       "starredAt": "2022-10-31T03:52:11Z"
@@ -2706,7 +2817,7 @@
     {
       "nameWithOwner": "shikijs/shiki",
       "url": "https://github.com/shikijs/shiki",
-      "stargazerCount": 11839,
+      "stargazerCount": 11896,
       "description": "A beautiful yet powerful syntax highlighter",
       "primaryLanguage": "TypeScript",
       "starredAt": "2022-10-27T11:32:49Z"
@@ -2722,7 +2833,7 @@
     {
       "nameWithOwner": "github/roadmap",
       "url": "https://github.com/github/roadmap",
-      "stargazerCount": 8314,
+      "stargazerCount": 8327,
       "description": "GitHub public roadmap",
       "primaryLanguage": null,
       "starredAt": "2022-10-27T06:54:21Z"
@@ -2738,7 +2849,7 @@
     {
       "nameWithOwner": "Stability-AI/diffusers",
       "url": "https://github.com/Stability-AI/diffusers",
-      "stargazerCount": 177,
+      "stargazerCount": 176,
       "description": "🤗 Diffusers: State-of-the-art diffusion models for image and audio generation in PyTorch",
       "primaryLanguage": "Python",
       "starredAt": "2022-10-24T10:52:31Z"
@@ -2746,7 +2857,7 @@
     {
       "nameWithOwner": "huggingface/diffusers",
       "url": "https://github.com/huggingface/diffusers",
-      "stargazerCount": 29914,
+      "stargazerCount": 30046,
       "description": "🤗 Diffusers: State-of-the-art diffusion models for image, video, and audio generation in PyTorch and FLAX.",
       "primaryLanguage": "Python",
       "starredAt": "2022-10-24T10:51:27Z"
@@ -2754,7 +2865,7 @@
     {
       "nameWithOwner": "Stability-AI/stability-sdk",
       "url": "https://github.com/Stability-AI/stability-sdk",
-      "stargazerCount": 2441,
+      "stargazerCount": 2440,
       "description": "SDK for interacting with stability.ai APIs (e.g. stable diffusion inference)",
       "primaryLanguage": "Jupyter Notebook",
       "starredAt": "2022-10-24T10:50:24Z"
@@ -2762,7 +2873,7 @@
     {
       "nameWithOwner": "johnbillion/query-monitor",
       "url": "https://github.com/johnbillion/query-monitor",
-      "stargazerCount": 1681,
+      "stargazerCount": 1683,
       "description": "The developer tools panel for WordPress",
       "primaryLanguage": "PHP",
       "starredAt": "2022-10-24T06:05:40Z"
@@ -2786,7 +2897,7 @@
     {
       "nameWithOwner": "naotokui/RhythmVAE_M4L",
       "url": "https://github.com/naotokui/RhythmVAE_M4L",
-      "stargazerCount": 235,
+      "stargazerCount": 236,
       "description": "Max for Live(M4L) Rhythm generator using Variational Autoencoder(VAE) ",
       "primaryLanguage": "Max",
       "starredAt": "2022-10-20T09:30:48Z"
@@ -2794,7 +2905,7 @@
     {
       "nameWithOwner": "EnvelopSound/EnvelopForLive",
       "url": "https://github.com/EnvelopSound/EnvelopForLive",
-      "stargazerCount": 502,
+      "stargazerCount": 503,
       "description": "Free, open-source tools for Ambisonic 3D panning within Max for Live 10+",
       "primaryLanguage": "Max",
       "starredAt": "2022-10-20T09:28:58Z"
@@ -2802,7 +2913,7 @@
     {
       "nameWithOwner": "Ableton/m4l-connection-kit",
       "url": "https://github.com/Ableton/m4l-connection-kit",
-      "stargazerCount": 526,
+      "stargazerCount": 528,
       "description": "Max for Live Connection Kit",
       "primaryLanguage": "C++",
       "starredAt": "2022-10-20T09:16:38Z"
@@ -2810,7 +2921,7 @@
     {
       "nameWithOwner": "kripken/ammo.js",
       "url": "https://github.com/kripken/ammo.js",
-      "stargazerCount": 4361,
+      "stargazerCount": 4371,
       "description": "Direct port of the Bullet physics engine to JavaScript using Emscripten",
       "primaryLanguage": "C++",
       "starredAt": "2022-10-20T08:09:44Z"
@@ -2818,7 +2929,7 @@
     {
       "nameWithOwner": "Automattic/pocket-casts-ios",
       "url": "https://github.com/Automattic/pocket-casts-ios",
-      "stargazerCount": 1718,
+      "stargazerCount": 1721,
       "description": "Pocket Casts iOS app 🎧",
       "primaryLanguage": "Swift",
       "starredAt": "2022-10-20T04:14:37Z"
@@ -2826,7 +2937,7 @@
     {
       "nameWithOwner": "divamgupta/diffusionbee-stable-diffusion-ui",
       "url": "https://github.com/divamgupta/diffusionbee-stable-diffusion-ui",
-      "stargazerCount": 13322,
+      "stargazerCount": 13341,
       "description": "Diffusion Bee is the easiest way to run Stable Diffusion locally on your M1 Mac. Comes with a one-click installer. No dependencies or technical knowledge needed.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2022-10-18T09:51:21Z"
@@ -2834,7 +2945,7 @@
     {
       "nameWithOwner": "neondatabase/neon",
       "url": "https://github.com/neondatabase/neon",
-      "stargazerCount": 19185,
+      "stargazerCount": 19286,
       "description": "Neon: Serverless Postgres. We separated storage and compute to offer autoscaling, code-like database branching, and scale to zero.",
       "primaryLanguage": "Rust",
       "starredAt": "2022-10-15T11:16:39Z"
@@ -2842,7 +2953,7 @@
     {
       "nameWithOwner": "swyxio/ai-notes",
       "url": "https://github.com/swyxio/ai-notes",
-      "stargazerCount": 5889,
+      "stargazerCount": 5897,
       "description": "notes for software engineers getting up to speed on new AI developments. Serves as datastore for https://latent.space writing, and product brainstorming, but has cleaned up canonical references under the /Resources folder.",
       "primaryLanguage": "HTML",
       "starredAt": "2022-10-15T09:14:24Z"
@@ -2858,7 +2969,7 @@
     {
       "nameWithOwner": "rxhanson/Rectangle",
       "url": "https://github.com/rxhanson/Rectangle",
-      "stargazerCount": 27308,
+      "stargazerCount": 27373,
       "description": "Move and resize windows on macOS with keyboard shortcuts and snap areas",
       "primaryLanguage": "Swift",
       "starredAt": "2022-10-13T00:25:50Z"
@@ -2866,7 +2977,7 @@
     {
       "nameWithOwner": "tursodatabase/libsql",
       "url": "https://github.com/tursodatabase/libsql",
-      "stargazerCount": 15237,
+      "stargazerCount": 15278,
       "description": "libSQL is a fork of SQLite that is both Open Source, and Open Contributions.",
       "primaryLanguage": "C",
       "starredAt": "2022-10-12T11:00:55Z"
@@ -2874,7 +2985,7 @@
     {
       "nameWithOwner": "webrcade/webrcade",
       "url": "https://github.com/webrcade/webrcade",
-      "stargazerCount": 1211,
+      "stargazerCount": 1218,
       "description": "Feed-driven gaming",
       "primaryLanguage": "JavaScript",
       "starredAt": "2022-10-12T10:44:19Z"
@@ -2882,7 +2993,7 @@
     {
       "nameWithOwner": "remoteintech/remote-jobs",
       "url": "https://github.com/remoteintech/remote-jobs",
-      "stargazerCount": 36455,
+      "stargazerCount": 37971,
       "description": "A list of semi to fully remote-friendly companies (jobs) in tech.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2022-10-12T10:32:25Z"
@@ -2890,7 +3001,7 @@
     {
       "nameWithOwner": "marp-team/marp-core",
       "url": "https://github.com/marp-team/marp-core",
-      "stargazerCount": 929,
+      "stargazerCount": 935,
       "description": "The core of Marp converter",
       "primaryLanguage": "TypeScript",
       "starredAt": "2022-09-23T11:20:34Z"
@@ -2898,7 +3009,7 @@
     {
       "nameWithOwner": "marp-team/marp",
       "url": "https://github.com/marp-team/marp",
-      "stargazerCount": 9312,
+      "stargazerCount": 9370,
       "description": "The entrance repository of Markdown presentation ecosystem",
       "primaryLanguage": "TypeScript",
       "starredAt": "2022-09-23T07:32:13Z"
@@ -2922,7 +3033,7 @@
     {
       "nameWithOwner": "markdoc/markdoc",
       "url": "https://github.com/markdoc/markdoc",
-      "stargazerCount": 7616,
+      "stargazerCount": 7635,
       "description": "A powerful, flexible, Markdown-based authoring framework.",
       "primaryLanguage": "TypeScript",
       "starredAt": "2022-09-16T11:28:21Z"
@@ -2930,7 +3041,7 @@
     {
       "nameWithOwner": "swyxio/swyxdotio",
       "url": "https://github.com/swyxio/swyxdotio",
-      "stargazerCount": 383,
+      "stargazerCount": 384,
       "description": "This is the repo for swyx's blog - Blog content is created in github issues, then posted on swyx.io as blog pages! Comment/watch to follow along my blog within GitHub",
       "primaryLanguage": "Svelte",
       "starredAt": "2022-09-15T10:05:36Z"
@@ -2938,7 +3049,7 @@
     {
       "nameWithOwner": "AUTOMATIC1111/stable-diffusion-webui",
       "url": "https://github.com/AUTOMATIC1111/stable-diffusion-webui",
-      "stargazerCount": 154815,
+      "stargazerCount": 155154,
       "description": "Stable Diffusion web UI",
       "primaryLanguage": "Python",
       "starredAt": "2022-09-15T09:41:35Z"
@@ -2946,7 +3057,7 @@
     {
       "nameWithOwner": "alibaba/EasyCV",
       "url": "https://github.com/alibaba/EasyCV",
-      "stargazerCount": 1875,
+      "stargazerCount": 1878,
       "description": "An all-in-one toolkit for computer vision",
       "primaryLanguage": "Python",
       "starredAt": "2022-09-15T09:37:40Z"
@@ -2954,7 +3065,7 @@
     {
       "nameWithOwner": "vercel/release",
       "url": "https://github.com/vercel/release",
-      "stargazerCount": 3582,
+      "stargazerCount": 3583,
       "description": "Generate changelogs with a single command",
       "primaryLanguage": "JavaScript",
       "starredAt": "2022-09-14T22:47:03Z"
@@ -2962,7 +3073,7 @@
     {
       "nameWithOwner": "gitify-app/gitify",
       "url": "https://github.com/gitify-app/gitify",
-      "stargazerCount": 4999,
+      "stargazerCount": 5013,
       "description": "GitHub notifications on your menu bar. Available on macOS, Windows & Linux.",
       "primaryLanguage": "TypeScript",
       "starredAt": "2022-09-14T11:30:04Z"
@@ -2970,7 +3081,7 @@
     {
       "nameWithOwner": "stefanbuck/awesome-browser-extensions-for-github",
       "url": "https://github.com/stefanbuck/awesome-browser-extensions-for-github",
-      "stargazerCount": 3138,
+      "stargazerCount": 3142,
       "description": "A collection of awesome browser extensions for GitHub.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2022-09-14T11:06:08Z"
@@ -2986,7 +3097,7 @@
     {
       "nameWithOwner": "WordPress/wordpress-playground",
       "url": "https://github.com/WordPress/wordpress-playground",
-      "stargazerCount": 1766,
+      "stargazerCount": 1769,
       "description": "Run WordPress in the browser via WebAssembly PHP",
       "primaryLanguage": "JavaScript",
       "starredAt": "2022-09-14T04:52:28Z"
@@ -2994,7 +3105,7 @@
     {
       "nameWithOwner": "triggerdotdev/jsonhero-web",
       "url": "https://github.com/triggerdotdev/jsonhero-web",
-      "stargazerCount": 10159,
+      "stargazerCount": 10165,
       "description": "JSON Hero is an open-source, beautiful JSON explorer for the web that lets you browse, search and navigate your JSON files at speed. 🚀. Built with 💜 by the Trigger.dev team.",
       "primaryLanguage": "TypeScript",
       "starredAt": "2022-09-12T23:03:56Z"
@@ -3010,7 +3121,7 @@
     {
       "nameWithOwner": "remarkjs/remark",
       "url": "https://github.com/remarkjs/remark",
-      "stargazerCount": 8341,
+      "stargazerCount": 8364,
       "description": "markdown processor powered by plugins part of the @unifiedjs collective",
       "primaryLanguage": "JavaScript",
       "starredAt": "2022-09-07T21:33:53Z"
@@ -3018,7 +3129,7 @@
     {
       "nameWithOwner": "rehypejs/rehype",
       "url": "https://github.com/rehypejs/rehype",
-      "stargazerCount": 2042,
+      "stargazerCount": 2050,
       "description": "HTML processor powered by plugins part of the @unifiedjs collective",
       "primaryLanguage": "JavaScript",
       "starredAt": "2022-09-07T21:31:39Z"
@@ -3026,7 +3137,7 @@
     {
       "nameWithOwner": "QwikDev/partytown",
       "url": "https://github.com/QwikDev/partytown",
-      "stargazerCount": 13422,
+      "stargazerCount": 13436,
       "description": "Relocate resource intensive third-party scripts off of the main thread and into a web worker. 🎉",
       "primaryLanguage": "TypeScript",
       "starredAt": "2022-09-07T02:39:50Z"
@@ -3034,7 +3145,7 @@
     {
       "nameWithOwner": "mozilla/webextension-polyfill",
       "url": "https://github.com/mozilla/webextension-polyfill",
-      "stargazerCount": 2928,
+      "stargazerCount": 2937,
       "description": "A lightweight polyfill library for Promise-based WebExtension APIs in Chrome",
       "primaryLanguage": "JavaScript",
       "starredAt": "2022-09-05T11:34:04Z"
@@ -3042,7 +3153,7 @@
     {
       "nameWithOwner": "fregante/browser-extension-template",
       "url": "https://github.com/fregante/browser-extension-template",
-      "stargazerCount": 816,
+      "stargazerCount": 817,
       "description": "📕 Barebones boilerplate with Parcel 2, options handler and auto-publishing",
       "primaryLanguage": "JavaScript",
       "starredAt": "2022-09-05T10:54:40Z"
@@ -3050,7 +3161,7 @@
     {
       "nameWithOwner": "WordPress/performance",
       "url": "https://github.com/WordPress/performance",
-      "stargazerCount": 406,
+      "stargazerCount": 408,
       "description": "Performance plugin from the WordPress Performance Group, which is a collection of standalone performance modules.",
       "primaryLanguage": "PHP",
       "starredAt": "2022-09-03T22:56:24Z"
@@ -3066,7 +3177,7 @@
     {
       "nameWithOwner": "jotaen/xit",
       "url": "https://github.com/jotaen/xit",
-      "stargazerCount": 1086,
+      "stargazerCount": 1087,
       "description": "A plain-text file format for todos and check lists",
       "primaryLanguage": null,
       "starredAt": "2022-08-26T11:42:23Z"
@@ -3074,7 +3185,7 @@
     {
       "nameWithOwner": "dwarvesf/hidden",
       "url": "https://github.com/dwarvesf/hidden",
-      "stargazerCount": 12529,
+      "stargazerCount": 12558,
       "description": "An ultra-light MacOS utility that helps hide menu bar icons",
       "primaryLanguage": "Swift",
       "starredAt": "2022-08-19T00:12:26Z"
@@ -3098,7 +3209,7 @@
     {
       "nameWithOwner": "carbon-language/carbon-lang",
       "url": "https://github.com/carbon-language/carbon-lang",
-      "stargazerCount": 33074,
+      "stargazerCount": 33111,
       "description": "Carbon Language's main repository: documents, design, implementation, and related tools. (NOTE: Carbon Language is experimental; see README)",
       "primaryLanguage": "C++",
       "starredAt": "2022-07-27T00:02:05Z"
@@ -3114,7 +3225,7 @@
     {
       "nameWithOwner": "ziglang/zig",
       "url": "https://github.com/ziglang/zig",
-      "stargazerCount": 40114,
+      "stargazerCount": 40271,
       "description": "General-purpose programming language and toolchain for maintaining robust, optimal, and reusable software.",
       "primaryLanguage": "Zig",
       "starredAt": "2022-07-11T03:33:52Z"
@@ -3122,7 +3233,7 @@
     {
       "nameWithOwner": "oven-sh/bun",
       "url": "https://github.com/oven-sh/bun",
-      "stargazerCount": 79290,
+      "stargazerCount": 79451,
       "description": "Incredibly fast JavaScript runtime, bundler, test runner, and package manager – all in one",
       "primaryLanguage": "Zig",
       "starredAt": "2022-07-11T03:33:24Z"
@@ -3130,7 +3241,7 @@
     {
       "nameWithOwner": "woocommerce/woocommerce-subscriptions-importer-exporter",
       "url": "https://github.com/woocommerce/woocommerce-subscriptions-importer-exporter",
-      "stargazerCount": 158,
+      "stargazerCount": 157,
       "description": "Import your subscribers to WooCommerce from a CSV. Or export your subscription data from WooCommerce to CSV.",
       "primaryLanguage": "PHP",
       "starredAt": "2022-07-01T00:08:19Z"
@@ -3138,7 +3249,7 @@
     {
       "nameWithOwner": "project-chip/connectedhomeip",
       "url": "https://github.com/project-chip/connectedhomeip",
-      "stargazerCount": 8083,
+      "stargazerCount": 8133,
       "description": "Matter (formerly Project CHIP) creates more connections between more objects, simplifying development for manufacturers and increasing compatibility for consumers, guided by the Connectivity Standards Alliance.",
       "primaryLanguage": "C++",
       "starredAt": "2022-06-07T01:39:01Z"
@@ -3154,7 +3265,7 @@
     {
       "nameWithOwner": "woocommerce/wc-smooth-generator",
       "url": "https://github.com/woocommerce/wc-smooth-generator",
-      "stargazerCount": 351,
+      "stargazerCount": 350,
       "description": "Smooth product, customer and order generation for WooCommerce",
       "primaryLanguage": "PHP",
       "starredAt": "2022-05-16T01:16:46Z"
@@ -3186,7 +3297,7 @@
     {
       "nameWithOwner": "jitsi/jitsi-meet",
       "url": "https://github.com/jitsi/jitsi-meet",
-      "stargazerCount": 25980,
+      "stargazerCount": 26125,
       "description": "Jitsi Meet - Secure, Simple and Scalable Video Conferences that you use as a standalone app or embed in your web application.",
       "primaryLanguage": "TypeScript",
       "starredAt": "2022-05-10T01:26:15Z"
@@ -3194,7 +3305,7 @@
     {
       "nameWithOwner": "audacity/audacity",
       "url": "https://github.com/audacity/audacity",
-      "stargazerCount": 13926,
+      "stargazerCount": 13983,
       "description": "Audio Editor                                     ",
       "primaryLanguage": "C++",
       "starredAt": "2022-05-10T01:25:55Z"
@@ -3202,7 +3313,7 @@
     {
       "nameWithOwner": "refined-github/refined-github",
       "url": "https://github.com/refined-github/refined-github",
-      "stargazerCount": 28818,
+      "stargazerCount": 28891,
       "description": ":octocat: Browser extension that simplifies the GitHub interface and adds useful features",
       "primaryLanguage": "TypeScript",
       "starredAt": "2022-05-10T00:43:12Z"
@@ -3218,7 +3329,7 @@
     {
       "nameWithOwner": "woocommerce/woocommerce-blocks",
       "url": "https://github.com/woocommerce/woocommerce-blocks",
-      "stargazerCount": 410,
+      "stargazerCount": 409,
       "description": "(Deprecated) This plugin has been merged into woocommerce/woocommerce",
       "primaryLanguage": "TypeScript",
       "starredAt": "2022-04-26T01:51:32Z"
@@ -3226,7 +3337,7 @@
     {
       "nameWithOwner": "Lumon-Industries/Macrodata-Refinement",
       "url": "https://github.com/Lumon-Industries/Macrodata-Refinement",
-      "stargazerCount": 437,
+      "stargazerCount": 438,
       "description": "Marcrodata Refinement",
       "primaryLanguage": "JavaScript",
       "starredAt": "2022-04-08T00:20:11Z"
@@ -3242,7 +3353,7 @@
     {
       "nameWithOwner": "microsoft/codetour",
       "url": "https://github.com/microsoft/codetour",
-      "stargazerCount": 4455,
+      "stargazerCount": 4456,
       "description": "VS Code extension that allows you to record and play back guided tours of codebases, directly within the editor.",
       "primaryLanguage": "TypeScript",
       "starredAt": "2022-02-25T04:57:05Z"
@@ -3250,7 +3361,7 @@
     {
       "nameWithOwner": "2ndalpha/gasmask",
       "url": "https://github.com/2ndalpha/gasmask",
-      "stargazerCount": 3788,
+      "stargazerCount": 3789,
       "description": "Hosts file manager for OS X",
       "primaryLanguage": "Objective-C",
       "starredAt": "2022-02-23T06:04:53Z"
@@ -3258,7 +3369,7 @@
     {
       "nameWithOwner": "woocommerce/woocommerce-paypal-payments",
       "url": "https://github.com/woocommerce/woocommerce-paypal-payments",
-      "stargazerCount": 70,
+      "stargazerCount": 71,
       "description": "",
       "primaryLanguage": "PHP",
       "starredAt": "2022-02-22T01:48:03Z"
@@ -3274,7 +3385,7 @@
     {
       "nameWithOwner": "slatedocs/slate",
       "url": "https://github.com/slatedocs/slate",
-      "stargazerCount": 36164,
+      "stargazerCount": 36160,
       "description": "Beautiful static documentation for your API",
       "primaryLanguage": "SCSS",
       "starredAt": "2022-02-21T23:59:14Z"
@@ -3314,7 +3425,7 @@
     {
       "nameWithOwner": "gbstack/ffprobe-python",
       "url": "https://github.com/gbstack/ffprobe-python",
-      "stargazerCount": 61,
+      "stargazerCount": 62,
       "description": "A wrapper of ffprobe command to extract metadata from media files.",
       "primaryLanguage": "Python",
       "starredAt": "2022-02-01T06:25:23Z"
@@ -3322,7 +3433,7 @@
     {
       "nameWithOwner": "dwarvesf/blurred",
       "url": "https://github.com/dwarvesf/blurred",
-      "stargazerCount": 982,
+      "stargazerCount": 985,
       "description": "A macOS utility that helps reduce distraction by dimming your inactive noise",
       "primaryLanguage": "Swift",
       "starredAt": "2022-01-25T20:46:10Z"
@@ -3330,7 +3441,7 @@
     {
       "nameWithOwner": "vercel/turborepo",
       "url": "https://github.com/vercel/turborepo",
-      "stargazerCount": 28262,
+      "stargazerCount": 28319,
       "description": "Build system optimized for JavaScript and TypeScript, written in Rust",
       "primaryLanguage": "Rust",
       "starredAt": "2022-01-12T05:17:25Z"
@@ -3338,7 +3449,7 @@
     {
       "nameWithOwner": "andreasbm/web-skills",
       "url": "https://github.com/andreasbm/web-skills",
-      "stargazerCount": 7200,
+      "stargazerCount": 7228,
       "description": "A visual overview of useful skills to learn as a web developer",
       "primaryLanguage": "JavaScript",
       "starredAt": "2022-01-06T05:21:38Z"
@@ -3346,7 +3457,7 @@
     {
       "nameWithOwner": "erikwiffin/0.30000000000000004",
       "url": "https://github.com/erikwiffin/0.30000000000000004",
-      "stargazerCount": 1490,
+      "stargazerCount": 1492,
       "description": "Floating Point Math Examples",
       "primaryLanguage": "CSS",
       "starredAt": "2022-01-05T04:42:21Z"
@@ -3354,7 +3465,7 @@
     {
       "nameWithOwner": "tldraw/tldraw",
       "url": "https://github.com/tldraw/tldraw",
-      "stargazerCount": 40905,
+      "stargazerCount": 41121,
       "description": "very good whiteboard SDK / infinite canvas SDK",
       "primaryLanguage": "TypeScript",
       "starredAt": "2021-12-18T05:14:11Z"
@@ -3378,7 +3489,7 @@
     {
       "nameWithOwner": "CorentinJ/Real-Time-Voice-Cloning",
       "url": "https://github.com/CorentinJ/Real-Time-Voice-Cloning",
-      "stargazerCount": 54746,
+      "stargazerCount": 54790,
       "description": "Clone a voice in 5 seconds to generate arbitrary speech in real-time",
       "primaryLanguage": "Python",
       "starredAt": "2021-12-16T07:28:56Z"
@@ -3386,7 +3497,7 @@
     {
       "nameWithOwner": "YfryTchsGD/Log4jAttackSurface",
       "url": "https://github.com/YfryTchsGD/Log4jAttackSurface",
-      "stargazerCount": 2079,
+      "stargazerCount": 2081,
       "description": "",
       "primaryLanguage": null,
       "starredAt": "2021-12-15T06:07:29Z"
@@ -3394,7 +3505,7 @@
     {
       "nameWithOwner": "CISOfy/lynis",
       "url": "https://github.com/CISOfy/lynis",
-      "stargazerCount": 14432,
+      "stargazerCount": 14471,
       "description": "Lynis - Security auditing tool for Linux, macOS, and UNIX-based systems. Assists with compliance testing (HIPAA/ISO27001/PCI DSS) and system hardening. Agentless, and installation optional.",
       "primaryLanguage": "Shell",
       "starredAt": "2021-12-15T05:47:52Z"
@@ -3402,7 +3513,7 @@
     {
       "nameWithOwner": "ajv-validator/ajv",
       "url": "https://github.com/ajv-validator/ajv",
-      "stargazerCount": 14302,
+      "stargazerCount": 14315,
       "description": "The fastest JSON schema Validator. Supports JSON Schema draft-04/06/07/2019-09/2020-12 and JSON Type Definition (RFC8927)",
       "primaryLanguage": "TypeScript",
       "starredAt": "2021-12-07T07:06:47Z"
@@ -3418,7 +3529,7 @@
     {
       "nameWithOwner": "AppFlowy-IO/AppFlowy",
       "url": "https://github.com/AppFlowy-IO/AppFlowy",
-      "stargazerCount": 64551,
+      "stargazerCount": 64718,
       "description": "Bring projects, wikis, and teams together with AI. AppFlowy is the AI collaborative workspace where you achieve more without losing control of your data. The leading open source Notion alternative.",
       "primaryLanguage": "Dart",
       "starredAt": "2021-12-07T05:30:59Z"
@@ -3426,7 +3537,7 @@
     {
       "nameWithOwner": "samschott/maestral",
       "url": "https://github.com/samschott/maestral",
-      "stargazerCount": 3192,
+      "stargazerCount": 3200,
       "description": "Open-source Dropbox client for macOS and Linux",
       "primaryLanguage": "Python",
       "starredAt": "2021-12-02T06:47:52Z"
@@ -3434,7 +3545,7 @@
     {
       "nameWithOwner": "yangshun/tech-interview-handbook",
       "url": "https://github.com/yangshun/tech-interview-handbook",
-      "stargazerCount": 127929,
+      "stargazerCount": 128253,
       "description": "💯 Curated coding interview preparation materials for busy software engineers",
       "primaryLanguage": "TypeScript",
       "starredAt": "2021-11-24T01:42:08Z"
@@ -3442,7 +3553,7 @@
     {
       "nameWithOwner": "yangshun/front-end-interview-handbook",
       "url": "https://github.com/yangshun/front-end-interview-handbook",
-      "stargazerCount": 43336,
+      "stargazerCount": 43350,
       "description": "🌐 Front End interview preparation materials for busy engineers (updated for 2025)",
       "primaryLanguage": "MDX",
       "starredAt": "2021-11-24T01:04:37Z"
@@ -3450,7 +3561,7 @@
     {
       "nameWithOwner": "remix-run/remix",
       "url": "https://github.com/remix-run/remix",
-      "stargazerCount": 31453,
+      "stargazerCount": 31487,
       "description": "Build Better Websites. Create modern, resilient user experiences with web fundamentals.",
       "primaryLanguage": "TypeScript",
       "starredAt": "2021-11-22T23:29:10Z"
@@ -3458,7 +3569,7 @@
     {
       "nameWithOwner": "cabinjs/cabin",
       "url": "https://github.com/cabinjs/cabin",
-      "stargazerCount": 892,
+      "stargazerCount": 891,
       "description": ":evergreen_tree: Cabin is the best self-hosted JavaScript and Node.js logging service.  Made for @forwardemail.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2021-11-22T04:27:21Z"
@@ -3466,7 +3577,7 @@
     {
       "nameWithOwner": "breejs/bree",
       "url": "https://github.com/breejs/bree",
-      "stargazerCount": 3187,
+      "stargazerCount": 3191,
       "description": "Bree is a Node.js and JavaScript job task scheduler with worker threads, cron, Date, and human syntax. Built for @ladjs, @forwardemail, @spamscanner, @cabinjs.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2021-11-22T04:26:25Z"
@@ -3474,7 +3585,7 @@
     {
       "nameWithOwner": "vaneenige/phenomenon",
       "url": "https://github.com/vaneenige/phenomenon",
-      "stargazerCount": 1817,
+      "stargazerCount": 1818,
       "description": "⚡️ A fast 2kB low-level WebGL API.",
       "primaryLanguage": "TypeScript",
       "starredAt": "2021-11-22T02:40:09Z"
@@ -3482,7 +3593,7 @@
     {
       "nameWithOwner": "shuding/cobe",
       "url": "https://github.com/shuding/cobe",
-      "stargazerCount": 3602,
+      "stargazerCount": 3622,
       "description": "5kB WebGL globe lib.",
       "primaryLanguage": "MDX",
       "starredAt": "2021-11-22T02:39:45Z"
@@ -3498,7 +3609,7 @@
     {
       "nameWithOwner": "rougier/scientific-visualization-book",
       "url": "https://github.com/rougier/scientific-visualization-book",
-      "stargazerCount": 10987,
+      "stargazerCount": 11004,
       "description": "An open access book on scientific visualization using python and matplotlib",
       "primaryLanguage": "Python",
       "starredAt": "2021-11-22T00:22:22Z"
@@ -3522,7 +3633,7 @@
     {
       "nameWithOwner": "hundredrabbits/Orca",
       "url": "https://github.com/hundredrabbits/Orca",
-      "stargazerCount": 4772,
+      "stargazerCount": 4778,
       "description": "Esoteric Programming Language",
       "primaryLanguage": "JavaScript",
       "starredAt": "2021-11-22T00:00:29Z"
@@ -3530,7 +3641,7 @@
     {
       "nameWithOwner": "hapijs/joi",
       "url": "https://github.com/hapijs/joi",
-      "stargazerCount": 21123,
+      "stargazerCount": 21135,
       "description": "The most powerful data validation library for JS",
       "primaryLanguage": "JavaScript",
       "starredAt": "2021-11-18T07:06:13Z"
@@ -3546,7 +3657,7 @@
     {
       "nameWithOwner": "stevegrunwell/asimov",
       "url": "https://github.com/stevegrunwell/asimov",
-      "stargazerCount": 1711,
+      "stargazerCount": 1717,
       "description": "Automatically exclude development dependencies from Apple Time Machine backups",
       "primaryLanguage": "PHP",
       "starredAt": "2021-11-16T23:31:16Z"
@@ -3562,7 +3673,7 @@
     {
       "nameWithOwner": "WordPress/gutenberg",
       "url": "https://github.com/WordPress/gutenberg",
-      "stargazerCount": 11302,
+      "stargazerCount": 11312,
       "description": "The Block Editor project for WordPress and beyond. Plugin is available from the official repository.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2021-11-14T22:54:43Z"
@@ -3570,7 +3681,7 @@
     {
       "nameWithOwner": "Automattic/wp-calypso",
       "url": "https://github.com/Automattic/wp-calypso",
-      "stargazerCount": 12562,
+      "stargazerCount": 12561,
       "description": "The JavaScript and API powered WordPress.com",
       "primaryLanguage": "TypeScript",
       "starredAt": "2021-11-14T22:54:34Z"
@@ -3578,7 +3689,7 @@
     {
       "nameWithOwner": "sparksuite/simple-html-invoice-template",
       "url": "https://github.com/sparksuite/simple-html-invoice-template",
-      "stargazerCount": 1687,
+      "stargazerCount": 1689,
       "description": "A modern, clean, and very simple responsive HTML invoice template",
       "primaryLanguage": "HTML",
       "starredAt": "2021-11-13T02:19:24Z"
@@ -3594,7 +3705,7 @@
     {
       "nameWithOwner": "federicocarboni/setup-ffmpeg",
       "url": "https://github.com/federicocarboni/setup-ffmpeg",
-      "stargazerCount": 127,
+      "stargazerCount": 128,
       "description": "Set up your GitHub Actions workflow with ffmpeg",
       "primaryLanguage": "JavaScript",
       "starredAt": "2021-11-08T03:00:07Z"
@@ -3602,7 +3713,7 @@
     {
       "nameWithOwner": "awalsh128/cache-apt-pkgs-action",
       "url": "https://github.com/awalsh128/cache-apt-pkgs-action",
-      "stargazerCount": 264,
+      "stargazerCount": 269,
       "description": "Cache APT packages in GitHub Actions",
       "primaryLanguage": "Go",
       "starredAt": "2021-11-08T02:49:14Z"
@@ -3610,7 +3721,7 @@
     {
       "nameWithOwner": "Alex0Blackwell/bias-monitor",
       "url": "https://github.com/Alex0Blackwell/bias-monitor",
-      "stargazerCount": 95,
+      "stargazerCount": 96,
       "description": "A Chrome Extension that promotes politically diverse news reading with Artificial Intelligence!",
       "primaryLanguage": "JavaScript",
       "starredAt": "2021-11-07T10:58:52Z"
@@ -3618,7 +3729,7 @@
     {
       "nameWithOwner": "giscus/giscus",
       "url": "https://github.com/giscus/giscus",
-      "stargazerCount": 10159,
+      "stargazerCount": 10222,
       "description": "A commenting system powered by GitHub Discussions. :octocat: :speech_balloon: :gem:",
       "primaryLanguage": "TypeScript",
       "starredAt": "2021-11-02T03:54:15Z"
@@ -3626,7 +3737,7 @@
     {
       "nameWithOwner": "bitwarden/cli",
       "url": "https://github.com/bitwarden/cli",
-      "stargazerCount": 1643,
+      "stargazerCount": 1644,
       "description": "The command line vault (Windows, macOS, & Linux).",
       "primaryLanguage": "TypeScript",
       "starredAt": "2021-11-01T03:37:42Z"
@@ -3642,7 +3753,7 @@
     {
       "nameWithOwner": "catdad/canvas-confetti",
       "url": "https://github.com/catdad/canvas-confetti",
-      "stargazerCount": 11776,
+      "stargazerCount": 11796,
       "description": "🎉 performant confetti animation in the browser",
       "primaryLanguage": "JavaScript",
       "starredAt": "2021-10-26T22:42:24Z"
@@ -3658,7 +3769,7 @@
     {
       "nameWithOwner": "meteorshowers/X-StereoLab",
       "url": "https://github.com/meteorshowers/X-StereoLab",
-      "stargazerCount": 709,
+      "stargazerCount": 711,
       "description": "SOS IROS 2018 GOOGLE; StereoNet ECCV2018 GOOGLE;  ActiveStereoNet ECCV2018 Oral GOOGLE; HITNET CVPR2021 GOOGLE；PLUME Uber ATG",
       "primaryLanguage": "Python",
       "starredAt": "2021-10-26T01:34:17Z"
@@ -3666,7 +3777,7 @@
     {
       "nameWithOwner": "image-size/image-size",
       "url": "https://github.com/image-size/image-size",
-      "stargazerCount": 2139,
+      "stargazerCount": 2142,
       "description": "Node module for detecting image dimensions",
       "primaryLanguage": "TypeScript",
       "starredAt": "2021-10-21T00:42:41Z"
@@ -3674,7 +3785,7 @@
     {
       "nameWithOwner": "raycast/extensions",
       "url": "https://github.com/raycast/extensions",
-      "stargazerCount": 6484,
+      "stargazerCount": 6498,
       "description": "Everything you need to extend Raycast.",
       "primaryLanguage": "TypeScript",
       "starredAt": "2021-10-18T22:14:02Z"
@@ -3682,7 +3793,7 @@
     {
       "nameWithOwner": "Vincit/objection.js",
       "url": "https://github.com/Vincit/objection.js",
-      "stargazerCount": 7337,
+      "stargazerCount": 7338,
       "description": "An SQL-friendly ORM for Node.js",
       "primaryLanguage": "JavaScript",
       "starredAt": "2021-10-18T02:20:51Z"
@@ -3690,7 +3801,7 @@
     {
       "nameWithOwner": "leonardomso/33-js-concepts",
       "url": "https://github.com/leonardomso/33-js-concepts",
-      "stargazerCount": 65361,
+      "stargazerCount": 65448,
       "description": "📜 33 JavaScript concepts every developer should know.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2021-10-18T02:12:04Z"
@@ -3698,7 +3809,7 @@
     {
       "nameWithOwner": "prisma/docs",
       "url": "https://github.com/prisma/docs",
-      "stargazerCount": 1024,
+      "stargazerCount": 1025,
       "description": "📚 Prisma Documentation",
       "primaryLanguage": "MDX",
       "starredAt": "2021-10-08T05:56:54Z"
@@ -3714,7 +3825,7 @@
     {
       "nameWithOwner": "batmany13/about-me",
       "url": "https://github.com/batmany13/about-me",
-      "stargazerCount": 99,
+      "stargazerCount": 100,
       "description": "About my leadership philosophy and a little about me",
       "primaryLanguage": null,
       "starredAt": "2021-09-28T10:16:49Z"
@@ -3746,7 +3857,7 @@
     {
       "nameWithOwner": "adamcooke/staytus",
       "url": "https://github.com/adamcooke/staytus",
-      "stargazerCount": 2179,
+      "stargazerCount": 2178,
       "description": "💡 An open source solution for publishing the status of your services",
       "primaryLanguage": "Ruby",
       "starredAt": "2021-08-31T23:13:19Z"
@@ -3762,7 +3873,7 @@
     {
       "nameWithOwner": "orpatashnik/StyleCLIP",
       "url": "https://github.com/orpatashnik/StyleCLIP",
-      "stargazerCount": 4104,
+      "stargazerCount": 4107,
       "description": "Official Implementation for \"StyleCLIP: Text-Driven Manipulation of StyleGAN Imagery\" (ICCV 2021 Oral)",
       "primaryLanguage": "HTML",
       "starredAt": "2021-08-31T06:30:51Z"
@@ -3810,7 +3921,7 @@
     {
       "nameWithOwner": "GoogleChromeLabs/browser-fs-access",
       "url": "https://github.com/GoogleChromeLabs/browser-fs-access",
-      "stargazerCount": 1498,
+      "stargazerCount": 1501,
       "description": "File System Access API with legacy fallback in the browser",
       "primaryLanguage": "JavaScript",
       "starredAt": "2021-08-03T02:37:29Z"
@@ -3858,7 +3969,7 @@
     {
       "nameWithOwner": "voxel51/fiftyone",
       "url": "https://github.com/voxel51/fiftyone",
-      "stargazerCount": 9732,
+      "stargazerCount": 9760,
       "description": "Refine high-quality datasets and visual AI models",
       "primaryLanguage": "Python",
       "starredAt": "2021-07-20T01:27:22Z"
@@ -3882,7 +3993,7 @@
     {
       "nameWithOwner": "koalaman/shellcheck",
       "url": "https://github.com/koalaman/shellcheck",
-      "stargazerCount": 37772,
+      "stargazerCount": 37845,
       "description": "ShellCheck, a static analysis tool for shell scripts",
       "primaryLanguage": "Haskell",
       "starredAt": "2021-07-16T10:16:46Z"
@@ -3906,7 +4017,7 @@
     {
       "nameWithOwner": "d3/d3-array",
       "url": "https://github.com/d3/d3-array",
-      "stargazerCount": 459,
+      "stargazerCount": 460,
       "description": "Array manipulation, ordering, searching, summarizing, etc.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2021-07-15T02:14:34Z"
@@ -3914,7 +4025,7 @@
     {
       "nameWithOwner": "yairEO/tagify",
       "url": "https://github.com/yairEO/tagify",
-      "stargazerCount": 3789,
+      "stargazerCount": 3795,
       "description": "🔖 lightweight, efficient Tags input component in Vanilla JS / React / Angular / Vue",
       "primaryLanguage": "HTML",
       "starredAt": "2021-07-13T05:06:30Z"
@@ -3938,7 +4049,7 @@
     {
       "nameWithOwner": "lagunacomputer/homebridge-MotionSensor",
       "url": "https://github.com/lagunacomputer/homebridge-MotionSensor",
-      "stargazerCount": 23,
+      "stargazerCount": 24,
       "description": "HomeBridge HomeKit Plugin for arduino based PIR motion sensors",
       "primaryLanguage": "C++",
       "starredAt": "2021-07-11T02:10:53Z"
@@ -3962,7 +4073,7 @@
     {
       "nameWithOwner": "radix-ui/primitives",
       "url": "https://github.com/radix-ui/primitives",
-      "stargazerCount": 17536,
+      "stargazerCount": 17599,
       "description": "Radix Primitives is an open-source UI component library for building high-quality, accessible design systems and web apps. Maintained by @workos.",
       "primaryLanguage": "TypeScript",
       "starredAt": "2021-07-10T09:45:13Z"
@@ -3970,7 +4081,7 @@
     {
       "nameWithOwner": "code-hike/codehike",
       "url": "https://github.com/code-hike/codehike",
-      "stargazerCount": 5176,
+      "stargazerCount": 5194,
       "description": "Build rich content websites with Markdown and React",
       "primaryLanguage": "TypeScript",
       "starredAt": "2021-07-02T23:33:50Z"
@@ -3986,7 +4097,7 @@
     {
       "nameWithOwner": "expressjs/multer",
       "url": "https://github.com/expressjs/multer",
-      "stargazerCount": 11860,
+      "stargazerCount": 11868,
       "description": "Node.js middleware for handling `multipart/form-data`.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2021-06-30T22:28:37Z"
@@ -4002,7 +4113,7 @@
     {
       "nameWithOwner": "shadowwalker/next-pwa",
       "url": "https://github.com/shadowwalker/next-pwa",
-      "stargazerCount": 4025,
+      "stargazerCount": 4026,
       "description": "Zero config PWA plugin for Next.js, with workbox 🧰",
       "primaryLanguage": "JavaScript",
       "starredAt": "2021-06-25T23:20:46Z"
@@ -4010,7 +4121,7 @@
     {
       "nameWithOwner": "charmbracelet/lipgloss",
       "url": "https://github.com/charmbracelet/lipgloss",
-      "stargazerCount": 9298,
+      "stargazerCount": 9367,
       "description": "Style definitions for nice terminal layouts 👄",
       "primaryLanguage": "Go",
       "starredAt": "2021-06-18T11:22:56Z"
@@ -4018,7 +4129,7 @@
     {
       "nameWithOwner": "timolins/react-hot-toast",
       "url": "https://github.com/timolins/react-hot-toast",
-      "stargazerCount": 10538,
+      "stargazerCount": 10571,
       "description": "Smoking Hot React Notifications 🔥 ",
       "primaryLanguage": "TypeScript",
       "starredAt": "2021-06-18T10:58:35Z"
@@ -4050,7 +4161,7 @@
     {
       "nameWithOwner": "pytorch/vision",
       "url": "https://github.com/pytorch/vision",
-      "stargazerCount": 17020,
+      "stargazerCount": 17046,
       "description": "Datasets, Transforms and Models specific to Computer Vision",
       "primaryLanguage": "Python",
       "starredAt": "2021-06-13T23:12:37Z"
@@ -4058,7 +4169,7 @@
     {
       "nameWithOwner": "dapi-labs/react-nice-avatar",
       "url": "https://github.com/dapi-labs/react-nice-avatar",
-      "stargazerCount": 1146,
+      "stargazerCount": 1148,
       "description": "react library for generating avatar",
       "primaryLanguage": "TypeScript",
       "starredAt": "2021-06-09T23:26:53Z"
@@ -4066,7 +4177,7 @@
     {
       "nameWithOwner": "reactjs/react-tabs",
       "url": "https://github.com/reactjs/react-tabs",
-      "stargazerCount": 3136,
+      "stargazerCount": 3139,
       "description": "An accessible and easy tab component for ReactJS.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2021-06-09T23:26:12Z"
@@ -4074,7 +4185,7 @@
     {
       "nameWithOwner": "boringdesigners/boring-avatars",
       "url": "https://github.com/boringdesigners/boring-avatars",
-      "stargazerCount": 5929,
+      "stargazerCount": 5938,
       "description": "Boring avatars is an open source React library that generates custom, SVG-based avatars from any username and color palette.",
       "primaryLanguage": "TypeScript",
       "starredAt": "2021-06-09T23:24:04Z"
@@ -4082,7 +4193,7 @@
     {
       "nameWithOwner": "withastro/astro",
       "url": "https://github.com/withastro/astro",
-      "stargazerCount": 52453,
+      "stargazerCount": 52629,
       "description": "The web framework for content-driven websites. ⭐️ Star to support our work!",
       "primaryLanguage": "TypeScript",
       "starredAt": "2021-06-08T22:07:46Z"
@@ -4114,7 +4225,7 @@
     {
       "nameWithOwner": "json5/json5",
       "url": "https://github.com/json5/json5",
-      "stargazerCount": 6914,
+      "stargazerCount": 6921,
       "description": "JSON5 — JSON for Humans",
       "primaryLanguage": "JavaScript",
       "starredAt": "2021-06-02T23:01:45Z"
@@ -4122,7 +4233,7 @@
     {
       "nameWithOwner": "homebridge/homebridge",
       "url": "https://github.com/homebridge/homebridge",
-      "stargazerCount": 24854,
+      "stargazerCount": 24865,
       "description": "HomeKit support for the impatient.",
       "primaryLanguage": "TypeScript",
       "starredAt": "2021-06-01T07:56:43Z"
@@ -4130,7 +4241,7 @@
     {
       "nameWithOwner": "plasticrake/homebridge-tplink-smarthome",
       "url": "https://github.com/plasticrake/homebridge-tplink-smarthome",
-      "stargazerCount": 505,
+      "stargazerCount": 504,
       "description": "TP-Link Smarthome Plugin for Homebridge",
       "primaryLanguage": "TypeScript",
       "starredAt": "2021-06-01T07:56:38Z"
@@ -4146,7 +4257,7 @@
     {
       "nameWithOwner": "argoproj/argo-workflows",
       "url": "https://github.com/argoproj/argo-workflows",
-      "stargazerCount": 15859,
+      "stargazerCount": 15879,
       "description": "Workflow Engine for Kubernetes",
       "primaryLanguage": "Go",
       "starredAt": "2021-06-01T05:38:42Z"
@@ -4154,7 +4265,7 @@
     {
       "nameWithOwner": "airctic/icevision",
       "url": "https://github.com/airctic/icevision",
-      "stargazerCount": 860,
+      "stargazerCount": 861,
       "description": "An Agnostic Computer Vision Framework - Pluggable to any Training Library: Fastai, Pytorch-Lightning with more to come",
       "primaryLanguage": "Python",
       "starredAt": "2021-06-01T00:21:36Z"
@@ -4162,7 +4273,7 @@
     {
       "nameWithOwner": "vanilla-extract-css/vanilla-extract",
       "url": "https://github.com/vanilla-extract-css/vanilla-extract",
-      "stargazerCount": 10007,
+      "stargazerCount": 10031,
       "description": "Zero-runtime Stylesheets-in-TypeScript",
       "primaryLanguage": "TypeScript",
       "starredAt": "2021-05-27T05:48:12Z"
@@ -4178,7 +4289,7 @@
     {
       "nameWithOwner": "prometheus/prometheus",
       "url": "https://github.com/prometheus/prometheus",
-      "stargazerCount": 59615,
+      "stargazerCount": 59748,
       "description": "The Prometheus monitoring system and time series database.",
       "primaryLanguage": "Go",
       "starredAt": "2021-05-26T10:59:53Z"
@@ -4186,7 +4297,7 @@
     {
       "nameWithOwner": "facebookexperimental/Recoil",
       "url": "https://github.com/facebookexperimental/Recoil",
-      "stargazerCount": 19603,
+      "stargazerCount": 19600,
       "description": "Recoil is an experimental state management library for React apps. It provides several capabilities that are difficult to achieve with React alone, while being compatible with the newest features of React.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2021-05-20T02:39:32Z"
@@ -4194,7 +4305,7 @@
     {
       "nameWithOwner": "mdn/content",
       "url": "https://github.com/mdn/content",
-      "stargazerCount": 9655,
+      "stargazerCount": 9666,
       "description": "The content behind MDN Web Docs",
       "primaryLanguage": "Markdown",
       "starredAt": "2021-05-18T05:19:34Z"
@@ -4202,7 +4313,7 @@
     {
       "nameWithOwner": "sylabs/singularity",
       "url": "https://github.com/sylabs/singularity",
-      "stargazerCount": 866,
+      "stargazerCount": 871,
       "description": "SingularityCE is the Community Edition of Singularity, an open source container platform designed to be simple, fast, and secure.",
       "primaryLanguage": "Go",
       "starredAt": "2021-05-18T03:51:15Z"
@@ -4210,7 +4321,7 @@
     {
       "nameWithOwner": "prisma/studio",
       "url": "https://github.com/prisma/studio",
-      "stargazerCount": 2010,
+      "stargazerCount": 2013,
       "description": "🎙️ The easiest way to explore and manipulate your data in all of your Prisma projects.",
       "primaryLanguage": null,
       "starredAt": "2021-05-18T00:59:20Z"
@@ -4218,7 +4329,7 @@
     {
       "nameWithOwner": "paralleldrive/cuid",
       "url": "https://github.com/paralleldrive/cuid",
-      "stargazerCount": 3498,
+      "stargazerCount": 3497,
       "description": "Collision-resistant ids optimized for horizontal scaling and performance.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2021-05-18T00:05:31Z"
@@ -4242,7 +4353,7 @@
     {
       "nameWithOwner": "Lightning-Universe/lightning-bolts",
       "url": "https://github.com/Lightning-Universe/lightning-bolts",
-      "stargazerCount": 1733,
+      "stargazerCount": 1734,
       "description": "Toolbox of models, callbacks, and datasets for AI/ML researchers.",
       "primaryLanguage": "Python",
       "starredAt": "2021-05-13T05:00:56Z"
@@ -4250,7 +4361,7 @@
     {
       "nameWithOwner": "keycloak/keycloak",
       "url": "https://github.com/keycloak/keycloak",
-      "stargazerCount": 28417,
+      "stargazerCount": 28793,
       "description": "Open Source Identity and Access Management For Modern Applications and Services",
       "primaryLanguage": "Java",
       "starredAt": "2021-05-13T02:29:51Z"
@@ -4258,7 +4369,7 @@
     {
       "nameWithOwner": "nextflow-io/nextflow",
       "url": "https://github.com/nextflow-io/nextflow",
-      "stargazerCount": 3075,
+      "stargazerCount": 3091,
       "description": "A DSL for data-driven computational pipelines",
       "primaryLanguage": "Groovy",
       "starredAt": "2021-05-13T02:17:26Z"
@@ -4274,7 +4385,7 @@
     {
       "nameWithOwner": "chintan9/plyr-react",
       "url": "https://github.com/chintan9/plyr-react",
-      "stargazerCount": 500,
+      "stargazerCount": 502,
       "description": "A simple, accessible and customisable react media player for Video, Audio, YouTube and Vimeo",
       "primaryLanguage": "TypeScript",
       "starredAt": "2021-05-11T02:25:03Z"
@@ -4282,7 +4393,7 @@
     {
       "nameWithOwner": "google/zx",
       "url": "https://github.com/google/zx",
-      "stargazerCount": 44382,
+      "stargazerCount": 44411,
       "description": "A tool for writing better scripts",
       "primaryLanguage": "JavaScript",
       "starredAt": "2021-05-11T00:49:26Z"
@@ -4290,7 +4401,7 @@
     {
       "nameWithOwner": "flightcontrolhq/superjson",
       "url": "https://github.com/flightcontrolhq/superjson",
-      "stargazerCount": 4948,
+      "stargazerCount": 4969,
       "description": "Safely serialize JavaScript expressions to a superset of JSON, which includes Dates, BigInts, and more.",
       "primaryLanguage": "TypeScript",
       "starredAt": "2021-05-10T06:34:17Z"
@@ -4298,7 +4409,7 @@
     {
       "nameWithOwner": "minio/minio-js",
       "url": "https://github.com/minio/minio-js",
-      "stargazerCount": 1056,
+      "stargazerCount": 1063,
       "description": "MinIO Client SDK for Javascript",
       "primaryLanguage": "JavaScript",
       "starredAt": "2021-05-10T03:34:48Z"
@@ -4314,7 +4425,7 @@
     {
       "nameWithOwner": "abhisheknaiidu/awesome-github-profile-readme",
       "url": "https://github.com/abhisheknaiidu/awesome-github-profile-readme",
-      "stargazerCount": 27196,
+      "stargazerCount": 27292,
       "description": "😎 A curated list of awesome GitHub Profile which updates in real time ",
       "primaryLanguage": null,
       "starredAt": "2021-05-10T00:13:28Z"
@@ -4330,7 +4441,7 @@
     {
       "nameWithOwner": "Lightning-Universe/lightning-flash",
       "url": "https://github.com/Lightning-Universe/lightning-flash",
-      "stargazerCount": 1740,
+      "stargazerCount": 1741,
       "description": "Your PyTorch AI Factory - Flash enables you to easily configure and run complex AI recipes for over 15 tasks across 7 data domains",
       "primaryLanguage": "Python",
       "starredAt": "2021-05-09T08:40:47Z"
@@ -4338,7 +4449,7 @@
     {
       "nameWithOwner": "cerebroapp/cerebro",
       "url": "https://github.com/cerebroapp/cerebro",
-      "stargazerCount": 8474,
+      "stargazerCount": 8476,
       "description": "🔵 Cerebro is an open-source launcher to improve your productivity and efficiency",
       "primaryLanguage": "JavaScript",
       "starredAt": "2021-05-08T05:23:22Z"
@@ -4346,7 +4457,7 @@
     {
       "nameWithOwner": "trekhleb/js-image-carver",
       "url": "https://github.com/trekhleb/js-image-carver",
-      "stargazerCount": 1583,
+      "stargazerCount": 1584,
       "description": "🌅 Content-aware image resizer and object remover based on Seam Carving algorithm",
       "primaryLanguage": "TypeScript",
       "starredAt": "2021-04-27T05:15:05Z"
@@ -4354,7 +4465,7 @@
     {
       "nameWithOwner": "dustinkirkland/python-petname",
       "url": "https://github.com/dustinkirkland/python-petname",
-      "stargazerCount": 46,
+      "stargazerCount": 47,
       "description": "",
       "primaryLanguage": "Python",
       "starredAt": "2021-04-27T04:47:10Z"
@@ -4362,7 +4473,7 @@
     {
       "nameWithOwner": "gzuidhof/starboard-notebook",
       "url": "https://github.com/gzuidhof/starboard-notebook",
-      "stargazerCount": 1311,
+      "stargazerCount": 1315,
       "description": "In-browser literate notebooks",
       "primaryLanguage": "TypeScript",
       "starredAt": "2021-04-27T04:05:49Z"
@@ -4370,7 +4481,7 @@
     {
       "nameWithOwner": "rh12503/triangula",
       "url": "https://github.com/rh12503/triangula",
-      "stargazerCount": 3867,
+      "stargazerCount": 3868,
       "description": "Generate high-quality triangulated and polygonal art from images.",
       "primaryLanguage": "Go",
       "starredAt": "2021-04-27T03:55:39Z"
@@ -4378,7 +4489,7 @@
     {
       "nameWithOwner": "djyde/cusdis",
       "url": "https://github.com/djyde/cusdis",
-      "stargazerCount": 2715,
+      "stargazerCount": 2716,
       "description": "lightweight, privacy-friendly alternative to Disqus.",
       "primaryLanguage": "TypeScript",
       "starredAt": "2021-04-21T01:30:43Z"
@@ -4394,7 +4505,7 @@
     {
       "nameWithOwner": "ethz-asl/kalibr",
       "url": "https://github.com/ethz-asl/kalibr",
-      "stargazerCount": 4852,
+      "stargazerCount": 4867,
       "description": "The Kalibr visual-inertial calibration toolbox",
       "primaryLanguage": "C++",
       "starredAt": "2021-04-15T06:39:39Z"
@@ -4434,7 +4545,7 @@
     {
       "nameWithOwner": "microsoft/Swin-Transformer",
       "url": "https://github.com/microsoft/Swin-Transformer",
-      "stargazerCount": 15043,
+      "stargazerCount": 15064,
       "description": "This is an official implementation for \"Swin Transformer: Hierarchical Vision Transformer using Shifted Windows\".",
       "primaryLanguage": "Python",
       "starredAt": "2021-04-07T04:29:16Z"
@@ -4450,7 +4561,7 @@
     {
       "nameWithOwner": "anuraghazra/github-readme-stats",
       "url": "https://github.com/anuraghazra/github-readme-stats",
-      "stargazerCount": 74569,
+      "stargazerCount": 74748,
       "description": ":zap: Dynamically generated stats for your github readmes",
       "primaryLanguage": "JavaScript",
       "starredAt": "2021-03-29T22:44:35Z"
@@ -4466,7 +4577,7 @@
     {
       "nameWithOwner": "woltapp/blurhash",
       "url": "https://github.com/woltapp/blurhash",
-      "stargazerCount": 16543,
+      "stargazerCount": 16561,
       "description": "A very compact representation of a placeholder for an image.",
       "primaryLanguage": "C",
       "starredAt": "2021-03-29T04:43:37Z"
@@ -4498,7 +4609,7 @@
     {
       "nameWithOwner": "pmndrs/zustand",
       "url": "https://github.com/pmndrs/zustand",
-      "stargazerCount": 53709,
+      "stargazerCount": 53926,
       "description": "🐻 Bear necessities for state management in React",
       "primaryLanguage": "TypeScript",
       "starredAt": "2021-03-06T10:27:39Z"
@@ -4506,7 +4617,7 @@
     {
       "nameWithOwner": "pmndrs/jotai",
       "url": "https://github.com/pmndrs/jotai",
-      "stargazerCount": 20248,
+      "stargazerCount": 20297,
       "description": "👻 Primitive and flexible state management for React",
       "primaryLanguage": "TypeScript",
       "starredAt": "2021-03-06T09:27:09Z"
@@ -4514,7 +4625,7 @@
     {
       "nameWithOwner": "rehooks/awesome-react-hooks",
       "url": "https://github.com/rehooks/awesome-react-hooks",
-      "stargazerCount": 10076,
+      "stargazerCount": 10088,
       "description": "Awesome React Hooks",
       "primaryLanguage": null,
       "starredAt": "2021-03-06T09:12:47Z"
@@ -4522,7 +4633,7 @@
     {
       "nameWithOwner": "orbit-love/orbit-model",
       "url": "https://github.com/orbit-love/orbit-model",
-      "stargazerCount": 997,
+      "stargazerCount": 999,
       "description": "A framework for building high gravity communities 🪐",
       "primaryLanguage": "CSS",
       "starredAt": "2021-03-04T20:08:34Z"
@@ -4530,7 +4641,7 @@
     {
       "nameWithOwner": "caddyserver/caddy",
       "url": "https://github.com/caddyserver/caddy",
-      "stargazerCount": 65742,
+      "stargazerCount": 65919,
       "description": "Fast and extensible multi-platform HTTP/1-2-3 web server with automatic HTTPS",
       "primaryLanguage": "Go",
       "starredAt": "2021-03-03T10:20:45Z"
@@ -4538,7 +4649,7 @@
     {
       "nameWithOwner": "raycast/script-commands",
       "url": "https://github.com/raycast/script-commands",
-      "stargazerCount": 6391,
+      "stargazerCount": 6407,
       "description": "Script Commands let you tailor Raycast to your needs. Think of them as little productivity boosts throughout your day.",
       "primaryLanguage": "Shell",
       "starredAt": "2021-03-01T21:41:27Z"
@@ -4554,7 +4665,7 @@
     {
       "nameWithOwner": "dbohdan/classless-css",
       "url": "https://github.com/dbohdan/classless-css",
-      "stargazerCount": 2127,
+      "stargazerCount": 2133,
       "description": "A list of classless CSS themes/frameworks with screenshots",
       "primaryLanguage": "HTML",
       "starredAt": "2021-03-01T09:47:00Z"
@@ -4562,7 +4673,7 @@
     {
       "nameWithOwner": "syntaxfm/website",
       "url": "https://github.com/syntaxfm/website",
-      "stargazerCount": 1130,
+      "stargazerCount": 1135,
       "description": "Syntax Podcast Website",
       "primaryLanguage": "Svelte",
       "starredAt": "2021-03-01T01:10:32Z"
@@ -4570,7 +4681,7 @@
     {
       "nameWithOwner": "TypeStrong/ts-node",
       "url": "https://github.com/TypeStrong/ts-node",
-      "stargazerCount": 13085,
+      "stargazerCount": 13087,
       "description": "TypeScript execution and REPL for node.js",
       "primaryLanguage": "TypeScript",
       "starredAt": "2021-03-01T01:02:05Z"
@@ -4586,7 +4697,7 @@
     {
       "nameWithOwner": "get-alex/alex",
       "url": "https://github.com/get-alex/alex",
-      "stargazerCount": 5026,
+      "stargazerCount": 5035,
       "description": "Catch insensitive, inconsiderate writing",
       "primaryLanguage": "JavaScript",
       "starredAt": "2021-02-28T22:25:27Z"
@@ -4602,7 +4713,7 @@
     {
       "nameWithOwner": "microsoft/monaco-editor",
       "url": "https://github.com/microsoft/monaco-editor",
-      "stargazerCount": 43337,
+      "stargazerCount": 43448,
       "description": "A browser based code editor",
       "primaryLanguage": "JavaScript",
       "starredAt": "2021-02-28T10:23:38Z"
@@ -4610,7 +4721,7 @@
     {
       "nameWithOwner": "airbnb/visx",
       "url": "https://github.com/airbnb/visx",
-      "stargazerCount": 20160,
+      "stargazerCount": 20182,
       "description": "🐯 visx | visualization components",
       "primaryLanguage": "TypeScript",
       "starredAt": "2021-02-25T11:02:26Z"
@@ -4618,7 +4729,7 @@
     {
       "nameWithOwner": "ben-rogerson/twin.macro",
       "url": "https://github.com/ben-rogerson/twin.macro",
-      "stargazerCount": 8024,
+      "stargazerCount": 8025,
       "description": "🦹‍♂️ Twin blends the magic of Tailwind with the flexibility of css-in-js (emotion, styled-components, solid-styled-components, stitches and goober) at build time.",
       "primaryLanguage": "TypeScript",
       "starredAt": "2021-02-25T11:01:34Z"
@@ -4626,7 +4737,7 @@
     {
       "nameWithOwner": "ionic-team/capacitor",
       "url": "https://github.com/ionic-team/capacitor",
-      "stargazerCount": 13643,
+      "stargazerCount": 13701,
       "description": "Build cross-platform Native Progressive Web Apps for iOS, Android, and the Web ⚡️",
       "primaryLanguage": "TypeScript",
       "starredAt": "2021-02-24T20:04:23Z"
@@ -4634,7 +4745,7 @@
     {
       "nameWithOwner": "stenciljs/core",
       "url": "https://github.com/stenciljs/core",
-      "stargazerCount": 12841,
+      "stargazerCount": 12846,
       "description": "A toolchain for building scalable, enterprise-ready component systems on top of TypeScript and Web Component standards. Stencil components can be distributed natively to React, Angular, Vue, and traditional web developers from a single, framework-agnostic codebase.",
       "primaryLanguage": "TypeScript",
       "starredAt": "2021-02-24T19:52:21Z"
@@ -4698,7 +4809,7 @@
     {
       "nameWithOwner": "devicons/devicon",
       "url": "https://github.com/devicons/devicon",
-      "stargazerCount": 10843,
+      "stargazerCount": 10888,
       "description": "Set of icons representing programming languages, designing & development tools",
       "primaryLanguage": "CSS",
       "starredAt": "2021-02-20T12:26:58Z"
@@ -4706,7 +4817,7 @@
     {
       "nameWithOwner": "b-fuze/deno-dom",
       "url": "https://github.com/b-fuze/deno-dom",
-      "stargazerCount": 458,
+      "stargazerCount": 461,
       "description": "Browser DOM & HTML parser in Deno",
       "primaryLanguage": "HTML",
       "starredAt": "2021-02-20T05:58:02Z"
@@ -4714,7 +4825,7 @@
     {
       "nameWithOwner": "opennextjs/opennextjs-netlify",
       "url": "https://github.com/opennextjs/opennextjs-netlify",
-      "stargazerCount": 750,
+      "stargazerCount": 753,
       "description": "Open Next.js adapter for Netlify",
       "primaryLanguage": "TypeScript",
       "starredAt": "2021-02-19T00:32:42Z"
@@ -4738,7 +4849,7 @@
     {
       "nameWithOwner": "typescript-cheatsheets/react",
       "url": "https://github.com/typescript-cheatsheets/react",
-      "stargazerCount": 46484,
+      "stargazerCount": 46506,
       "description": "Cheatsheets for experienced React developers getting started with TypeScript",
       "primaryLanguage": "JavaScript",
       "starredAt": "2021-02-16T03:27:27Z"
@@ -4754,7 +4865,7 @@
     {
       "nameWithOwner": "fontsource/fontsource",
       "url": "https://github.com/fontsource/fontsource",
-      "stargazerCount": 5429,
+      "stargazerCount": 5450,
       "description": "Self-host Open Source fonts in neatly bundled NPM packages.",
       "primaryLanguage": "TypeScript",
       "starredAt": "2021-02-15T22:13:39Z"
@@ -4762,7 +4873,7 @@
     {
       "nameWithOwner": "prisma/prisma",
       "url": "https://github.com/prisma/prisma",
-      "stargazerCount": 42941,
+      "stargazerCount": 42999,
       "description": "Next-generation ORM for Node.js & TypeScript | PostgreSQL, MySQL, MariaDB, SQL Server, SQLite, MongoDB and CockroachDB",
       "primaryLanguage": "TypeScript",
       "starredAt": "2021-02-15T11:47:48Z"
@@ -4770,7 +4881,7 @@
     {
       "nameWithOwner": "kentcdodds/mdx-bundler",
       "url": "https://github.com/kentcdodds/mdx-bundler",
-      "stargazerCount": 1871,
+      "stargazerCount": 1876,
       "description": "🦤 Give me MDX/TSX strings and I'll give you back a component you can render. Supports imports!",
       "primaryLanguage": "JavaScript",
       "starredAt": "2021-02-15T01:58:27Z"
@@ -4778,7 +4889,7 @@
     {
       "nameWithOwner": "nandorojo/swr-firestore",
       "url": "https://github.com/nandorojo/swr-firestore",
-      "stargazerCount": 779,
+      "stargazerCount": 780,
       "description": "Implement Vercel's useSWR for querying Firestore in React/React Native/Expo apps. 👩‍🚒🔥",
       "primaryLanguage": "TypeScript",
       "starredAt": "2021-02-14T21:46:41Z"
@@ -4802,7 +4913,7 @@
     {
       "nameWithOwner": "blitz-js/blitz",
       "url": "https://github.com/blitz-js/blitz",
-      "stargazerCount": 13950,
+      "stargazerCount": 13981,
       "description": "⚡️ The Missing Fullstack Toolkit for Next.js",
       "primaryLanguage": "TypeScript",
       "starredAt": "2021-02-12T22:47:28Z"
@@ -4810,7 +4921,7 @@
     {
       "nameWithOwner": "iam-abbas/Reddit-Stock-Trends",
       "url": "https://github.com/iam-abbas/Reddit-Stock-Trends",
-      "stargazerCount": 1552,
+      "stargazerCount": 1554,
       "description": "Fetch currently trending stocks on Reddit",
       "primaryLanguage": "Python",
       "starredAt": "2021-02-12T10:01:33Z"
@@ -4818,7 +4929,7 @@
     {
       "nameWithOwner": "excalidraw/excalidraw",
       "url": "https://github.com/excalidraw/excalidraw",
-      "stargazerCount": 104150,
+      "stargazerCount": 104753,
       "description": "Virtual whiteboard for sketching hand-drawn like diagrams",
       "primaryLanguage": "TypeScript",
       "starredAt": "2021-02-12T09:45:54Z"
@@ -4834,7 +4945,7 @@
     {
       "nameWithOwner": "hashicorp/vault",
       "url": "https://github.com/hashicorp/vault",
-      "stargazerCount": 32804,
+      "stargazerCount": 32853,
       "description": "A tool for secrets management, encryption as a service, and privileged access management",
       "primaryLanguage": "Go",
       "starredAt": "2021-02-12T09:44:36Z"
@@ -4842,7 +4953,7 @@
     {
       "nameWithOwner": "bahmutov/start-server-and-test",
       "url": "https://github.com/bahmutov/start-server-and-test",
-      "stargazerCount": 1561,
+      "stargazerCount": 1562,
       "description": "Starts server, waits for URL, then runs test command; when the tests end, shuts down server",
       "primaryLanguage": "JavaScript",
       "starredAt": "2021-02-11T23:30:15Z"
@@ -4850,7 +4961,7 @@
     {
       "nameWithOwner": "authlib/authlib",
       "url": "https://github.com/authlib/authlib",
-      "stargazerCount": 4907,
+      "stargazerCount": 4923,
       "description": "The ultimate Python library in building OAuth, OpenID Connect clients and servers. JWS,JWE,JWK,JWA,JWT included.",
       "primaryLanguage": "Python",
       "starredAt": "2021-02-11T22:22:13Z"
@@ -4866,7 +4977,7 @@
     {
       "nameWithOwner": "muxinc/upchunk",
       "url": "https://github.com/muxinc/upchunk",
-      "stargazerCount": 390,
+      "stargazerCount": 393,
       "description": "Uploads Chunks! Takes big files, splits them up, then uploads each one with care (and PUT requests).",
       "primaryLanguage": "TypeScript",
       "starredAt": "2021-02-11T10:53:43Z"
@@ -4890,7 +5001,7 @@
     {
       "nameWithOwner": "jxnblk/mdx-deck",
       "url": "https://github.com/jxnblk/mdx-deck",
-      "stargazerCount": 11452,
+      "stargazerCount": 11458,
       "description": "♠️ React MDX-based presentation decks",
       "primaryLanguage": "JavaScript",
       "starredAt": "2021-02-10T21:08:12Z"
@@ -4922,7 +5033,7 @@
     {
       "nameWithOwner": "greird/chordictionaryjs",
       "url": "https://github.com/greird/chordictionaryjs",
-      "stargazerCount": 126,
+      "stargazerCount": 127,
       "description": ":guitar: A Javascript library for dynamic chord recognition, generation and graphic representation for any fretted instrument.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2021-02-10T02:29:41Z"
@@ -4930,7 +5041,7 @@
     {
       "nameWithOwner": "cypress-io/cypress",
       "url": "https://github.com/cypress-io/cypress",
-      "stargazerCount": 48784,
+      "stargazerCount": 48794,
       "description": "Fast, easy and reliable testing for anything that runs in a browser.",
       "primaryLanguage": "TypeScript",
       "starredAt": "2021-02-09T10:33:33Z"
@@ -4938,7 +5049,7 @@
     {
       "nameWithOwner": "creativetimofficial/david-ai",
       "url": "https://github.com/creativetimofficial/david-ai",
-      "stargazerCount": 5914,
+      "stargazerCount": 5926,
       "description": "David AI is a free and open-source collection of customizable, production-ready UI components built with Tailwind CSS.",
       "primaryLanguage": "HTML",
       "starredAt": "2021-02-09T04:40:39Z"
@@ -4954,7 +5065,7 @@
     {
       "nameWithOwner": "developit/redaxios",
       "url": "https://github.com/developit/redaxios",
-      "stargazerCount": 4832,
+      "stargazerCount": 4835,
       "description": "The Axios API, as an 800 byte Fetch wrapper.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2021-02-08T21:35:38Z"
@@ -4970,7 +5081,7 @@
     {
       "nameWithOwner": "pyodide/pyodide",
       "url": "https://github.com/pyodide/pyodide",
-      "stargazerCount": 13487,
+      "stargazerCount": 13512,
       "description": "Pyodide is a Python distribution for the browser and Node.js based on WebAssembly",
       "primaryLanguage": "Python",
       "starredAt": "2021-02-08T21:01:29Z"
@@ -4978,7 +5089,7 @@
     {
       "nameWithOwner": "remotion-dev/remotion",
       "url": "https://github.com/remotion-dev/remotion",
-      "stargazerCount": 23061,
+      "stargazerCount": 23384,
       "description": "🎥      Make videos programmatically with React",
       "primaryLanguage": "TypeScript",
       "starredAt": "2021-02-08T20:40:52Z"
@@ -4986,7 +5097,7 @@
     {
       "nameWithOwner": "ffmpegwasm/ffmpeg.wasm",
       "url": "https://github.com/ffmpegwasm/ffmpeg.wasm",
-      "stargazerCount": 16138,
+      "stargazerCount": 16191,
       "description": "FFmpeg for browser, powered by WebAssembly",
       "primaryLanguage": "C",
       "starredAt": "2021-02-08T11:37:10Z"
@@ -4994,7 +5105,7 @@
     {
       "nameWithOwner": "nextauthjs/next-auth",
       "url": "https://github.com/nextauthjs/next-auth",
-      "stargazerCount": 27185,
+      "stargazerCount": 27241,
       "description": "Authentication for the Web.",
       "primaryLanguage": "TypeScript",
       "starredAt": "2021-02-08T05:35:35Z"
@@ -5010,7 +5121,7 @@
     {
       "nameWithOwner": "imagemin/imagemin-cli",
       "url": "https://github.com/imagemin/imagemin-cli",
-      "stargazerCount": 942,
+      "stargazerCount": 943,
       "description": "Minify images seamlessly",
       "primaryLanguage": "JavaScript",
       "starredAt": "2021-02-07T20:12:06Z"
@@ -5042,7 +5153,7 @@
     {
       "nameWithOwner": "penpot/penpot",
       "url": "https://github.com/penpot/penpot",
-      "stargazerCount": 39248,
+      "stargazerCount": 39412,
       "description": "Penpot: The open-source design tool for design and code collaboration",
       "primaryLanguage": "Clojure",
       "starredAt": "2021-02-06T23:55:42Z"
@@ -5050,7 +5161,7 @@
     {
       "nameWithOwner": "archivy/archivy",
       "url": "https://github.com/archivy/archivy",
-      "stargazerCount": 3238,
+      "stargazerCount": 3239,
       "description": "Archivy is a self-hostable knowledge repository that allows you to learn and retain information in your own personal and extensible wiki.",
       "primaryLanguage": "Python",
       "starredAt": "2021-02-06T23:52:37Z"
@@ -5058,7 +5169,7 @@
     {
       "nameWithOwner": "tauri-apps/tauri",
       "url": "https://github.com/tauri-apps/tauri",
-      "stargazerCount": 94844,
+      "stargazerCount": 95172,
       "description": "Build smaller, faster, and more secure desktop and mobile applications with a web frontend.",
       "primaryLanguage": "Rust",
       "starredAt": "2021-02-06T23:47:26Z"
@@ -5066,7 +5177,7 @@
     {
       "nameWithOwner": "supabase/postgres",
       "url": "https://github.com/supabase/postgres",
-      "stargazerCount": 1576,
+      "stargazerCount": 1581,
       "description": "Unmodified Postgres with some useful plugins",
       "primaryLanguage": "PLpgSQL",
       "starredAt": "2021-02-05T20:56:14Z"
@@ -5074,7 +5185,7 @@
     {
       "nameWithOwner": "DefinitelyTyped/DefinitelyTyped",
       "url": "https://github.com/DefinitelyTyped/DefinitelyTyped",
-      "stargazerCount": 50087,
+      "stargazerCount": 50133,
       "description": "The repository for high quality TypeScript type definitions.",
       "primaryLanguage": "TypeScript",
       "starredAt": "2021-02-05T10:58:02Z"
@@ -5082,7 +5193,7 @@
     {
       "nameWithOwner": "fastify/fastify-sensible",
       "url": "https://github.com/fastify/fastify-sensible",
-      "stargazerCount": 508,
+      "stargazerCount": 511,
       "description": "Defaults for Fastify that everyone can agree on",
       "primaryLanguage": "JavaScript",
       "starredAt": "2021-02-04T23:00:29Z"
@@ -5090,7 +5201,7 @@
     {
       "nameWithOwner": "PostgREST/postgrest",
       "url": "https://github.com/PostgREST/postgrest",
-      "stargazerCount": 25542,
+      "stargazerCount": 25559,
       "description": "REST API for any Postgres database",
       "primaryLanguage": "Haskell",
       "starredAt": "2021-02-04T01:39:20Z"
@@ -5106,7 +5217,7 @@
     {
       "nameWithOwner": "vitejs/vite",
       "url": "https://github.com/vitejs/vite",
-      "stargazerCount": 74317,
+      "stargazerCount": 74512,
       "description": "Next generation frontend tooling. It's fast!",
       "primaryLanguage": "TypeScript",
       "starredAt": "2021-02-02T00:50:15Z"
@@ -5114,7 +5225,7 @@
     {
       "nameWithOwner": "mit-han-lab/data-efficient-gans",
       "url": "https://github.com/mit-han-lab/data-efficient-gans",
-      "stargazerCount": 1306,
+      "stargazerCount": 1307,
       "description": "[NeurIPS 2020] Differentiable Augmentation for Data-Efficient GAN Training",
       "primaryLanguage": "Python",
       "starredAt": "2021-02-01T01:25:53Z"
@@ -5146,7 +5257,7 @@
     {
       "nameWithOwner": "GANs-in-Action/gans-in-action",
       "url": "https://github.com/GANs-in-Action/gans-in-action",
-      "stargazerCount": 1022,
+      "stargazerCount": 1023,
       "description": "Companion repository to GANs in Action: Deep learning with Generative Adversarial Networks",
       "primaryLanguage": "Jupyter Notebook",
       "starredAt": "2021-01-29T01:18:24Z"
@@ -5154,7 +5265,7 @@
     {
       "nameWithOwner": "facebookresearch/pycls",
       "url": "https://github.com/facebookresearch/pycls",
-      "stargazerCount": 2158,
+      "stargazerCount": 2160,
       "description": "Codebase for Image Classification Research, written in PyTorch.",
       "primaryLanguage": "Python",
       "starredAt": "2021-01-29T01:05:09Z"
@@ -5170,7 +5281,7 @@
     {
       "nameWithOwner": "google-research/google-research",
       "url": "https://github.com/google-research/google-research",
-      "stargazerCount": 36080,
+      "stargazerCount": 36128,
       "description": "Google Research",
       "primaryLanguage": "Jupyter Notebook",
       "starredAt": "2021-01-29T00:33:30Z"
@@ -5186,7 +5297,7 @@
     {
       "nameWithOwner": "JiaRenChang/PSMNet",
       "url": "https://github.com/JiaRenChang/PSMNet",
-      "stargazerCount": 1498,
+      "stargazerCount": 1499,
       "description": "Pyramid Stereo Matching Network (CVPR2018)",
       "primaryLanguage": "Python",
       "starredAt": "2021-01-28T20:38:26Z"
@@ -5194,7 +5305,7 @@
     {
       "nameWithOwner": "debidatta/syndata-generation",
       "url": "https://github.com/debidatta/syndata-generation",
-      "stargazerCount": 289,
+      "stargazerCount": 290,
       "description": "Code used to generate synthetic scenes and bounding box annotations for object detection. This was used to generate data used in the Cut, Paste and Learn paper",
       "primaryLanguage": "Python",
       "starredAt": "2021-01-28T20:30:38Z"
@@ -5210,7 +5321,7 @@
     {
       "nameWithOwner": "thlorenz/doctoc",
       "url": "https://github.com/thlorenz/doctoc",
-      "stargazerCount": 4347,
+      "stargazerCount": 4352,
       "description": "📜 Generates table of contents for markdown files inside local git repository. Links are compatible with anchors generated by github or other sites.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2021-01-26T22:31:32Z"
@@ -5218,7 +5329,7 @@
     {
       "nameWithOwner": "activeloopai/deeplake",
       "url": "https://github.com/activeloopai/deeplake",
-      "stargazerCount": 8733,
+      "stargazerCount": 8760,
       "description": "Database for AI. Store Vectors, Images, Texts, Videos, etc. Use with LLMs/LangChain. Store, query, version, & visualize any AI data. Stream data in real-time to PyTorch/TensorFlow. https://activeloop.ai",
       "primaryLanguage": "Python",
       "starredAt": "2021-01-26T22:26:28Z"
@@ -5226,7 +5337,7 @@
     {
       "nameWithOwner": "superhighfives/pika",
       "url": "https://github.com/superhighfives/pika",
-      "stargazerCount": 2067,
+      "stargazerCount": 2080,
       "description": "An open-source colour picker app for macOS",
       "primaryLanguage": "Swift",
       "starredAt": "2021-01-13T01:16:00Z"
@@ -5234,7 +5345,7 @@
     {
       "nameWithOwner": "brammitch/recharts-to-png",
       "url": "https://github.com/brammitch/recharts-to-png",
-      "stargazerCount": 49,
+      "stargazerCount": 50,
       "description": "Create images from HTML elements",
       "primaryLanguage": "TypeScript",
       "starredAt": "2021-01-12T00:46:44Z"
@@ -5242,7 +5353,7 @@
     {
       "nameWithOwner": "upptime/upptime",
       "url": "https://github.com/upptime/upptime",
-      "stargazerCount": 16346,
+      "stargazerCount": 16390,
       "description": "⬆️ GitHub Actions uptime monitor & status page by @AnandChowdhary",
       "primaryLanguage": "JSON",
       "starredAt": "2021-01-11T00:51:20Z"
@@ -5266,7 +5377,7 @@
     {
       "nameWithOwner": "quantopian/zipline",
       "url": "https://github.com/quantopian/zipline",
-      "stargazerCount": 18725,
+      "stargazerCount": 18769,
       "description": "Zipline, a Pythonic Algorithmic Trading Library",
       "primaryLanguage": "Python",
       "starredAt": "2020-12-28T05:31:21Z"
@@ -5274,7 +5385,7 @@
     {
       "nameWithOwner": "chrisdonahue/wavegan",
       "url": "https://github.com/chrisdonahue/wavegan",
-      "stargazerCount": 1365,
+      "stargazerCount": 1364,
       "description": "WaveGAN: Learn to synthesize raw audio with generative adversarial networks",
       "primaryLanguage": "Python",
       "starredAt": "2020-12-22T22:38:51Z"
@@ -5282,7 +5393,7 @@
     {
       "nameWithOwner": "magenta/ddsp",
       "url": "https://github.com/magenta/ddsp",
-      "stargazerCount": 3075,
+      "stargazerCount": 3079,
       "description": " DDSP: Differentiable Digital Signal Processing",
       "primaryLanguage": "Python",
       "starredAt": "2020-12-22T22:37:48Z"
@@ -5290,7 +5401,7 @@
     {
       "nameWithOwner": "reactjs/server-components-demo",
       "url": "https://github.com/reactjs/server-components-demo",
-      "stargazerCount": 4336,
+      "stargazerCount": 4338,
       "description": "Demo app of React Server Components.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2020-12-22T10:55:38Z"
@@ -5322,7 +5433,7 @@
     {
       "nameWithOwner": "KyleAMathews/react-headroom",
       "url": "https://github.com/KyleAMathews/react-headroom",
-      "stargazerCount": 1862,
+      "stargazerCount": 1864,
       "description": "Hide your header until you need it",
       "primaryLanguage": "JavaScript",
       "starredAt": "2020-12-09T22:31:36Z"
@@ -5330,7 +5441,7 @@
     {
       "nameWithOwner": "leongersen/noUiSlider",
       "url": "https://github.com/leongersen/noUiSlider",
-      "stargazerCount": 5766,
+      "stargazerCount": 5771,
       "description": "noUiSlider is a lightweight, ARIA-accessible JavaScript range slider with multi-touch and keyboard support. It is fully GPU animated: no reflows, so it is fast; even on older devices. It also fits wonderfully in responsive designs and has no dependencies.",
       "primaryLanguage": "TypeScript",
       "starredAt": "2020-12-07T05:54:45Z"
@@ -5338,7 +5449,7 @@
     {
       "nameWithOwner": "iawia002/lux",
       "url": "https://github.com/iawia002/lux",
-      "stargazerCount": 29912,
+      "stargazerCount": 29948,
       "description": "👾 Fast and simple video download library and CLI tool written in Go",
       "primaryLanguage": "Go",
       "starredAt": "2020-12-07T01:56:06Z"
@@ -5346,7 +5457,7 @@
     {
       "nameWithOwner": "sidorares/node-mysql2",
       "url": "https://github.com/sidorares/node-mysql2",
-      "stargazerCount": 4254,
+      "stargazerCount": 4257,
       "description": ":zap: fast mysqljs/mysql compatible mysql driver for node.js",
       "primaryLanguage": "JavaScript",
       "starredAt": "2020-12-03T03:48:41Z"
@@ -5354,7 +5465,7 @@
     {
       "nameWithOwner": "backstage/backstage",
       "url": "https://github.com/backstage/backstage",
-      "stargazerCount": 30803,
+      "stargazerCount": 30851,
       "description": "Backstage is an open framework for building developer portals",
       "primaryLanguage": "TypeScript",
       "starredAt": "2020-12-03T03:30:20Z"
@@ -5362,7 +5473,7 @@
     {
       "nameWithOwner": "joshuaellis/react-tensorflow",
       "url": "https://github.com/joshuaellis/react-tensorflow",
-      "stargazerCount": 160,
+      "stargazerCount": 159,
       "description": "Tensorflow hooks for React.js",
       "primaryLanguage": "TypeScript",
       "starredAt": "2020-12-02T23:31:42Z"
@@ -5378,7 +5489,7 @@
     {
       "nameWithOwner": "allenai/scitldr",
       "url": "https://github.com/allenai/scitldr",
-      "stargazerCount": 758,
+      "stargazerCount": 759,
       "description": "",
       "primaryLanguage": "Python",
       "starredAt": "2020-11-26T05:36:01Z"
@@ -5386,7 +5497,7 @@
     {
       "nameWithOwner": "plotly/dash",
       "url": "https://github.com/plotly/dash",
-      "stargazerCount": 23512,
+      "stargazerCount": 23874,
       "description": "Data Apps & Dashboards for Python. No JavaScript Required.",
       "primaryLanguage": "Python",
       "starredAt": "2020-11-25T21:40:38Z"
@@ -5394,7 +5505,7 @@
     {
       "nameWithOwner": "alpinejs/alpine",
       "url": "https://github.com/alpinejs/alpine",
-      "stargazerCount": 30081,
+      "stargazerCount": 30127,
       "description": "A rugged, minimal framework for composing JavaScript behavior in your markup. ",
       "primaryLanguage": "HTML",
       "starredAt": "2020-11-25T21:34:32Z"
@@ -5410,7 +5521,7 @@
     {
       "nameWithOwner": "sivel/speedtest-cli",
       "url": "https://github.com/sivel/speedtest-cli",
-      "stargazerCount": 13861,
+      "stargazerCount": 13868,
       "description": "Command line interface for testing internet bandwidth using speedtest.net",
       "primaryLanguage": "Python",
       "starredAt": "2020-11-25T20:53:15Z"
@@ -5426,7 +5537,7 @@
     {
       "nameWithOwner": "apple/tensorflow_macos",
       "url": "https://github.com/apple/tensorflow_macos",
-      "stargazerCount": 3675,
+      "stargazerCount": 3674,
       "description": "TensorFlow for macOS 11.0+ accelerated using Apple's ML Compute framework. ",
       "primaryLanguage": "Shell",
       "starredAt": "2020-11-25T20:32:40Z"
@@ -5434,7 +5545,7 @@
     {
       "nameWithOwner": "orf/gping",
       "url": "https://github.com/orf/gping",
-      "stargazerCount": 11760,
+      "stargazerCount": 11780,
       "description": "Ping, but with a graph",
       "primaryLanguage": "Rust",
       "starredAt": "2020-11-23T00:38:12Z"
@@ -5450,7 +5561,7 @@
     {
       "nameWithOwner": "dhaitz/mplcyberpunk",
       "url": "https://github.com/dhaitz/mplcyberpunk",
-      "stargazerCount": 1778,
+      "stargazerCount": 1781,
       "description": "\"Cyberpunk style\" for matplotlib plots",
       "primaryLanguage": "Python",
       "starredAt": "2020-11-03T02:53:05Z"
@@ -5458,7 +5569,7 @@
     {
       "nameWithOwner": "garrettj403/SciencePlots",
       "url": "https://github.com/garrettj403/SciencePlots",
-      "stargazerCount": 8074,
+      "stargazerCount": 8098,
       "description": "Matplotlib styles for scientific plotting",
       "primaryLanguage": "Python",
       "starredAt": "2020-11-03T02:48:46Z"
@@ -5474,7 +5585,7 @@
     {
       "nameWithOwner": "plentico/plenti",
       "url": "https://github.com/plentico/plenti",
-      "stargazerCount": 1043,
+      "stargazerCount": 1046,
       "description": "Static Site Generator with Go backend and Svelte frontend",
       "primaryLanguage": "JavaScript",
       "starredAt": "2020-11-03T01:03:44Z"
@@ -5482,7 +5593,7 @@
     {
       "nameWithOwner": "kirkjerk/lowLagAudio",
       "url": "https://github.com/kirkjerk/lowLagAudio",
-      "stargazerCount": 90,
+      "stargazerCount": 89,
       "description": "responsive html5 audio wrapper",
       "primaryLanguage": "JavaScript",
       "starredAt": "2020-11-02T22:31:55Z"
@@ -5490,7 +5601,7 @@
     {
       "nameWithOwner": "Externalizable/bongo.cat",
       "url": "https://github.com/Externalizable/bongo.cat",
-      "stargazerCount": 3507,
+      "stargazerCount": 3516,
       "description": "Hit the bongos like Bongo Cat!",
       "primaryLanguage": "JavaScript",
       "starredAt": "2020-11-02T22:31:37Z"
@@ -5498,7 +5609,7 @@
     {
       "nameWithOwner": "sql-js/sql.js",
       "url": "https://github.com/sql-js/sql.js",
-      "stargazerCount": 13242,
+      "stargazerCount": 13275,
       "description": "A javascript library to run SQLite on the web.  ",
       "primaryLanguage": "JavaScript",
       "starredAt": "2020-11-02T22:26:01Z"
@@ -5506,7 +5617,7 @@
     {
       "nameWithOwner": "elastic/elasticsearch",
       "url": "https://github.com/elastic/elasticsearch",
-      "stargazerCount": 73319,
+      "stargazerCount": 73408,
       "description": "Free and Open Source, Distributed, RESTful Search Engine",
       "primaryLanguage": "Java",
       "starredAt": "2020-10-30T06:07:21Z"
@@ -5522,7 +5633,7 @@
     {
       "nameWithOwner": "ai/easings.net",
       "url": "https://github.com/ai/easings.net",
-      "stargazerCount": 8373,
+      "stargazerCount": 8381,
       "description": "Easing Functions Cheat Sheet",
       "primaryLanguage": "CSS",
       "starredAt": "2020-10-29T06:03:53Z"
@@ -5546,7 +5657,7 @@
     {
       "nameWithOwner": "MTG/essentia.js",
       "url": "https://github.com/MTG/essentia.js",
-      "stargazerCount": 728,
+      "stargazerCount": 730,
       "description": "JavaScript library for music/audio analysis and processing powered by Essentia WebAssembly",
       "primaryLanguage": "TypeScript",
       "starredAt": "2020-10-22T22:48:57Z"
@@ -5554,7 +5665,7 @@
     {
       "nameWithOwner": "rclone/rclone",
       "url": "https://github.com/rclone/rclone",
-      "stargazerCount": 51633,
+      "stargazerCount": 51784,
       "description": "\"rsync for cloud storage\" - Google Drive, S3, Dropbox, Backblaze B2, One Drive, Swift, Hubic, Wasabi, Google Cloud Storage, Azure Blob, Azure Files, Yandex Files",
       "primaryLanguage": "Go",
       "starredAt": "2020-10-19T01:36:41Z"
@@ -5562,7 +5673,7 @@
     {
       "nameWithOwner": "OpenRefine/OpenRefine",
       "url": "https://github.com/OpenRefine/OpenRefine",
-      "stargazerCount": 11440,
+      "stargazerCount": 11451,
       "description": "OpenRefine is a free, open source power tool for working with messy data and improving it",
       "primaryLanguage": "Java",
       "starredAt": "2020-10-13T23:51:17Z"
@@ -5570,7 +5681,7 @@
     {
       "nameWithOwner": "muesli/duf",
       "url": "https://github.com/muesli/duf",
-      "stargazerCount": 13527,
+      "stargazerCount": 13551,
       "description": "Disk Usage/Free Utility - a better 'df' alternative",
       "primaryLanguage": "Go",
       "starredAt": "2020-10-07T07:01:15Z"
@@ -5578,7 +5689,7 @@
     {
       "nameWithOwner": "LingDong-/q5xjs",
       "url": "https://github.com/LingDong-/q5xjs",
-      "stargazerCount": 561,
+      "stargazerCount": 564,
       "description": "A small and fast alternative (experimental) implementation of p5.js",
       "primaryLanguage": "JavaScript",
       "starredAt": "2020-10-06T05:47:04Z"
@@ -5586,7 +5697,7 @@
     {
       "nameWithOwner": "prabhuignoto/react-chrono",
       "url": "https://github.com/prabhuignoto/react-chrono",
-      "stargazerCount": 4090,
+      "stargazerCount": 4093,
       "description": "Modern Timeline Component for React",
       "primaryLanguage": "HTML",
       "starredAt": "2020-10-06T05:44:56Z"
@@ -5626,7 +5737,7 @@
     {
       "nameWithOwner": "vasanthv/ahey",
       "url": "https://github.com/vasanthv/ahey",
-      "stargazerCount": 3994,
+      "stargazerCount": 4055,
       "description": "Free group video call for the web. No signups. No downloads.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2020-09-14T02:28:27Z"
@@ -5634,7 +5745,7 @@
     {
       "nameWithOwner": "awesome-css-group/awesome-css",
       "url": "https://github.com/awesome-css-group/awesome-css",
-      "stargazerCount": 5313,
+      "stargazerCount": 5318,
       "description": ":art: A curated contents of amazing CSS :)",
       "primaryLanguage": null,
       "starredAt": "2020-09-10T05:28:29Z"
@@ -5658,7 +5769,7 @@
     {
       "nameWithOwner": "plotly/plotly.R",
       "url": "https://github.com/plotly/plotly.R",
-      "stargazerCount": 2626,
+      "stargazerCount": 2628,
       "description": "An interactive graphing library for R",
       "primaryLanguage": "R",
       "starredAt": "2020-09-03T04:04:36Z"
@@ -5698,7 +5809,7 @@
     {
       "nameWithOwner": "javascriptdata/danfojs",
       "url": "https://github.com/javascriptdata/danfojs",
-      "stargazerCount": 4961,
+      "stargazerCount": 4969,
       "description": "Danfo.js is an open source, JavaScript library providing high performance, intuitive, and easy to use data structures for manipulating and processing structured data.",
       "primaryLanguage": "TypeScript",
       "starredAt": "2020-09-01T03:58:29Z"
@@ -5706,7 +5817,7 @@
     {
       "nameWithOwner": "tailwindlabs/heroicons",
       "url": "https://github.com/tailwindlabs/heroicons",
-      "stargazerCount": 22683,
+      "stargazerCount": 22722,
       "description": "A set of free MIT-licensed high-quality SVG icons for UI development.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2020-08-27T22:54:16Z"
@@ -5714,7 +5825,7 @@
     {
       "nameWithOwner": "PipedreamHQ/pipedream",
       "url": "https://github.com/PipedreamHQ/pipedream",
-      "stargazerCount": 10239,
+      "stargazerCount": 10334,
       "description": "Connect APIs, remarkably fast.  Free for developers.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2020-08-26T21:22:37Z"
@@ -5730,7 +5841,7 @@
     {
       "nameWithOwner": "umami-software/umami",
       "url": "https://github.com/umami-software/umami",
-      "stargazerCount": 27438,
+      "stargazerCount": 27601,
       "description": "Umami is a modern, privacy-focused alternative to Google Analytics.",
       "primaryLanguage": "TypeScript",
       "starredAt": "2020-08-24T01:24:06Z"
@@ -5738,7 +5849,7 @@
     {
       "nameWithOwner": "rome/tools",
       "url": "https://github.com/rome/tools",
-      "stargazerCount": 23612,
+      "stargazerCount": 23606,
       "description": "Unified developer tools for JavaScript, TypeScript, and the web",
       "primaryLanguage": "Rust",
       "starredAt": "2020-08-20T23:54:05Z"
@@ -5746,7 +5857,7 @@
     {
       "nameWithOwner": "up-banking/api",
       "url": "https://github.com/up-banking/api",
-      "stargazerCount": 392,
+      "stargazerCount": 397,
       "description": "The Up Banking API Specification",
       "primaryLanguage": null,
       "starredAt": "2020-07-31T07:48:08Z"
@@ -5754,7 +5865,7 @@
     {
       "nameWithOwner": "lutzroeder/netron",
       "url": "https://github.com/lutzroeder/netron",
-      "stargazerCount": 31011,
+      "stargazerCount": 31087,
       "description": "Visualizer for neural network, deep learning and machine learning models",
       "primaryLanguage": "JavaScript",
       "starredAt": "2020-07-27T01:29:51Z"
@@ -5762,7 +5873,7 @@
     {
       "nameWithOwner": "HumanSignal/label-studio-frontend",
       "url": "https://github.com/HumanSignal/label-studio-frontend",
-      "stargazerCount": 436,
+      "stargazerCount": 438,
       "description": "Data labeling react app that is backend agnostic and can be embedded into your applications — distributed as an NPM package",
       "primaryLanguage": "JavaScript",
       "starredAt": "2020-07-25T08:34:32Z"
@@ -5778,7 +5889,7 @@
     {
       "nameWithOwner": "welldone-software/why-did-you-render",
       "url": "https://github.com/welldone-software/why-did-you-render",
-      "stargazerCount": 12076,
+      "stargazerCount": 12138,
       "description": "why-did-you-render by Welldone Software monkey patches React to notify you about potentially avoidable re-renders. (Works with React Native as well.)",
       "primaryLanguage": "JavaScript",
       "starredAt": "2020-07-23T23:11:03Z"
@@ -5786,7 +5897,7 @@
     {
       "nameWithOwner": "knex/knex",
       "url": "https://github.com/knex/knex",
-      "stargazerCount": 19933,
+      "stargazerCount": 19940,
       "description": "A query builder for PostgreSQL, MySQL, CockroachDB, SQL Server, SQLite3 and Oracle, designed to be flexible, portable, and fun to use.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2020-07-23T20:19:14Z"
@@ -5810,7 +5921,7 @@
     {
       "nameWithOwner": "GoogleChromeLabs/comlink-loader",
       "url": "https://github.com/GoogleChromeLabs/comlink-loader",
-      "stargazerCount": 626,
+      "stargazerCount": 627,
       "description": "Webpack loader to offload modules to Worker threads seamlessly using Comlink.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2020-07-21T01:22:34Z"
@@ -5818,7 +5929,7 @@
     {
       "nameWithOwner": "SkalskiP/make-sense",
       "url": "https://github.com/SkalskiP/make-sense",
-      "stargazerCount": 3406,
+      "stargazerCount": 3412,
       "description": "Free to use online tool for labelling photos. https://makesense.ai",
       "primaryLanguage": "TypeScript",
       "starredAt": "2020-07-20T05:47:47Z"
@@ -5826,7 +5937,7 @@
     {
       "nameWithOwner": "streamlit/streamlit",
       "url": "https://github.com/streamlit/streamlit",
-      "stargazerCount": 40558,
+      "stargazerCount": 40727,
       "description": "Streamlit — A faster way to build and share data apps.",
       "primaryLanguage": "Python",
       "starredAt": "2020-07-20T05:12:30Z"
@@ -5834,7 +5945,7 @@
     {
       "nameWithOwner": "streamlit/demo-self-driving",
       "url": "https://github.com/streamlit/demo-self-driving",
-      "stargazerCount": 1251,
+      "stargazerCount": 1252,
       "description": "Streamlit app demonstrating an image browser for the Udacity self-driving-car dataset with realtime object detection using YOLO.",
       "primaryLanguage": "Python",
       "starredAt": "2020-07-20T05:12:12Z"
@@ -5850,7 +5961,7 @@
     {
       "nameWithOwner": "adobe/react-spectrum",
       "url": "https://github.com/adobe/react-spectrum",
-      "stargazerCount": 14163,
+      "stargazerCount": 14180,
       "description": "A collection of libraries and tools that help you build adaptive, accessible, and robust user experiences.",
       "primaryLanguage": "TypeScript",
       "starredAt": "2020-07-15T22:39:40Z"
@@ -5866,7 +5977,7 @@
     {
       "nameWithOwner": "gradio-app/gradio",
       "url": "https://github.com/gradio-app/gradio",
-      "stargazerCount": 39170,
+      "stargazerCount": 39313,
       "description": "Build and share delightful machine learning apps, all in Python. 🌟 Star to support our work!",
       "primaryLanguage": "Python",
       "starredAt": "2020-07-10T01:17:23Z"
@@ -5874,7 +5985,7 @@
     {
       "nameWithOwner": "clearml/clearml",
       "url": "https://github.com/clearml/clearml",
-      "stargazerCount": 6168,
+      "stargazerCount": 6191,
       "description": "ClearML - Auto-Magical CI/CD to streamline your AI workload. Experiment Management, Data Management, Pipeline, Orchestration, Scheduling & Serving in one MLOps/LLMOps solution",
       "primaryLanguage": "Python",
       "starredAt": "2020-07-09T21:11:29Z"
@@ -5882,7 +5993,7 @@
     {
       "nameWithOwner": "FydeOS/chromium_os-raspberry_pi",
       "url": "https://github.com/FydeOS/chromium_os-raspberry_pi",
-      "stargazerCount": 1726,
+      "stargazerCount": 1727,
       "description": "Build your Chromium OS for Raspberry Pi 4B, Pi400 and the latest Raspberry Pi 5",
       "primaryLanguage": "Shell",
       "starredAt": "2020-07-08T20:13:28Z"
@@ -5898,7 +6009,7 @@
     {
       "nameWithOwner": "mathieudutour/gatsby-digital-garden",
       "url": "https://github.com/mathieudutour/gatsby-digital-garden",
-      "stargazerCount": 681,
+      "stargazerCount": 680,
       "description": "🌷 🌻 🌺 Create a digital garden with Gatsby",
       "primaryLanguage": "JavaScript",
       "starredAt": "2020-07-06T04:15:08Z"
@@ -5914,7 +6025,7 @@
     {
       "nameWithOwner": "foambubble/foam",
       "url": "https://github.com/foambubble/foam",
-      "stargazerCount": 16299,
+      "stargazerCount": 16327,
       "description": "A personal knowledge management and sharing system for VSCode",
       "primaryLanguage": "TypeScript",
       "starredAt": "2020-07-06T03:59:50Z"
@@ -5922,7 +6033,7 @@
     {
       "nameWithOwner": "splitbee/react-notion",
       "url": "https://github.com/splitbee/react-notion",
-      "stargazerCount": 2971,
+      "stargazerCount": 2975,
       "description": "A fast React renderer for Notion pages ",
       "primaryLanguage": "TypeScript",
       "starredAt": "2020-07-06T03:47:02Z"
@@ -5930,7 +6041,7 @@
     {
       "nameWithOwner": "MaggieAppleton/digital-gardeners",
       "url": "https://github.com/MaggieAppleton/digital-gardeners",
-      "stargazerCount": 4407,
+      "stargazerCount": 4422,
       "description": "Resources, links, projects, and ideas for gardeners tending their digital notes on the public interwebs",
       "primaryLanguage": "JavaScript",
       "starredAt": "2020-07-06T03:46:40Z"
@@ -5954,7 +6065,7 @@
     {
       "nameWithOwner": "ifzhang/FairMOT",
       "url": "https://github.com/ifzhang/FairMOT",
-      "stargazerCount": 4142,
+      "stargazerCount": 4149,
       "description": "[IJCV-2021] FairMOT: On the Fairness of Detection and Re-Identification in Multi-Object Tracking",
       "primaryLanguage": "Python",
       "starredAt": "2020-07-03T00:28:42Z"
@@ -5978,7 +6089,7 @@
     {
       "nameWithOwner": "google/leveldb",
       "url": "https://github.com/google/leveldb",
-      "stargazerCount": 37926,
+      "stargazerCount": 37946,
       "description": "LevelDB is a fast key-value storage library written at Google that provides an ordered mapping from string keys to string values.",
       "primaryLanguage": "C++",
       "starredAt": "2020-07-01T04:03:58Z"
@@ -5986,7 +6097,7 @@
     {
       "nameWithOwner": "iterative/dvc",
       "url": "https://github.com/iterative/dvc",
-      "stargazerCount": 14693,
+      "stargazerCount": 14721,
       "description": "🦉 Data Versioning and ML Experiments",
       "primaryLanguage": "Python",
       "starredAt": "2020-07-01T03:45:37Z"
@@ -6010,7 +6121,7 @@
     {
       "nameWithOwner": "mit-han-lab/temporal-shift-module",
       "url": "https://github.com/mit-han-lab/temporal-shift-module",
-      "stargazerCount": 2135,
+      "stargazerCount": 2134,
       "description": "[ICCV 2019] TSM: Temporal Shift Module for Efficient Video Understanding",
       "primaryLanguage": "Python",
       "starredAt": "2020-06-28T00:46:29Z"
@@ -6018,7 +6129,7 @@
     {
       "nameWithOwner": "microsoft/CameraTraps",
       "url": "https://github.com/microsoft/CameraTraps",
-      "stargazerCount": 918,
+      "stargazerCount": 924,
       "description": "PyTorch Wildlife: a Collaborative Deep Learning Framework for Conservation.",
       "primaryLanguage": "Python",
       "starredAt": "2020-06-25T23:44:06Z"
@@ -6034,7 +6145,7 @@
     {
       "nameWithOwner": "google-research/simclr",
       "url": "https://github.com/google-research/simclr",
-      "stargazerCount": 4326,
+      "stargazerCount": 4333,
       "description": "SimCLRv2 - Big Self-Supervised Models are Strong Semi-Supervised Learners",
       "primaryLanguage": "Jupyter Notebook",
       "starredAt": "2020-06-25T03:03:17Z"
@@ -6042,7 +6153,7 @@
     {
       "nameWithOwner": "aleju/imgaug",
       "url": "https://github.com/aleju/imgaug",
-      "stargazerCount": 14632,
+      "stargazerCount": 14641,
       "description": "Image augmentation for machine learning experiments.",
       "primaryLanguage": "Python",
       "starredAt": "2020-06-25T02:42:15Z"
@@ -6050,7 +6161,7 @@
     {
       "nameWithOwner": "dundalek/markmap",
       "url": "https://github.com/dundalek/markmap",
-      "stargazerCount": 1876,
+      "stargazerCount": 1878,
       "description": "Visualize markdown documents as mindmaps",
       "primaryLanguage": "JavaScript",
       "starredAt": "2020-06-24T02:36:16Z"
@@ -6082,7 +6193,7 @@
     {
       "nameWithOwner": "researchmm/TracKit",
       "url": "https://github.com/researchmm/TracKit",
-      "stargazerCount": 619,
+      "stargazerCount": 620,
       "description": "[ECCV'20] Ocean: Object-aware Anchor-Free Tracking",
       "primaryLanguage": "Python",
       "starredAt": "2020-06-23T01:36:32Z"
@@ -6098,7 +6209,7 @@
     {
       "nameWithOwner": "alex-damian/pulse",
       "url": "https://github.com/alex-damian/pulse",
-      "stargazerCount": 8009,
+      "stargazerCount": 8010,
       "description": "PULSE: Self-Supervised Photo Upsampling via Latent Space Exploration of Generative Models",
       "primaryLanguage": "Python",
       "starredAt": "2020-06-20T08:53:23Z"
@@ -6106,7 +6217,7 @@
     {
       "nameWithOwner": "manicman1999/StyleGAN2-Tensorflow-2.0",
       "url": "https://github.com/manicman1999/StyleGAN2-Tensorflow-2.0",
-      "stargazerCount": 486,
+      "stargazerCount": 485,
       "description": "StyleGAN 2 in Tensorflow 2.0",
       "primaryLanguage": "Python",
       "starredAt": "2020-06-20T08:36:38Z"
@@ -6114,7 +6225,7 @@
     {
       "nameWithOwner": "junyanz/CycleGAN",
       "url": "https://github.com/junyanz/CycleGAN",
-      "stargazerCount": 12703,
+      "stargazerCount": 12712,
       "description": "Software that can generate photos from paintings,  turn horses into zebras,  perform style transfer, and more.",
       "primaryLanguage": "Lua",
       "starredAt": "2020-06-20T08:34:24Z"
@@ -6122,7 +6233,7 @@
     {
       "nameWithOwner": "lengstrom/fast-style-transfer",
       "url": "https://github.com/lengstrom/fast-style-transfer",
-      "stargazerCount": 10962,
+      "stargazerCount": 10965,
       "description": "TensorFlow CNN for fast style transfer ⚡🖥🎨🖼",
       "primaryLanguage": "Python",
       "starredAt": "2020-06-20T07:14:22Z"
@@ -6130,7 +6241,7 @@
     {
       "nameWithOwner": "manuelruder/artistic-videos",
       "url": "https://github.com/manuelruder/artistic-videos",
-      "stargazerCount": 1753,
+      "stargazerCount": 1754,
       "description": "Torch implementation for the paper \"Artistic style transfer for videos\"",
       "primaryLanguage": "C++",
       "starredAt": "2020-06-20T07:12:41Z"
@@ -6146,7 +6257,7 @@
     {
       "nameWithOwner": "super-linter/super-linter",
       "url": "https://github.com/super-linter/super-linter",
-      "stargazerCount": 9971,
+      "stargazerCount": 9994,
       "description": "Combination of multiple linters to run as a GitHub Action or standalone",
       "primaryLanguage": "Shell",
       "starredAt": "2020-06-19T08:33:56Z"
@@ -6154,7 +6265,7 @@
     {
       "nameWithOwner": "UniversalDataTool/universal-data-tool",
       "url": "https://github.com/UniversalDataTool/universal-data-tool",
-      "stargazerCount": 2001,
+      "stargazerCount": 2003,
       "description": "Collaborate & label any type of data, images, text, or documents, in an easy web interface or desktop app.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2020-06-17T01:53:07Z"
@@ -6162,7 +6273,7 @@
     {
       "nameWithOwner": "fastapi/fastapi",
       "url": "https://github.com/fastapi/fastapi",
-      "stargazerCount": 87605,
+      "stargazerCount": 87952,
       "description": "FastAPI framework, high performance, easy to learn, fast to code, ready for production",
       "primaryLanguage": "Python",
       "starredAt": "2020-06-16T20:02:08Z"
@@ -6178,7 +6289,7 @@
     {
       "nameWithOwner": "supervisely/supervisely",
       "url": "https://github.com/supervisely/supervisely",
-      "stargazerCount": 489,
+      "stargazerCount": 491,
       "description": "Supervisely SDK for Python - convenient way to automate, customize and extend Supervisely Platform for your computer vision task ",
       "primaryLanguage": "Python",
       "starredAt": "2020-06-15T06:17:16Z"
@@ -6186,7 +6297,7 @@
     {
       "nameWithOwner": "mbrevda/react-image",
       "url": "https://github.com/mbrevda/react-image",
-      "stargazerCount": 1220,
+      "stargazerCount": 1222,
       "description": "React.js <img> tag rendering with multiple fallback & loader support",
       "primaryLanguage": "TypeScript",
       "starredAt": "2020-06-15T05:41:46Z"
@@ -6194,7 +6305,7 @@
     {
       "nameWithOwner": "zotero/zotero",
       "url": "https://github.com/zotero/zotero",
-      "stargazerCount": 12032,
+      "stargazerCount": 12076,
       "description": "Zotero is a free, easy-to-use tool to help you collect, organize, annotate, cite, and share your research sources.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2020-06-15T00:41:27Z"
@@ -6202,7 +6313,7 @@
     {
       "nameWithOwner": "cleinc/bts",
       "url": "https://github.com/cleinc/bts",
-      "stargazerCount": 660,
+      "stargazerCount": 661,
       "description": "From Big to Small: Multi-Scale Local Planar Guidance for Monocular Depth Estimation",
       "primaryLanguage": "Python",
       "starredAt": "2020-06-14T22:58:09Z"
@@ -6210,7 +6321,7 @@
     {
       "nameWithOwner": "nianticlabs/monodepth2",
       "url": "https://github.com/nianticlabs/monodepth2",
-      "stargazerCount": 4376,
+      "stargazerCount": 4380,
       "description": "[ICCV 2019] Monocular depth estimation from a single image",
       "primaryLanguage": "Jupyter Notebook",
       "starredAt": "2020-06-14T22:58:02Z"
@@ -6218,7 +6329,7 @@
     {
       "nameWithOwner": "ageron/handson-ml2",
       "url": "https://github.com/ageron/handson-ml2",
-      "stargazerCount": 29076,
+      "stargazerCount": 29131,
       "description": "A series of Jupyter notebooks that walk you through the fundamentals of Machine Learning and Deep Learning in Python using Scikit-Learn, Keras and TensorFlow 2.",
       "primaryLanguage": "Jupyter Notebook",
       "starredAt": "2020-06-14T08:40:45Z"
@@ -6226,7 +6337,7 @@
     {
       "nameWithOwner": "jakevdp/PythonDataScienceHandbook",
       "url": "https://github.com/jakevdp/PythonDataScienceHandbook",
-      "stargazerCount": 45029,
+      "stargazerCount": 45116,
       "description": "Python Data Science Handbook: full text in Jupyter Notebooks",
       "primaryLanguage": "Jupyter Notebook",
       "starredAt": "2020-06-14T08:34:24Z"
@@ -6234,7 +6345,7 @@
     {
       "nameWithOwner": "ultralytics/yolov5",
       "url": "https://github.com/ultralytics/yolov5",
-      "stargazerCount": 54747,
+      "stargazerCount": 54874,
       "description": "YOLOv5 🚀 in PyTorch > ONNX > CoreML > TFLite",
       "primaryLanguage": "Python",
       "starredAt": "2020-06-13T08:33:28Z"
@@ -6242,7 +6353,7 @@
     {
       "nameWithOwner": "starship/starship",
       "url": "https://github.com/starship/starship",
-      "stargazerCount": 50118,
+      "stargazerCount": 50260,
       "description": "☄🌌️  The minimal, blazing-fast, and infinitely customizable prompt for any shell!",
       "primaryLanguage": "Rust",
       "starredAt": "2020-06-13T05:23:20Z"
@@ -6250,7 +6361,7 @@
     {
       "nameWithOwner": "facebookresearch/detr",
       "url": "https://github.com/facebookresearch/detr",
-      "stargazerCount": 14541,
+      "stargazerCount": 14567,
       "description": "End-to-End Object Detection with Transformers",
       "primaryLanguage": "Python",
       "starredAt": "2020-06-12T08:34:38Z"
@@ -6258,7 +6369,7 @@
     {
       "nameWithOwner": "jsbroks/coco-annotator",
       "url": "https://github.com/jsbroks/coco-annotator",
-      "stargazerCount": 2220,
+      "stargazerCount": 2222,
       "description": ":pencil2: Web-based image segmentation tool for object detection, localization, and keypoints",
       "primaryLanguage": "Vue",
       "starredAt": "2020-06-12T08:29:38Z"
@@ -6266,7 +6377,7 @@
     {
       "nameWithOwner": "GokuMohandas/Made-With-ML",
       "url": "https://github.com/GokuMohandas/Made-With-ML",
-      "stargazerCount": 41218,
+      "stargazerCount": 41526,
       "description": "Learn how to design, develop, deploy and iterate on production-grade ML applications.",
       "primaryLanguage": "Jupyter Notebook",
       "starredAt": "2020-06-12T08:14:43Z"
@@ -6306,7 +6417,7 @@
     {
       "nameWithOwner": "supabase/supabase",
       "url": "https://github.com/supabase/supabase",
-      "stargazerCount": 86076,
+      "stargazerCount": 86481,
       "description": "The Postgres development platform. Supabase gives you a dedicated Postgres database to build your web, mobile, and AI applications.",
       "primaryLanguage": "TypeScript",
       "starredAt": "2020-06-02T19:33:37Z"
@@ -6322,7 +6433,7 @@
     {
       "nameWithOwner": "linkstrifer/react-rough-notation",
       "url": "https://github.com/linkstrifer/react-rough-notation",
-      "stargazerCount": 572,
+      "stargazerCount": 575,
       "description": "React wrapper for rough-notation",
       "primaryLanguage": "TypeScript",
       "starredAt": "2020-06-01T03:25:39Z"
@@ -6330,7 +6441,7 @@
     {
       "nameWithOwner": "rough-stuff/rough-notation",
       "url": "https://github.com/rough-stuff/rough-notation",
-      "stargazerCount": 9118,
+      "stargazerCount": 9133,
       "description": "Create and animate hand-drawn annotations on a web page",
       "primaryLanguage": "TypeScript",
       "starredAt": "2020-06-01T03:25:26Z"
@@ -6338,7 +6449,7 @@
     {
       "nameWithOwner": "open-AIMS/ozfish",
       "url": "https://github.com/open-AIMS/ozfish",
-      "stargazerCount": 43,
+      "stargazerCount": 44,
       "description": "Public dataset of Australian fish species for advancing machine learning research ",
       "primaryLanguage": null,
       "starredAt": "2020-05-29T06:20:07Z"
@@ -6394,7 +6505,7 @@
     {
       "nameWithOwner": "h2non/filetype.py",
       "url": "https://github.com/h2non/filetype.py",
-      "stargazerCount": 711,
+      "stargazerCount": 715,
       "description": "Small, dependency-free, fast Python package to infer binary file types checking the magic numbers signature",
       "primaryLanguage": "Python",
       "starredAt": "2020-05-14T06:06:25Z"
@@ -6418,7 +6529,7 @@
     {
       "nameWithOwner": "xahidbuffon/FUnIE-GAN",
       "url": "https://github.com/xahidbuffon/FUnIE-GAN",
-      "stargazerCount": 554,
+      "stargazerCount": 558,
       "description": "Fast underwater image enhancement for Improved Visual Perception. #TensorFlow #PyTorch #RAL2020",
       "primaryLanguage": "Python",
       "starredAt": "2020-05-12T23:28:51Z"
@@ -6426,7 +6537,7 @@
     {
       "nameWithOwner": "wangyanckxx/Single-Underwater-Image-Enhancement-and-Color-Restoration",
       "url": "https://github.com/wangyanckxx/Single-Underwater-Image-Enhancement-and-Color-Restoration",
-      "stargazerCount": 719,
+      "stargazerCount": 720,
       "description": "Single Underwater Image Enhancement and Color Restoration, which is Python implementation for a comprehensive review paper \"An Experimental-based Review of Image Enhancement and Image Restoration Methods for Underwater Imaging\"",
       "primaryLanguage": "Python",
       "starredAt": "2020-05-12T23:28:37Z"
@@ -6442,7 +6553,7 @@
     {
       "nameWithOwner": "sindresorhus/pretty-bytes",
       "url": "https://github.com/sindresorhus/pretty-bytes",
-      "stargazerCount": 1214,
+      "stargazerCount": 1217,
       "description": "Convert bytes to a human readable string: 1337 → 1.34 kB",
       "primaryLanguage": "JavaScript",
       "starredAt": "2020-05-08T00:32:36Z"
@@ -6458,7 +6569,7 @@
     {
       "nameWithOwner": "sst/guide",
       "url": "https://github.com/sst/guide",
-      "stargazerCount": 3693,
+      "stargazerCount": 3692,
       "description": "Repo for guide.sst.dev",
       "primaryLanguage": "SCSS",
       "starredAt": "2020-04-21T20:16:56Z"
@@ -6490,7 +6601,7 @@
     {
       "nameWithOwner": "vime-js/vime",
       "url": "https://github.com/vime-js/vime",
-      "stargazerCount": 2814,
+      "stargazerCount": 2815,
       "description": "Customizable, extensible, accessible and framework agnostic media player. Modern alternative to Video.js and Plyr. Supports HTML5, HLS, Dash, YouTube, Vimeo, Dailymotion...",
       "primaryLanguage": "TypeScript",
       "starredAt": "2020-04-20T00:10:59Z"
@@ -6506,7 +6617,7 @@
     {
       "nameWithOwner": "StylishThemes/GitHub-Dark",
       "url": "https://github.com/StylishThemes/GitHub-Dark",
-      "stargazerCount": 9753,
+      "stargazerCount": 9756,
       "description": ":octocat: Dark GitHub style",
       "primaryLanguage": "CSS",
       "starredAt": "2020-04-15T23:55:11Z"
@@ -6514,7 +6625,7 @@
     {
       "nameWithOwner": "archiverjs/node-archiver",
       "url": "https://github.com/archiverjs/node-archiver",
-      "stargazerCount": 2892,
+      "stargazerCount": 2893,
       "description": "a streaming interface for archive generation",
       "primaryLanguage": "JavaScript",
       "starredAt": "2020-04-05T22:32:00Z"
@@ -6522,7 +6633,7 @@
     {
       "nameWithOwner": "jimmywarting/StreamSaver.js",
       "url": "https://github.com/jimmywarting/StreamSaver.js",
-      "stargazerCount": 4224,
+      "stargazerCount": 4235,
       "description": "StreamSaver writes stream to the filesystem directly asynchronous",
       "primaryLanguage": "JavaScript",
       "starredAt": "2020-04-05T22:03:08Z"
@@ -6530,7 +6641,7 @@
     {
       "nameWithOwner": "Stuk/jszip",
       "url": "https://github.com/Stuk/jszip",
-      "stargazerCount": 10099,
+      "stargazerCount": 10110,
       "description": "Create, read and edit .zip files with Javascript",
       "primaryLanguage": "JavaScript",
       "starredAt": "2020-04-05T22:00:27Z"
@@ -6554,7 +6665,7 @@
     {
       "nameWithOwner": "joshwcomeau/use-sound",
       "url": "https://github.com/joshwcomeau/use-sound",
-      "stargazerCount": 2981,
+      "stargazerCount": 2986,
       "description": "A React Hook for playing sound effects",
       "primaryLanguage": "JavaScript",
       "starredAt": "2020-03-30T23:51:10Z"
@@ -6586,7 +6697,7 @@
     {
       "nameWithOwner": "BetterTyped/react-zoom-pan-pinch",
       "url": "https://github.com/BetterTyped/react-zoom-pan-pinch",
-      "stargazerCount": 1724,
+      "stargazerCount": 1729,
       "description": "🖼 React library to support easy zoom, pan, pinch on various html dom elements like <img> and <div>",
       "primaryLanguage": "TypeScript",
       "starredAt": "2020-03-19T01:32:39Z"
@@ -6602,7 +6713,7 @@
     {
       "nameWithOwner": "phillipi/pix2pix",
       "url": "https://github.com/phillipi/pix2pix",
-      "stargazerCount": 10470,
+      "stargazerCount": 10476,
       "description": "Image-to-image translation with conditional adversarial nets",
       "primaryLanguage": "Lua",
       "starredAt": "2020-03-13T04:00:52Z"
@@ -6610,7 +6721,7 @@
     {
       "nameWithOwner": "redwoodjs/graphql",
       "url": "https://github.com/redwoodjs/graphql",
-      "stargazerCount": 17642,
+      "stargazerCount": 17645,
       "description": "RedwoodGraphQL",
       "primaryLanguage": "TypeScript",
       "starredAt": "2020-03-12T03:47:18Z"
@@ -6618,7 +6729,7 @@
     {
       "nameWithOwner": "bartobri/no-more-secrets",
       "url": "https://github.com/bartobri/no-more-secrets",
-      "stargazerCount": 7662,
+      "stargazerCount": 7670,
       "description": "A command line tool that recreates the famous data decryption effect seen in the 1992 movie Sneakers.",
       "primaryLanguage": "C",
       "starredAt": "2020-03-11T22:42:39Z"
@@ -6642,7 +6753,7 @@
     {
       "nameWithOwner": "mattdesl/glsl-film-grain",
       "url": "https://github.com/mattdesl/glsl-film-grain",
-      "stargazerCount": 191,
+      "stargazerCount": 192,
       "description": "natural looking film grain using noise functions",
       "primaryLanguage": "JavaScript",
       "starredAt": "2020-03-11T10:34:24Z"
@@ -6650,7 +6761,7 @@
     {
       "nameWithOwner": "remy/nodemon",
       "url": "https://github.com/remy/nodemon",
-      "stargazerCount": 26596,
+      "stargazerCount": 26599,
       "description": "Monitor for any changes in your node.js application and automatically restart the server - perfect for development",
       "primaryLanguage": "JavaScript",
       "starredAt": "2020-03-10T09:48:22Z"
@@ -6658,7 +6769,7 @@
     {
       "nameWithOwner": "robinloeffel/cosha",
       "url": "https://github.com/robinloeffel/cosha",
-      "stargazerCount": 980,
+      "stargazerCount": 979,
       "description": "Colorful shadows for your images. 🎨",
       "primaryLanguage": "TypeScript",
       "starredAt": "2020-03-09T05:15:51Z"
@@ -6682,7 +6793,7 @@
     {
       "nameWithOwner": "inconvergent/inconvergent-sandbox",
       "url": "https://github.com/inconvergent/inconvergent-sandbox",
-      "stargazerCount": 119,
+      "stargazerCount": 120,
       "description": "Interactive demos written in p5.js",
       "primaryLanguage": "JavaScript",
       "starredAt": "2020-03-09T01:11:00Z"
@@ -6690,7 +6801,7 @@
     {
       "nameWithOwner": "inconvergent/differential-line",
       "url": "https://github.com/inconvergent/differential-line",
-      "stargazerCount": 690,
+      "stargazerCount": 692,
       "description": "a generative algorithm",
       "primaryLanguage": "Python",
       "starredAt": "2020-03-09T01:10:58Z"
@@ -6730,7 +6841,7 @@
     {
       "nameWithOwner": "Experience-Monks/nice-color-palettes",
       "url": "https://github.com/Experience-Monks/nice-color-palettes",
-      "stargazerCount": 953,
+      "stargazerCount": 952,
       "description": "nice colour palettes as JSON",
       "primaryLanguage": "JavaScript",
       "starredAt": "2020-03-05T21:42:30Z"
@@ -6738,7 +6849,7 @@
     {
       "nameWithOwner": "mattdesl/workshop-generative-art",
       "url": "https://github.com/mattdesl/workshop-generative-art",
-      "stargazerCount": 1384,
+      "stargazerCount": 1385,
       "description": "A workshop on creative coding & generative art",
       "primaryLanguage": "JavaScript",
       "starredAt": "2020-03-05T04:16:30Z"
@@ -6746,7 +6857,7 @@
     {
       "nameWithOwner": "antonioru/beautiful-react-hooks",
       "url": "https://github.com/antonioru/beautiful-react-hooks",
-      "stargazerCount": 8357,
+      "stargazerCount": 8362,
       "description": "🔥 A collection of beautiful and (hopefully) useful React hooks to speed-up your components and hooks development 🔥",
       "primaryLanguage": "JavaScript",
       "starredAt": "2020-03-05T03:32:50Z"
@@ -6754,7 +6865,7 @@
     {
       "nameWithOwner": "thi-ng/umbrella",
       "url": "https://github.com/thi-ng/umbrella",
-      "stargazerCount": 3615,
+      "stargazerCount": 3619,
       "description": "⛱  Broadly scoped ecosystem & mono-repository of 209 TypeScript projects (and ~185 examples) for general purpose, functional, data driven development",
       "primaryLanguage": "TypeScript",
       "starredAt": "2020-03-05T00:30:42Z"
@@ -6770,7 +6881,7 @@
     {
       "nameWithOwner": "erget/StereoVision",
       "url": "https://github.com/erget/StereoVision",
-      "stargazerCount": 687,
+      "stargazerCount": 690,
       "description": "Library and utilities for 3d reconstruction from stereo cameras.",
       "primaryLanguage": "Python",
       "starredAt": "2020-03-04T01:33:44Z"
@@ -6778,7 +6889,7 @@
     {
       "nameWithOwner": "P5-wrapper/react",
       "url": "https://github.com/P5-wrapper/react",
-      "stargazerCount": 534,
+      "stargazerCount": 535,
       "description": "A wrapper component that allows you to utilise P5 sketches within React apps.",
       "primaryLanguage": "TypeScript",
       "starredAt": "2020-03-03T04:53:41Z"
@@ -6786,7 +6897,7 @@
     {
       "nameWithOwner": "nvm-sh/nvm",
       "url": "https://github.com/nvm-sh/nvm",
-      "stargazerCount": 85988,
+      "stargazerCount": 86158,
       "description": "Node Version Manager - POSIX-compliant bash script to manage multiple active node.js versions",
       "primaryLanguage": "Shell",
       "starredAt": "2020-03-02T01:52:05Z"
@@ -6802,7 +6913,7 @@
     {
       "nameWithOwner": "MikeKovarik/exifr",
       "url": "https://github.com/MikeKovarik/exifr",
-      "stargazerCount": 1160,
+      "stargazerCount": 1165,
       "description": "📷 The fastest and most versatile JS EXIF reading library.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2020-02-28T01:43:32Z"
@@ -6818,7 +6929,7 @@
     {
       "nameWithOwner": "TanStack/query",
       "url": "https://github.com/TanStack/query",
-      "stargazerCount": 45960,
+      "stargazerCount": 46107,
       "description": "🤖 Powerful asynchronous state management, server-state utilities and data fetching for the web. TS/JS, React Query, Solid Query, Svelte Query and Vue Query.",
       "primaryLanguage": "TypeScript",
       "starredAt": "2020-02-27T00:36:43Z"
@@ -6834,7 +6945,7 @@
     {
       "nameWithOwner": "denoland/deno",
       "url": "https://github.com/denoland/deno",
-      "stargazerCount": 103675,
+      "stargazerCount": 103768,
       "description": "A modern runtime for JavaScript and TypeScript.",
       "primaryLanguage": "Rust",
       "starredAt": "2020-02-23T01:01:14Z"
@@ -6858,7 +6969,7 @@
     {
       "nameWithOwner": "stripe/react-stripe-js",
       "url": "https://github.com/stripe/react-stripe-js",
-      "stargazerCount": 1910,
+      "stargazerCount": 1924,
       "description": "React components for Stripe.js and Stripe Elements",
       "primaryLanguage": "TypeScript",
       "starredAt": "2020-02-21T23:21:07Z"
@@ -6866,7 +6977,7 @@
     {
       "nameWithOwner": "react-figma/react-figma",
       "url": "https://github.com/react-figma/react-figma",
-      "stargazerCount": 2635,
+      "stargazerCount": 2637,
       "description": "⚛️ A React renderer for Figma",
       "primaryLanguage": "TypeScript",
       "starredAt": "2020-02-21T10:20:59Z"
@@ -6874,7 +6985,7 @@
     {
       "nameWithOwner": "cssstats/cssstats",
       "url": "https://github.com/cssstats/cssstats",
-      "stargazerCount": 2823,
+      "stargazerCount": 2825,
       "description": "Visualize various stats about your CSS",
       "primaryLanguage": "JavaScript",
       "starredAt": "2020-02-21T02:24:52Z"
@@ -6890,7 +7001,7 @@
     {
       "nameWithOwner": "Jigsaw-Code/outline-apps",
       "url": "https://github.com/Jigsaw-Code/outline-apps",
-      "stargazerCount": 8822,
+      "stargazerCount": 8840,
       "description": "Outline Client and Manager, developed by Jigsaw. Outline Manager makes it easy to create your own VPN server. Outline Client lets you share access to your VPN with anyone in your network, giving them access to the free and open internet.",
       "primaryLanguage": "TypeScript",
       "starredAt": "2020-02-20T01:01:13Z"
@@ -6898,7 +7009,7 @@
     {
       "nameWithOwner": "Jigsaw-Code/outline-server",
       "url": "https://github.com/Jigsaw-Code/outline-server",
-      "stargazerCount": 6020,
+      "stargazerCount": 6034,
       "description": "Outline Server, developed by Jigsaw. The Outline Server is a proxy server that runs a Shadowsocks instance and provides a REST API for access key management.",
       "primaryLanguage": "TypeScript",
       "starredAt": "2020-02-20T01:01:12Z"
@@ -6914,7 +7025,7 @@
     {
       "nameWithOwner": "jpeg-js/jpeg-js",
       "url": "https://github.com/jpeg-js/jpeg-js",
-      "stargazerCount": 579,
+      "stargazerCount": 581,
       "description": "A pure javascript JPEG encoder and decoder for node.js",
       "primaryLanguage": "JavaScript",
       "starredAt": "2020-02-19T02:13:00Z"
@@ -6922,7 +7033,7 @@
     {
       "nameWithOwner": "americanexpress/jest-image-snapshot",
       "url": "https://github.com/americanexpress/jest-image-snapshot",
-      "stargazerCount": 3890,
+      "stargazerCount": 3892,
       "description": "✨ Jest matcher for image comparisons. Most commonly used for visual regression testing.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2020-02-18T23:48:37Z"
@@ -6930,7 +7041,7 @@
     {
       "nameWithOwner": "Secretmapper/react-image-annotation",
       "url": "https://github.com/Secretmapper/react-image-annotation",
-      "stargazerCount": 336,
+      "stargazerCount": 337,
       "description": " An infinitely customizable image annotation library built on React",
       "primaryLanguage": "JavaScript",
       "starredAt": "2020-02-18T10:44:49Z"
@@ -6938,7 +7049,7 @@
     {
       "nameWithOwner": "reduxjs/cra-template-redux",
       "url": "https://github.com/reduxjs/cra-template-redux",
-      "stargazerCount": 1268,
+      "stargazerCount": 1266,
       "description": "ARCHIVED: the CRA+JS template has moved to https://github.com/reduxjs/redux-templates",
       "primaryLanguage": "JavaScript",
       "starredAt": "2020-02-18T10:17:10Z"
@@ -6954,7 +7065,7 @@
     {
       "nameWithOwner": "NVlabs/PWC-Net",
       "url": "https://github.com/NVlabs/PWC-Net",
-      "stargazerCount": 1695,
+      "stargazerCount": 1696,
       "description": "PWC-Net: CNNs for Optical Flow Using Pyramid, Warping, and Cost Volume, CVPR 2018 (Oral)",
       "primaryLanguage": "Python",
       "starredAt": "2020-02-17T05:35:45Z"
@@ -6962,7 +7073,7 @@
     {
       "nameWithOwner": "deepspeedai/DeepSpeed",
       "url": "https://github.com/deepspeedai/DeepSpeed",
-      "stargazerCount": 39488,
+      "stargazerCount": 39582,
       "description": "DeepSpeed is a deep learning optimization library that makes distributed training and inference easy, efficient, and effective.",
       "primaryLanguage": "Python",
       "starredAt": "2020-02-17T05:31:32Z"
@@ -6970,7 +7081,7 @@
     {
       "nameWithOwner": "evanw/esbuild",
       "url": "https://github.com/evanw/esbuild",
-      "stargazerCount": 39149,
+      "stargazerCount": 39179,
       "description": "An extremely fast bundler for the web",
       "primaryLanguage": "Go",
       "starredAt": "2020-02-17T04:50:08Z"
@@ -6978,7 +7089,7 @@
     {
       "nameWithOwner": "fullcalendar/fullcalendar",
       "url": "https://github.com/fullcalendar/fullcalendar",
-      "stargazerCount": 19718,
+      "stargazerCount": 19771,
       "description": "Full-sized drag & drop event calendar in JavaScript",
       "primaryLanguage": "TypeScript",
       "starredAt": "2020-02-17T04:49:23Z"
@@ -6986,7 +7097,7 @@
     {
       "nameWithOwner": "bvaughn/react-window",
       "url": "https://github.com/bvaughn/react-window",
-      "stargazerCount": 16642,
+      "stargazerCount": 16669,
       "description": "React components for efficiently rendering large lists and tabular data",
       "primaryLanguage": "JavaScript",
       "starredAt": "2020-02-15T10:34:06Z"
@@ -7002,7 +7113,7 @@
     {
       "nameWithOwner": "unjs/defu",
       "url": "https://github.com/unjs/defu",
-      "stargazerCount": 1223,
+      "stargazerCount": 1231,
       "description": "🌊 Assign default properties recursively",
       "primaryLanguage": "TypeScript",
       "starredAt": "2020-02-13T00:02:32Z"
@@ -7034,7 +7145,7 @@
     {
       "nameWithOwner": "facebookresearch/meshrcnn",
       "url": "https://github.com/facebookresearch/meshrcnn",
-      "stargazerCount": 1156,
+      "stargazerCount": 1159,
       "description": "code for Mesh R-CNN, ICCV 2019",
       "primaryLanguage": "Python",
       "starredAt": "2020-02-07T01:35:34Z"
@@ -7042,7 +7153,7 @@
     {
       "nameWithOwner": "facebookresearch/pytorch3d",
       "url": "https://github.com/facebookresearch/pytorch3d",
-      "stargazerCount": 9401,
+      "stargazerCount": 9418,
       "description": "PyTorch3D is FAIR's library of reusable components for deep learning with 3D data",
       "primaryLanguage": "Python",
       "starredAt": "2020-02-07T01:33:58Z"
@@ -7050,7 +7161,7 @@
     {
       "nameWithOwner": "craffel/pretty-midi",
       "url": "https://github.com/craffel/pretty-midi",
-      "stargazerCount": 962,
+      "stargazerCount": 964,
       "description": "Utility functions for handling MIDI data in a nice/intuitive way.",
       "primaryLanguage": "Jupyter Notebook",
       "starredAt": "2020-02-07T01:01:31Z"
@@ -7066,7 +7177,7 @@
     {
       "nameWithOwner": "rorywalsh/cabbage",
       "url": "https://github.com/rorywalsh/cabbage",
-      "stargazerCount": 533,
+      "stargazerCount": 534,
       "description": "Framework for developing audio plugins with the Csound programming language.",
       "primaryLanguage": "C++",
       "starredAt": "2020-02-06T21:31:17Z"
@@ -7074,7 +7185,7 @@
     {
       "nameWithOwner": "csound/csound",
       "url": "https://github.com/csound/csound",
-      "stargazerCount": 1360,
+      "stargazerCount": 1358,
       "description": "Main repository for Csound",
       "primaryLanguage": "C",
       "starredAt": "2020-02-06T21:29:23Z"
@@ -7090,7 +7201,7 @@
     {
       "nameWithOwner": "NVIDIA/nvidia-container-runtime",
       "url": "https://github.com/NVIDIA/nvidia-container-runtime",
-      "stargazerCount": 1121,
+      "stargazerCount": 1122,
       "description": "NVIDIA container runtime",
       "primaryLanguage": null,
       "starredAt": "2020-02-05T03:08:24Z"
@@ -7114,7 +7225,7 @@
     {
       "nameWithOwner": "k3s-io/k3s",
       "url": "https://github.com/k3s-io/k3s",
-      "stargazerCount": 30286,
+      "stargazerCount": 30357,
       "description": "Lightweight Kubernetes",
       "primaryLanguage": "Go",
       "starredAt": "2020-01-31T04:12:21Z"
@@ -7122,7 +7233,7 @@
     {
       "nameWithOwner": "wesbos/awesome-uses",
       "url": "https://github.com/wesbos/awesome-uses",
-      "stargazerCount": 4682,
+      "stargazerCount": 4685,
       "description": "A list of /uses pages detailing developer setups, gear, software and configs.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2020-01-30T20:29:17Z"
@@ -7138,7 +7249,7 @@
     {
       "nameWithOwner": "kornia/kornia",
       "url": "https://github.com/kornia/kornia",
-      "stargazerCount": 10633,
+      "stargazerCount": 10654,
       "description": "🐍 Geometric Computer Vision Library for Spatial AI",
       "primaryLanguage": "Python",
       "starredAt": "2020-01-29T23:48:23Z"
@@ -7154,7 +7265,7 @@
     {
       "nameWithOwner": "tvillarete/ipod-classic-js",
       "url": "https://github.com/tvillarete/ipod-classic-js",
-      "stargazerCount": 1519,
+      "stargazerCount": 1522,
       "description": "An iPod Classic simulator that connects to Apple Music and Spotify. Built with React & Styled Components",
       "primaryLanguage": "TypeScript",
       "starredAt": "2020-01-29T22:38:48Z"
@@ -7162,7 +7273,7 @@
     {
       "nameWithOwner": "smallbets/userbase",
       "url": "https://github.com/smallbets/userbase",
-      "stargazerCount": 2310,
+      "stargazerCount": 2311,
       "description": "Create secure and private web apps using only static JavaScript, HTML, and CSS.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2020-01-29T04:42:29Z"
@@ -7170,7 +7281,7 @@
     {
       "nameWithOwner": "immerjs/immer",
       "url": "https://github.com/immerjs/immer",
-      "stargazerCount": 28500,
+      "stargazerCount": 28524,
       "description": "Create the next immutable state by mutating the current one",
       "primaryLanguage": "JavaScript",
       "starredAt": "2020-01-29T01:06:47Z"
@@ -7178,7 +7289,7 @@
     {
       "nameWithOwner": "reduxjs/redux-toolkit",
       "url": "https://github.com/reduxjs/redux-toolkit",
-      "stargazerCount": 11026,
+      "stargazerCount": 11034,
       "description": "The official, opinionated, batteries-included toolset for efficient Redux development",
       "primaryLanguage": "TypeScript",
       "starredAt": "2020-01-28T21:51:33Z"
@@ -7194,7 +7305,7 @@
     {
       "nameWithOwner": "anvaka/panzoom",
       "url": "https://github.com/anvaka/panzoom",
-      "stargazerCount": 1926,
+      "stargazerCount": 1929,
       "description": "Universal pan and zoom library (DOM, SVG, Custom)",
       "primaryLanguage": "JavaScript",
       "starredAt": "2020-01-27T21:52:44Z"
@@ -7218,7 +7329,7 @@
     {
       "nameWithOwner": "microsoft/playwright",
       "url": "https://github.com/microsoft/playwright",
-      "stargazerCount": 75147,
+      "stargazerCount": 75542,
       "description": "Playwright is a framework for Web Testing and Automation. It allows testing Chromium, Firefox and WebKit with a single API. ",
       "primaryLanguage": "TypeScript",
       "starredAt": "2020-01-23T22:42:27Z"
@@ -7234,7 +7345,7 @@
     {
       "nameWithOwner": "tldr-pages/tldr",
       "url": "https://github.com/tldr-pages/tldr",
-      "stargazerCount": 56513,
+      "stargazerCount": 58235,
       "description": "📚 Collaborative cheatsheets for console commands",
       "primaryLanguage": "Markdown",
       "starredAt": "2020-01-23T03:53:44Z"
@@ -7250,7 +7361,7 @@
     {
       "nameWithOwner": "uuidjs/uuid",
       "url": "https://github.com/uuidjs/uuid",
-      "stargazerCount": 15024,
+      "stargazerCount": 15035,
       "description": "Generate RFC-compliant UUIDs in JavaScript",
       "primaryLanguage": "TypeScript",
       "starredAt": "2020-01-23T03:23:35Z"
@@ -7290,7 +7401,7 @@
     {
       "nameWithOwner": "axa-group/Parsr",
       "url": "https://github.com/axa-group/Parsr",
-      "stargazerCount": 5988,
+      "stargazerCount": 5989,
       "description": "Transforms PDF, Documents and Images into Enriched Structured Data",
       "primaryLanguage": "JavaScript",
       "starredAt": "2020-01-21T22:58:19Z"
@@ -7306,7 +7417,7 @@
     {
       "nameWithOwner": "thobbs/genartlib",
       "url": "https://github.com/thobbs/genartlib",
-      "stargazerCount": 231,
+      "stargazerCount": 232,
       "description": "Utilities for creating generative artwork with Clojure",
       "primaryLanguage": "Clojure",
       "starredAt": "2020-01-20T23:53:23Z"
@@ -7346,7 +7457,7 @@
     {
       "nameWithOwner": "avinashpaliwal/Super-SloMo",
       "url": "https://github.com/avinashpaliwal/Super-SloMo",
-      "stargazerCount": 3023,
+      "stargazerCount": 3024,
       "description": "PyTorch implementation of Super SloMo by Jiang et al.",
       "primaryLanguage": "Python",
       "starredAt": "2020-01-17T01:50:24Z"
@@ -7378,7 +7489,7 @@
     {
       "nameWithOwner": "facebookresearch/SlowFast",
       "url": "https://github.com/facebookresearch/SlowFast",
-      "stargazerCount": 7031,
+      "stargazerCount": 7039,
       "description": "PySlowFast: video understanding codebase from FAIR for reproducing state-of-the-art video models.",
       "primaryLanguage": "Python",
       "starredAt": "2020-01-15T00:43:19Z"
@@ -7394,7 +7505,7 @@
     {
       "nameWithOwner": "gurkirt/realtime-action-detection",
       "url": "https://github.com/gurkirt/realtime-action-detection",
-      "stargazerCount": 321,
+      "stargazerCount": 320,
       "description": "This repository  host the code for real-time action detection paper ",
       "primaryLanguage": "MATLAB",
       "starredAt": "2020-01-15T00:40:34Z"
@@ -7410,7 +7521,7 @@
     {
       "nameWithOwner": "hoppscotch/hoppscotch",
       "url": "https://github.com/hoppscotch/hoppscotch",
-      "stargazerCount": 73128,
+      "stargazerCount": 73317,
       "description": "Open source API development ecosystem - https://hoppscotch.io (open-source alternative to Postman, Insomnia)",
       "primaryLanguage": "TypeScript",
       "starredAt": "2020-01-08T07:05:49Z"
@@ -7418,7 +7529,7 @@
     {
       "nameWithOwner": "lukehaas/RunJS",
       "url": "https://github.com/lukehaas/RunJS",
-      "stargazerCount": 2123,
+      "stargazerCount": 2124,
       "description": "RunJS is a JavaScript playground for macOS, Windows and Linux. Write code with instant feedback and access to Node.js and browser APIs.",
       "primaryLanguage": null,
       "starredAt": "2020-01-08T07:04:51Z"
@@ -7442,7 +7553,7 @@
     {
       "nameWithOwner": "coreui/coreui-icons",
       "url": "https://github.com/coreui/coreui-icons",
-      "stargazerCount": 2031,
+      "stargazerCount": 2033,
       "description": "CoreUI Free Icons -  Premium designed free icon set with marks in SVG, Webfont and raster formats",
       "primaryLanguage": "TypeScript",
       "starredAt": "2020-01-07T02:26:15Z"
@@ -7450,7 +7561,7 @@
     {
       "nameWithOwner": "mmazzarolo/ordinary-puzzles-app",
       "url": "https://github.com/mmazzarolo/ordinary-puzzles-app",
-      "stargazerCount": 493,
+      "stargazerCount": 494,
       "description": "Mobile and web puzzle game built with React-Native",
       "primaryLanguage": "TypeScript",
       "starredAt": "2019-12-22T22:24:54Z"
@@ -7474,7 +7585,7 @@
     {
       "nameWithOwner": "rawgraphs/rawgraphs-app",
       "url": "https://github.com/rawgraphs/rawgraphs-app",
-      "stargazerCount": 8822,
+      "stargazerCount": 8835,
       "description": "A web interface to create custom vector-based visualizations on top of RAWGraphs core",
       "primaryLanguage": "JavaScript",
       "starredAt": "2019-12-18T03:18:09Z"
@@ -7490,7 +7601,7 @@
     {
       "nameWithOwner": "AnswerDotAI/nbdev",
       "url": "https://github.com/AnswerDotAI/nbdev",
-      "stargazerCount": 5145,
+      "stargazerCount": 5154,
       "description": "Create delightful software with Jupyter Notebooks",
       "primaryLanguage": "Jupyter Notebook",
       "starredAt": "2019-12-18T01:16:43Z"
@@ -7498,7 +7609,7 @@
     {
       "nameWithOwner": "openlayers/openlayers",
       "url": "https://github.com/openlayers/openlayers",
-      "stargazerCount": 11993,
+      "stargazerCount": 12017,
       "description": "OpenLayers",
       "primaryLanguage": "JavaScript",
       "starredAt": "2019-12-16T06:16:41Z"
@@ -7530,7 +7641,7 @@
     {
       "nameWithOwner": "huggingface/transformers",
       "url": "https://github.com/huggingface/transformers",
-      "stargazerCount": 147391,
+      "stargazerCount": 147796,
       "description": "🤗 Transformers: the model-definition framework for state-of-the-art machine learning models in text, vision, audio, and multimodal models, for both inference and training. ",
       "primaryLanguage": "Python",
       "starredAt": "2019-11-19T02:22:36Z"
@@ -7546,7 +7657,7 @@
     {
       "nameWithOwner": "bberak/react-native-game-engine",
       "url": "https://github.com/bberak/react-native-game-engine",
-      "stargazerCount": 3028,
+      "stargazerCount": 3030,
       "description": "A lightweight Game Engine for React Native 🕹⚡🎮",
       "primaryLanguage": "JavaScript",
       "starredAt": "2019-11-19T01:31:26Z"
@@ -7554,7 +7665,7 @@
     {
       "nameWithOwner": "FormidableLabs/react-game-kit",
       "url": "https://github.com/FormidableLabs/react-game-kit",
-      "stargazerCount": 4622,
+      "stargazerCount": 4623,
       "description": "Component library for making games with React  & React Native",
       "primaryLanguage": "JavaScript",
       "starredAt": "2019-11-19T01:30:15Z"
@@ -7570,7 +7681,7 @@
     {
       "nameWithOwner": "xo/usql",
       "url": "https://github.com/xo/usql",
-      "stargazerCount": 9444,
+      "stargazerCount": 9469,
       "description": "Universal command-line interface for SQL databases",
       "primaryLanguage": "Go",
       "starredAt": "2019-11-18T01:49:07Z"
@@ -7578,7 +7689,7 @@
     {
       "nameWithOwner": "JustinBeckwith/linkinator",
       "url": "https://github.com/JustinBeckwith/linkinator",
-      "stargazerCount": 1078,
+      "stargazerCount": 1084,
       "description": "🐿 Scurry around your site and find all those broken links. ",
       "primaryLanguage": "TypeScript",
       "starredAt": "2019-11-15T03:09:56Z"
@@ -7594,7 +7705,7 @@
     {
       "nameWithOwner": "GoogleChromeLabs/react-adaptive-hooks",
       "url": "https://github.com/GoogleChromeLabs/react-adaptive-hooks",
-      "stargazerCount": 5143,
+      "stargazerCount": 5146,
       "description": "Deliver experiences best suited to a user's device and network constraints",
       "primaryLanguage": "JavaScript",
       "starredAt": "2019-11-12T07:54:19Z"
@@ -7602,7 +7713,7 @@
     {
       "nameWithOwner": "drawcall/Proton",
       "url": "https://github.com/drawcall/Proton",
-      "stargazerCount": 2461,
+      "stargazerCount": 2462,
       "description": "Javascript particle animation library",
       "primaryLanguage": "JavaScript",
       "starredAt": "2019-11-12T03:37:35Z"
@@ -7610,7 +7721,7 @@
     {
       "nameWithOwner": "tailwindlabs/tailwindcss-intellisense",
       "url": "https://github.com/tailwindlabs/tailwindcss-intellisense",
-      "stargazerCount": 3206,
+      "stargazerCount": 3220,
       "description": "Intelligent Tailwind CSS tooling for Visual Studio Code",
       "primaryLanguage": "TypeScript",
       "starredAt": "2019-11-11T06:55:26Z"
@@ -7626,7 +7737,7 @@
     {
       "nameWithOwner": "flatlogic/react-native-starter",
       "url": "https://github.com/flatlogic/react-native-starter",
-      "stargazerCount": 2382,
+      "stargazerCount": 2389,
       "description": "🚀A powerful react native starter template that bootstraps development of your mobile application ",
       "primaryLanguage": "JavaScript",
       "starredAt": "2019-11-07T03:40:34Z"
@@ -7650,7 +7761,7 @@
     {
       "nameWithOwner": "Lightning-AI/pytorch-lightning",
       "url": "https://github.com/Lightning-AI/pytorch-lightning",
-      "stargazerCount": 29851,
+      "stargazerCount": 29898,
       "description": "Pretrain, finetune ANY AI model of ANY size on multiple GPUs, TPUs with zero code changes.",
       "primaryLanguage": "Python",
       "starredAt": "2019-10-31T01:13:31Z"
@@ -7658,7 +7769,7 @@
     {
       "nameWithOwner": "facebookresearch/detectron2",
       "url": "https://github.com/facebookresearch/detectron2",
-      "stargazerCount": 32439,
+      "stargazerCount": 32496,
       "description": "Detectron2 is a platform for object detection, segmentation and other visual recognition tasks.",
       "primaryLanguage": "Python",
       "starredAt": "2019-10-30T23:38:43Z"
@@ -7666,7 +7777,7 @@
     {
       "nameWithOwner": "invertase/react-native-firebase",
       "url": "https://github.com/invertase/react-native-firebase",
-      "stargazerCount": 12017,
+      "stargazerCount": 12038,
       "description": "🔥 A well-tested feature-rich modular Firebase implementation for React Native. Supports both iOS & Android platforms for all Firebase services.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2019-10-30T06:55:32Z"
@@ -7674,7 +7785,7 @@
     {
       "nameWithOwner": "AlDanial/cloc",
       "url": "https://github.com/AlDanial/cloc",
-      "stargazerCount": 21380,
+      "stargazerCount": 21439,
       "description": "cloc counts blank lines, comment lines, and physical lines of source code in many programming languages.",
       "primaryLanguage": "Perl",
       "starredAt": "2019-10-30T06:01:13Z"
@@ -7698,7 +7809,7 @@
     {
       "nameWithOwner": "microsoft/computervision-recipes",
       "url": "https://github.com/microsoft/computervision-recipes",
-      "stargazerCount": 9727,
+      "stargazerCount": 9732,
       "description": "Best Practices, code samples, and documentation for Computer Vision.",
       "primaryLanguage": "Jupyter Notebook",
       "starredAt": "2019-10-29T04:45:41Z"
@@ -7706,7 +7817,7 @@
     {
       "nameWithOwner": "leeoniya/uPlot",
       "url": "https://github.com/leeoniya/uPlot",
-      "stargazerCount": 9267,
+      "stargazerCount": 9305,
       "description": "📈 A small, fast chart for time series, lines, areas, ohlc & bars",
       "primaryLanguage": "JavaScript",
       "starredAt": "2019-10-29T04:26:33Z"
@@ -7714,7 +7825,7 @@
     {
       "nameWithOwner": "mermaid-js/mermaid",
       "url": "https://github.com/mermaid-js/mermaid",
-      "stargazerCount": 81536,
+      "stargazerCount": 81800,
       "description": "Generation of diagrams like flowcharts or sequence diagrams from text in a similar manner as markdown",
       "primaryLanguage": "TypeScript",
       "starredAt": "2019-10-29T04:24:31Z"
@@ -7730,7 +7841,7 @@
     {
       "nameWithOwner": "vercel/swr",
       "url": "https://github.com/vercel/swr",
-      "stargazerCount": 31720,
+      "stargazerCount": 31763,
       "description": "React Hooks for Data Fetching",
       "primaryLanguage": "TypeScript",
       "starredAt": "2019-10-29T01:00:11Z"
@@ -7738,7 +7849,7 @@
     {
       "nameWithOwner": "fluent-ffmpeg/node-fluent-ffmpeg",
       "url": "https://github.com/fluent-ffmpeg/node-fluent-ffmpeg",
-      "stargazerCount": 8209,
+      "stargazerCount": 8210,
       "description": "A fluent API to FFMPEG (http://www.ffmpeg.org)",
       "primaryLanguage": "JavaScript",
       "starredAt": "2019-10-28T03:13:31Z"
@@ -7746,7 +7857,7 @@
     {
       "nameWithOwner": "ripienaar/free-for-dev",
       "url": "https://github.com/ripienaar/free-for-dev",
-      "stargazerCount": 107481,
+      "stargazerCount": 108426,
       "description": "A list of SaaS, PaaS and IaaS offerings that have free tiers of interest to devops and infradev",
       "primaryLanguage": "HTML",
       "starredAt": "2019-10-28T02:19:57Z"
@@ -7762,7 +7873,7 @@
     {
       "nameWithOwner": "expo/expo",
       "url": "https://github.com/expo/expo",
-      "stargazerCount": 41925,
+      "stargazerCount": 42124,
       "description": "An open-source framework for making universal native apps with React. Expo runs on Android, iOS, and the web.",
       "primaryLanguage": "TypeScript",
       "starredAt": "2019-10-26T22:47:21Z"
@@ -7778,7 +7889,7 @@
     {
       "nameWithOwner": "voidcosmos/npkill",
       "url": "https://github.com/voidcosmos/npkill",
-      "stargazerCount": 8664,
+      "stargazerCount": 8685,
       "description": "List any node_modules 📦 dir in your system and how heavy they are. You can then select which ones you want to erase to free up space 🧹",
       "primaryLanguage": "TypeScript",
       "starredAt": "2019-10-25T05:40:32Z"
@@ -7786,7 +7897,7 @@
     {
       "nameWithOwner": "simonwep/pickr",
       "url": "https://github.com/simonwep/pickr",
-      "stargazerCount": 4426,
+      "stargazerCount": 4428,
       "description": "🎨 Pickr - A simple, multi-themed, responsive and hackable Color-Picker library. No dependencies, no jQuery. Compatible with all CSS Frameworks e.g. Bootstrap, Materialize. Supports alpha channel, rgba, hsla, hsva and more!",
       "primaryLanguage": "JavaScript",
       "starredAt": "2019-10-25T05:40:02Z"
@@ -7794,7 +7905,7 @@
     {
       "nameWithOwner": "cloudflare/wrangler-action",
       "url": "https://github.com/cloudflare/wrangler-action",
-      "stargazerCount": 1539,
+      "stargazerCount": 1552,
       "description": "🧙‍♀️ easily deploy cloudflare workers applications using wrangler and github actions",
       "primaryLanguage": "TypeScript",
       "starredAt": "2019-10-25T03:18:09Z"
@@ -7810,7 +7921,7 @@
     {
       "nameWithOwner": "brunosimon/folio-2019",
       "url": "https://github.com/brunosimon/folio-2019",
-      "stargazerCount": 4507,
+      "stargazerCount": 4516,
       "description": "",
       "primaryLanguage": "JavaScript",
       "starredAt": "2019-10-24T22:44:00Z"
@@ -7834,7 +7945,7 @@
     {
       "nameWithOwner": "bbc/peaks.js",
       "url": "https://github.com/bbc/peaks.js",
-      "stargazerCount": 3313,
+      "stargazerCount": 3316,
       "description": "JavaScript UI component for interacting with audio waveforms",
       "primaryLanguage": "JavaScript",
       "starredAt": "2019-10-22T03:11:35Z"
@@ -7866,7 +7977,7 @@
     {
       "nameWithOwner": "mifi/lossless-cut",
       "url": "https://github.com/mifi/lossless-cut",
-      "stargazerCount": 32494,
+      "stargazerCount": 32663,
       "description": "The swiss army knife of lossless video/audio editing",
       "primaryLanguage": "TypeScript",
       "starredAt": "2019-10-21T05:35:17Z"
@@ -7874,7 +7985,7 @@
     {
       "nameWithOwner": "p0deje/Maccy",
       "url": "https://github.com/p0deje/Maccy",
-      "stargazerCount": 16035,
+      "stargazerCount": 16166,
       "description": "Lightweight clipboard manager for macOS",
       "primaryLanguage": "Swift",
       "starredAt": "2019-10-18T03:18:31Z"
@@ -7882,7 +7993,7 @@
     {
       "nameWithOwner": "leaflet-extras/leaflet-providers",
       "url": "https://github.com/leaflet-extras/leaflet-providers",
-      "stargazerCount": 2275,
+      "stargazerCount": 2280,
       "description": "An extension to Leaflet that contains configurations for various free tile providers.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2019-10-17T06:21:38Z"
@@ -7890,7 +8001,7 @@
     {
       "nameWithOwner": "tinacms/tinacms",
       "url": "https://github.com/tinacms/tinacms",
-      "stargazerCount": 12652,
+      "stargazerCount": 12664,
       "description": "A fully open-source headless CMS that supports Markdown and Visual Editing",
       "primaryLanguage": "TypeScript",
       "starredAt": "2019-10-17T04:03:58Z"
@@ -7906,7 +8017,7 @@
     {
       "nameWithOwner": "streamich/react-use",
       "url": "https://github.com/streamich/react-use",
-      "stargazerCount": 43298,
+      "stargazerCount": 43365,
       "description": "React Hooks — 👍",
       "primaryLanguage": "TypeScript",
       "starredAt": "2019-10-15T04:21:52Z"
@@ -7914,7 +8025,7 @@
     {
       "nameWithOwner": "kentcdodds/use-deep-compare-effect",
       "url": "https://github.com/kentcdodds/use-deep-compare-effect",
-      "stargazerCount": 1905,
+      "stargazerCount": 1907,
       "description": "🐋 It's react's useEffect hook, except using deep comparison on the inputs, not reference equality",
       "primaryLanguage": "TypeScript",
       "starredAt": "2019-10-15T03:23:36Z"
@@ -7922,7 +8033,7 @@
     {
       "nameWithOwner": "mourner/bullshit.js",
       "url": "https://github.com/mourner/bullshit.js",
-      "stargazerCount": 1876,
+      "stargazerCount": 1877,
       "description": "A bookmarklet for translating marketing speak into human-readable text. :poop:",
       "primaryLanguage": "JavaScript",
       "starredAt": "2019-10-15T03:10:21Z"
@@ -7930,7 +8041,7 @@
     {
       "nameWithOwner": "nostalgic-css/NES.css",
       "url": "https://github.com/nostalgic-css/NES.css",
-      "stargazerCount": 21207,
+      "stargazerCount": 21218,
       "description": "NES-style CSS Framework | ファミコン風CSSフレームワーク",
       "primaryLanguage": "SCSS",
       "starredAt": "2019-10-09T03:57:22Z"
@@ -7946,7 +8057,7 @@
     {
       "nameWithOwner": "testing-library/jest-dom",
       "url": "https://github.com/testing-library/jest-dom",
-      "stargazerCount": 4540,
+      "stargazerCount": 4543,
       "description": ":owl: Custom jest matchers to test the state of the DOM",
       "primaryLanguage": "JavaScript",
       "starredAt": "2019-10-09T02:08:03Z"
@@ -7962,7 +8073,7 @@
     {
       "nameWithOwner": "electron-react-boilerplate/electron-react-boilerplate",
       "url": "https://github.com/electron-react-boilerplate/electron-react-boilerplate",
-      "stargazerCount": 23925,
+      "stargazerCount": 23949,
       "description": "A Foundation for Scalable Cross-Platform Apps",
       "primaryLanguage": "TypeScript",
       "starredAt": "2019-10-04T01:54:17Z"
@@ -7970,7 +8081,7 @@
     {
       "nameWithOwner": "nodegui/nodegui",
       "url": "https://github.com/nodegui/nodegui",
-      "stargazerCount": 9105,
+      "stargazerCount": 9113,
       "description": "A library for building cross-platform native desktop applications with Node.js and CSS  🚀.  React NodeGui : https://react.nodegui.org and Vue NodeGui: https://vue.nodegui.org",
       "primaryLanguage": "C++",
       "starredAt": "2019-10-04T01:53:42Z"
@@ -7986,7 +8097,7 @@
     {
       "nameWithOwner": "firefly-iii/firefly-iii",
       "url": "https://github.com/firefly-iii/firefly-iii",
-      "stargazerCount": 19850,
+      "stargazerCount": 19957,
       "description": "Firefly III: a personal finances manager",
       "primaryLanguage": "PHP",
       "starredAt": "2019-10-03T03:17:03Z"
@@ -7994,7 +8105,7 @@
     {
       "nameWithOwner": "sindresorhus/p-map",
       "url": "https://github.com/sindresorhus/p-map",
-      "stargazerCount": 1438,
+      "stargazerCount": 1442,
       "description": "Map over promises concurrently",
       "primaryLanguage": "JavaScript",
       "starredAt": "2019-09-27T01:40:36Z"
@@ -8010,7 +8121,7 @@
     {
       "nameWithOwner": "gskinner/regexr",
       "url": "https://github.com/gskinner/regexr",
-      "stargazerCount": 10179,
+      "stargazerCount": 10190,
       "description": "RegExr is a HTML/JS based tool for creating, testing, and learning about Regular Expressions.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2019-09-26T03:53:26Z"
@@ -8018,7 +8129,7 @@
     {
       "nameWithOwner": "gpujs/gpu.js",
       "url": "https://github.com/gpujs/gpu.js",
-      "stargazerCount": 15285,
+      "stargazerCount": 15289,
       "description": "GPU Accelerated JavaScript",
       "primaryLanguage": "JavaScript",
       "starredAt": "2019-09-26T02:21:38Z"
@@ -8026,7 +8137,7 @@
     {
       "nameWithOwner": "nock/nock",
       "url": "https://github.com/nock/nock",
-      "stargazerCount": 12985,
+      "stargazerCount": 12992,
       "description": "HTTP server mocking and expectations library for Node.js",
       "primaryLanguage": "JavaScript",
       "starredAt": "2019-09-26T02:16:19Z"
@@ -8050,7 +8161,7 @@
     {
       "nameWithOwner": "stackbit/jamstackthemes",
       "url": "https://github.com/stackbit/jamstackthemes",
-      "stargazerCount": 622,
+      "stargazerCount": 624,
       "description": "A list of themes and starters for JAMstack sites.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2019-09-26T01:06:24Z"
@@ -8058,7 +8169,7 @@
     {
       "nameWithOwner": "fastify/fastify-auth",
       "url": "https://github.com/fastify/fastify-auth",
-      "stargazerCount": 370,
+      "stargazerCount": 371,
       "description": "Run multiple auth functions in Fastify",
       "primaryLanguage": "JavaScript",
       "starredAt": "2019-09-25T02:52:24Z"
@@ -8066,7 +8177,7 @@
     {
       "nameWithOwner": "soumak77/firebase-mock",
       "url": "https://github.com/soumak77/firebase-mock",
-      "stargazerCount": 351,
+      "stargazerCount": 352,
       "description": "Firebase mock library for writing unit tests",
       "primaryLanguage": "JavaScript",
       "starredAt": "2019-09-25T02:25:14Z"
@@ -8082,7 +8193,7 @@
     {
       "nameWithOwner": "swyxio/async-render-toolbox",
       "url": "https://github.com/swyxio/async-render-toolbox",
-      "stargazerCount": 318,
+      "stargazerCount": 319,
       "description": "BECAUSE PERFORMANCE SHOULD BE SEXY",
       "primaryLanguage": "JavaScript",
       "starredAt": "2019-09-22T19:58:55Z"
@@ -8090,7 +8201,7 @@
     {
       "nameWithOwner": "puppeteer/puppeteer",
       "url": "https://github.com/puppeteer/puppeteer",
-      "stargazerCount": 91240,
+      "stargazerCount": 91588,
       "description": "JavaScript API for Chrome and Firefox",
       "primaryLanguage": "TypeScript",
       "starredAt": "2019-09-19T06:58:38Z"
@@ -8098,7 +8209,7 @@
     {
       "nameWithOwner": "jest-community/vscode-jest",
       "url": "https://github.com/jest-community/vscode-jest",
-      "stargazerCount": 2879,
+      "stargazerCount": 2880,
       "description": "The optimal flow for Jest based testing in VS Code",
       "primaryLanguage": "TypeScript",
       "starredAt": "2019-09-19T03:08:56Z"
@@ -8106,7 +8217,7 @@
     {
       "nameWithOwner": "jestjs/jest",
       "url": "https://github.com/jestjs/jest",
-      "stargazerCount": 44912,
+      "stargazerCount": 44944,
       "description": "Delightful JavaScript Testing.",
       "primaryLanguage": "TypeScript",
       "starredAt": "2019-09-19T02:51:14Z"
@@ -8114,7 +8225,7 @@
     {
       "nameWithOwner": "testing-library/react-testing-library",
       "url": "https://github.com/testing-library/react-testing-library",
-      "stargazerCount": 19340,
+      "stargazerCount": 19346,
       "description": "🐐 Simple and complete React DOM testing utilities that encourage good testing practices.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2019-09-18T08:56:24Z"
@@ -8122,7 +8233,7 @@
     {
       "nameWithOwner": "ropensci/rredlist",
       "url": "https://github.com/ropensci/rredlist",
-      "stargazerCount": 55,
+      "stargazerCount": 58,
       "description": "IUCN Red List API Client",
       "primaryLanguage": "R",
       "starredAt": "2019-09-17T06:25:04Z"
@@ -8130,7 +8241,7 @@
     {
       "nameWithOwner": "nexxtway/react-rainbow",
       "url": "https://github.com/nexxtway/react-rainbow",
-      "stargazerCount": 1792,
+      "stargazerCount": 1791,
       "description": "🌈  React Rainbow Components. Build your web application in a snap.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2019-09-17T03:36:13Z"
@@ -8146,7 +8257,7 @@
     {
       "nameWithOwner": "TanStack/table",
       "url": "https://github.com/TanStack/table",
-      "stargazerCount": 26726,
+      "stargazerCount": 26788,
       "description": "🤖 Headless UI for building powerful tables & datagrids for TS/JS -  React-Table, Vue-Table, Solid-Table, Svelte-Table",
       "primaryLanguage": "TypeScript",
       "starredAt": "2019-09-13T21:58:16Z"
@@ -8154,7 +8265,7 @@
     {
       "nameWithOwner": "topojson/world-atlas",
       "url": "https://github.com/topojson/world-atlas",
-      "stargazerCount": 1092,
+      "stargazerCount": 1094,
       "description": "Pre-built TopoJSON from Natural Earth.",
       "primaryLanguage": "Shell",
       "starredAt": "2019-09-13T00:27:01Z"
@@ -8202,7 +8313,7 @@
     {
       "nameWithOwner": "qinwf/awesome-R",
       "url": "https://github.com/qinwf/awesome-R",
-      "stargazerCount": 6248,
+      "stargazerCount": 6252,
       "description": "A curated list of awesome R packages, frameworks and software.",
       "primaryLanguage": "R",
       "starredAt": "2019-09-12T03:42:36Z"
@@ -8210,7 +8321,7 @@
     {
       "nameWithOwner": "system-ui/theme-ui",
       "url": "https://github.com/system-ui/theme-ui",
-      "stargazerCount": 5354,
+      "stargazerCount": 5359,
       "description": "Build consistent, themeable React apps based on constraint-based design principles",
       "primaryLanguage": "TypeScript",
       "starredAt": "2019-09-11T03:21:05Z"
@@ -8226,7 +8337,7 @@
     {
       "nameWithOwner": "wri/gfw",
       "url": "https://github.com/wri/gfw",
-      "stargazerCount": 292,
+      "stargazerCount": 294,
       "description": "Global Forest Watch: An online, global, near-real time forest monitoring tool",
       "primaryLanguage": "JavaScript",
       "starredAt": "2019-09-10T23:49:08Z"
@@ -8258,7 +8369,7 @@
     {
       "nameWithOwner": "jrnl-org/jrnl",
       "url": "https://github.com/jrnl-org/jrnl",
-      "stargazerCount": 6764,
+      "stargazerCount": 6773,
       "description": "Collect your thoughts and notes without leaving the command line.",
       "primaryLanguage": "Python",
       "starredAt": "2019-09-09T04:19:57Z"
@@ -8266,7 +8377,7 @@
     {
       "nameWithOwner": "thumbsup/thumbsup",
       "url": "https://github.com/thumbsup/thumbsup",
-      "stargazerCount": 815,
+      "stargazerCount": 819,
       "description": "Generate static HTML photo / video galleries",
       "primaryLanguage": "JavaScript",
       "starredAt": "2019-09-08T09:06:03Z"
@@ -8282,7 +8393,7 @@
     {
       "nameWithOwner": "hello-efficiency-inc/raven-reader",
       "url": "https://github.com/hello-efficiency-inc/raven-reader",
-      "stargazerCount": 2793,
+      "stargazerCount": 2795,
       "description": "📖 All your articles in one place. Beautiful.",
       "primaryLanguage": "Vue",
       "starredAt": "2019-09-06T06:16:11Z"
@@ -8298,7 +8409,7 @@
     {
       "nameWithOwner": "chakra-ui/chakra-ui",
       "url": "https://github.com/chakra-ui/chakra-ui",
-      "stargazerCount": 39412,
+      "stargazerCount": 39453,
       "description": "Chakra UI is a component system for building SaaS products with speed ⚡️",
       "primaryLanguage": "TypeScript",
       "starredAt": "2019-09-05T07:46:40Z"
@@ -8306,7 +8417,7 @@
     {
       "nameWithOwner": "electron/fiddle",
       "url": "https://github.com/electron/fiddle",
-      "stargazerCount": 7600,
+      "stargazerCount": 7601,
       "description": ":electron: 🚀 The easiest way to get started with Electron",
       "primaryLanguage": "TypeScript",
       "starredAt": "2019-09-05T03:09:14Z"
@@ -8314,7 +8425,7 @@
     {
       "nameWithOwner": "sindresorhus/del",
       "url": "https://github.com/sindresorhus/del",
-      "stargazerCount": 1337,
+      "stargazerCount": 1338,
       "description": "Delete files and directories",
       "primaryLanguage": "JavaScript",
       "starredAt": "2019-09-04T23:07:07Z"
@@ -8322,7 +8433,7 @@
     {
       "nameWithOwner": "isaacs/rimraf",
       "url": "https://github.com/isaacs/rimraf",
-      "stargazerCount": 5785,
+      "stargazerCount": 5790,
       "description": "A `rm -rf` util for nodejs",
       "primaryLanguage": "TypeScript",
       "starredAt": "2019-09-04T23:05:47Z"
@@ -8330,7 +8441,7 @@
     {
       "nameWithOwner": "keystonejs/keystone",
       "url": "https://github.com/keystonejs/keystone",
-      "stargazerCount": 9632,
+      "stargazerCount": 9641,
       "description": "The superpowered headless CMS for Node.js — built with GraphQL and React",
       "primaryLanguage": "TypeScript",
       "starredAt": "2019-09-04T21:56:34Z"
@@ -8338,7 +8449,7 @@
     {
       "nameWithOwner": "steren/awesome-cloud-run",
       "url": "https://github.com/steren/awesome-cloud-run",
-      "stargazerCount": 856,
+      "stargazerCount": 857,
       "description": "👓 ⏩ A curated list of resources about all things Cloud Run",
       "primaryLanguage": "Dockerfile",
       "starredAt": "2019-09-04T21:17:18Z"
@@ -8346,7 +8457,7 @@
     {
       "nameWithOwner": "react-hook-form/react-hook-form",
       "url": "https://github.com/react-hook-form/react-hook-form",
-      "stargazerCount": 43535,
+      "stargazerCount": 43586,
       "description": "📋 React Hooks for form state management and validation (Web + React Native)",
       "primaryLanguage": "TypeScript",
       "starredAt": "2019-09-02T21:24:41Z"
@@ -8354,7 +8465,7 @@
     {
       "nameWithOwner": "infinitered/ignite",
       "url": "https://github.com/infinitered/ignite",
-      "stargazerCount": 18796,
+      "stargazerCount": 18829,
       "description": "Infinite Red's battle-tested React Native project boilerplate, along with a CLI, component/model generators, and more! 9 years of continuous development and counting.",
       "primaryLanguage": "TypeScript",
       "starredAt": "2019-09-02T07:01:03Z"
@@ -8362,7 +8473,7 @@
     {
       "nameWithOwner": "nushell/nushell",
       "url": "https://github.com/nushell/nushell",
-      "stargazerCount": 35840,
+      "stargazerCount": 35945,
       "description": "A new type of shell",
       "primaryLanguage": "Rust",
       "starredAt": "2019-09-02T06:25:22Z"
@@ -8378,7 +8489,7 @@
     {
       "nameWithOwner": "rnmapbox/maps",
       "url": "https://github.com/rnmapbox/maps",
-      "stargazerCount": 2551,
+      "stargazerCount": 2560,
       "description": "A Mapbox react native module for creating custom maps",
       "primaryLanguage": "Kotlin",
       "starredAt": "2019-08-31T22:53:52Z"
@@ -8386,7 +8497,7 @@
     {
       "nameWithOwner": "opendatacam/opendatacam",
       "url": "https://github.com/opendatacam/opendatacam",
-      "stargazerCount": 1673,
+      "stargazerCount": 1672,
       "description": "An open source tool to quantify the world",
       "primaryLanguage": "JavaScript",
       "starredAt": "2019-08-31T11:04:09Z"
@@ -8394,7 +8505,7 @@
     {
       "nameWithOwner": "sveltejs/svelte",
       "url": "https://github.com/sveltejs/svelte",
-      "stargazerCount": 83517,
+      "stargazerCount": 83610,
       "description": "web development for the rest of us",
       "primaryLanguage": "JavaScript",
       "starredAt": "2019-08-29T09:10:36Z"
@@ -8402,7 +8513,7 @@
     {
       "nameWithOwner": "lucagrulla/node-tail",
       "url": "https://github.com/lucagrulla/node-tail",
-      "stargazerCount": 467,
+      "stargazerCount": 468,
       "description": "The zero dependency Node.js module for tailing a file",
       "primaryLanguage": "JavaScript",
       "starredAt": "2019-08-29T04:33:36Z"
@@ -8410,7 +8521,7 @@
     {
       "nameWithOwner": "sindresorhus/delay",
       "url": "https://github.com/sindresorhus/delay",
-      "stargazerCount": 618,
+      "stargazerCount": 619,
       "description": "Delay a promise a specified amount of time",
       "primaryLanguage": "JavaScript",
       "starredAt": "2019-08-29T03:42:34Z"
@@ -8426,7 +8537,7 @@
     {
       "nameWithOwner": "sindresorhus/p-throttle",
       "url": "https://github.com/sindresorhus/p-throttle",
-      "stargazerCount": 484,
+      "stargazerCount": 485,
       "description": "Throttle promise-returning & async functions",
       "primaryLanguage": "JavaScript",
       "starredAt": "2019-08-27T06:44:28Z"
@@ -8458,7 +8569,7 @@
     {
       "nameWithOwner": "mourner/simplify-js",
       "url": "https://github.com/mourner/simplify-js",
-      "stargazerCount": 2350,
+      "stargazerCount": 2353,
       "description": "High-performance JavaScript polyline simplification library",
       "primaryLanguage": "JavaScript",
       "starredAt": "2019-08-26T04:50:55Z"
@@ -8474,7 +8585,7 @@
     {
       "nameWithOwner": "google-ai-edge/mediapipe",
       "url": "https://github.com/google-ai-edge/mediapipe",
-      "stargazerCount": 30746,
+      "stargazerCount": 30872,
       "description": "Cross-platform, customizable ML solutions for live and streaming media.",
       "primaryLanguage": "C++",
       "starredAt": "2019-08-23T10:51:55Z"
@@ -8490,7 +8601,7 @@
     {
       "nameWithOwner": "urql-graphql/urql",
       "url": "https://github.com/urql-graphql/urql",
-      "stargazerCount": 8829,
+      "stargazerCount": 8834,
       "description": "The highly customizable and versatile GraphQL client with which you add on features like normalized caching as you grow.",
       "primaryLanguage": "TypeScript",
       "starredAt": "2019-08-23T09:56:36Z"
@@ -8498,7 +8609,7 @@
     {
       "nameWithOwner": "knative/docs",
       "url": "https://github.com/knative/docs",
-      "stargazerCount": 4804,
+      "stargazerCount": 4813,
       "description": "User documentation for Knative components.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2019-08-23T03:43:44Z"
@@ -8506,7 +8617,7 @@
     {
       "nameWithOwner": "ahmetb/cloud-run-faq",
       "url": "https://github.com/ahmetb/cloud-run-faq",
-      "stargazerCount": 2335,
+      "stargazerCount": 2337,
       "description": "Unofficial FAQ and everything you've been wondering about Google Cloud Run.",
       "primaryLanguage": "Shell",
       "starredAt": "2019-08-22T09:17:42Z"
@@ -8538,7 +8649,7 @@
     {
       "nameWithOwner": "sdras/ecommerce-netlify",
       "url": "https://github.com/sdras/ecommerce-netlify",
-      "stargazerCount": 1557,
+      "stargazerCount": 1558,
       "description": "🛍 A JAMstack Ecommerce Site built with Nuxt and Netlify Functions",
       "primaryLanguage": "Vue",
       "starredAt": "2019-08-20T20:33:26Z"
@@ -8554,7 +8665,7 @@
     {
       "nameWithOwner": "donnemartin/system-design-primer",
       "url": "https://github.com/donnemartin/system-design-primer",
-      "stargazerCount": 312747,
+      "stargazerCount": 314089,
       "description": "Learn how to design large-scale systems. Prep for the system design interview.  Includes Anki flashcards.",
       "primaryLanguage": "Python",
       "starredAt": "2019-08-19T08:28:37Z"
@@ -8562,7 +8673,7 @@
     {
       "nameWithOwner": "DavidWells/analytics",
       "url": "https://github.com/DavidWells/analytics",
-      "stargazerCount": 2579,
+      "stargazerCount": 2582,
       "description": " Lightweight analytics abstraction layer for tracking page views, custom events, & identifying visitors         ",
       "primaryLanguage": "JavaScript",
       "starredAt": "2019-08-16T21:37:36Z"
@@ -8578,7 +8689,7 @@
     {
       "nameWithOwner": "volta-cli/volta",
       "url": "https://github.com/volta-cli/volta",
-      "stargazerCount": 12201,
+      "stargazerCount": 12233,
       "description": "Volta: JS Toolchains as Code. ⚡",
       "primaryLanguage": "Rust",
       "starredAt": "2019-08-16T09:57:14Z"
@@ -8594,7 +8705,7 @@
     {
       "nameWithOwner": "iamkun/dayjs",
       "url": "https://github.com/iamkun/dayjs",
-      "stargazerCount": 48011,
+      "stargazerCount": 48045,
       "description": "⏰ Day.js 2kB immutable date-time library alternative to Moment.js with the same modern API",
       "primaryLanguage": "JavaScript",
       "starredAt": "2019-08-16T00:18:14Z"
@@ -8626,7 +8737,7 @@
     {
       "nameWithOwner": "sdras/awesome-actions",
       "url": "https://github.com/sdras/awesome-actions",
-      "stargazerCount": 26471,
+      "stargazerCount": 26511,
       "description": "A curated list of awesome actions to use on GitHub",
       "primaryLanguage": null,
       "starredAt": "2019-08-14T07:16:14Z"
@@ -8650,7 +8761,7 @@
     {
       "nameWithOwner": "race2infinity/The-Documentation-Compendium",
       "url": "https://github.com/race2infinity/The-Documentation-Compendium",
-      "stargazerCount": 5762,
+      "stargazerCount": 5768,
       "description": "📢 Various README templates & tips on writing high-quality documentation that people want to read.",
       "primaryLanguage": null,
       "starredAt": "2019-08-13T10:38:31Z"
@@ -8674,7 +8785,7 @@
     {
       "nameWithOwner": "jinwchoi/awesome-action-recognition",
       "url": "https://github.com/jinwchoi/awesome-action-recognition",
-      "stargazerCount": 3917,
+      "stargazerCount": 3920,
       "description": "A curated list of action recognition and related area resources",
       "primaryLanguage": null,
       "starredAt": "2019-08-13T04:40:53Z"
@@ -8714,7 +8825,7 @@
     {
       "nameWithOwner": "HumanSignal/label-studio",
       "url": "https://github.com/HumanSignal/label-studio",
-      "stargazerCount": 23491,
+      "stargazerCount": 24022,
       "description": "Label Studio is a multi-type data labeling and annotation tool with standardized output format",
       "primaryLanguage": "JavaScript",
       "starredAt": "2019-08-12T07:33:01Z"
@@ -8722,7 +8833,7 @@
     {
       "nameWithOwner": "cookpete/auto-changelog",
       "url": "https://github.com/cookpete/auto-changelog",
-      "stargazerCount": 1345,
+      "stargazerCount": 1350,
       "description": "Command line tool for generating a changelog from git tags and commit history",
       "primaryLanguage": "JavaScript",
       "starredAt": "2019-08-12T02:41:22Z"
@@ -8730,7 +8841,7 @@
     {
       "nameWithOwner": "Swizec/useAuth",
       "url": "https://github.com/Swizec/useAuth",
-      "stargazerCount": 2585,
+      "stargazerCount": 2587,
       "description": "The simplest way to add authentication to your React app. Supports various providers.",
       "primaryLanguage": "TypeScript",
       "starredAt": "2019-08-10T12:00:42Z"
@@ -8738,7 +8849,7 @@
     {
       "nameWithOwner": "statelyai/xstate",
       "url": "https://github.com/statelyai/xstate",
-      "stargazerCount": 28515,
+      "stargazerCount": 28564,
       "description": "Actor-based state management & orchestration for complex app logic.",
       "primaryLanguage": "TypeScript",
       "starredAt": "2019-08-10T10:02:20Z"
@@ -8754,7 +8865,7 @@
     {
       "nameWithOwner": "sindresorhus/promise-fun",
       "url": "https://github.com/sindresorhus/promise-fun",
-      "stargazerCount": 4985,
+      "stargazerCount": 4990,
       "description": "Promise packages, patterns, chat, and tutorials",
       "primaryLanguage": null,
       "starredAt": "2019-08-09T01:21:30Z"
@@ -8770,7 +8881,7 @@
     {
       "nameWithOwner": "jaredly/qmoji",
       "url": "https://github.com/jaredly/qmoji",
-      "stargazerCount": 296,
+      "stargazerCount": 297,
       "description": "🙃 Like mojibar, but written in swift",
       "primaryLanguage": "Swift",
       "starredAt": "2019-08-06T07:49:04Z"
@@ -8778,7 +8889,7 @@
     {
       "nameWithOwner": "cutenode/1x.engineer",
       "url": "https://github.com/cutenode/1x.engineer",
-      "stargazerCount": 2098,
+      "stargazerCount": 2099,
       "description": "The official website of 1x Engineers around the world",
       "primaryLanguage": null,
       "starredAt": "2019-08-06T01:02:21Z"
@@ -8786,7 +8897,7 @@
     {
       "nameWithOwner": "httpcats/http.cat",
       "url": "https://github.com/httpcats/http.cat",
-      "stargazerCount": 3269,
+      "stargazerCount": 3283,
       "description": ":cat: HTTP Cats API",
       "primaryLanguage": "TypeScript",
       "starredAt": "2019-08-05T06:49:34Z"
@@ -8810,7 +8921,7 @@
     {
       "nameWithOwner": "johan/world.geo.json",
       "url": "https://github.com/johan/world.geo.json",
-      "stargazerCount": 2135,
+      "stargazerCount": 2138,
       "description": "Annotated geo-json geometry files for the world",
       "primaryLanguage": null,
       "starredAt": "2019-08-05T00:45:12Z"
@@ -8834,7 +8945,7 @@
     {
       "nameWithOwner": "chentsulin/awesome-graphql",
       "url": "https://github.com/chentsulin/awesome-graphql",
-      "stargazerCount": 14784,
+      "stargazerCount": 14785,
       "description": "Awesome list of GraphQL",
       "primaryLanguage": null,
       "starredAt": "2019-08-01T00:31:27Z"
@@ -8850,7 +8961,7 @@
     {
       "nameWithOwner": "sindresorhus/pretty-ms",
       "url": "https://github.com/sindresorhus/pretty-ms",
-      "stargazerCount": 1166,
+      "stargazerCount": 1167,
       "description": "Convert milliseconds to a human readable string: `1337000000` → `15d 11h 23m 20s`",
       "primaryLanguage": "JavaScript",
       "starredAt": "2019-07-31T01:59:37Z"
@@ -8866,7 +8977,7 @@
     {
       "nameWithOwner": "SortableJS/Sortable",
       "url": "https://github.com/SortableJS/Sortable",
-      "stargazerCount": 30581,
+      "stargazerCount": 30607,
       "description": "Reorderable drag-and-drop lists for modern browsers and touch devices. No jQuery or framework required.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2019-07-23T07:06:17Z"
@@ -8874,7 +8985,7 @@
     {
       "nameWithOwner": "jimp-dev/jimp",
       "url": "https://github.com/jimp-dev/jimp",
-      "stargazerCount": 14426,
+      "stargazerCount": 14443,
       "description": "An image processing library written entirely in JavaScript for Node, with zero external or native dependencies.",
       "primaryLanguage": "TypeScript",
       "starredAt": "2019-07-23T02:31:27Z"
@@ -8882,7 +8993,7 @@
     {
       "nameWithOwner": "EvanHahn/HumanizeDuration.js",
       "url": "https://github.com/EvanHahn/HumanizeDuration.js",
-      "stargazerCount": 1698,
+      "stargazerCount": 1700,
       "description": "361000 becomes \"6 minutes, 1 second\"",
       "primaryLanguage": "JavaScript",
       "starredAt": "2019-07-23T02:21:40Z"
@@ -8890,7 +9001,7 @@
     {
       "nameWithOwner": "chrisveness/geodesy",
       "url": "https://github.com/chrisveness/geodesy",
-      "stargazerCount": 1199,
+      "stargazerCount": 1201,
       "description": "Libraries of geodesy functions implemented in JavaScript",
       "primaryLanguage": "JavaScript",
       "starredAt": "2019-07-23T02:21:28Z"
@@ -8898,7 +9009,7 @@
     {
       "nameWithOwner": "paulrosen/abcjs",
       "url": "https://github.com/paulrosen/abcjs",
-      "stargazerCount": 2102,
+      "stargazerCount": 2106,
       "description": "javascript for rendering abc music notation",
       "primaryLanguage": "HTML",
       "starredAt": "2019-07-23T02:20:39Z"
@@ -8906,7 +9017,7 @@
     {
       "nameWithOwner": "surveyjs/survey-library",
       "url": "https://github.com/surveyjs/survey-library",
-      "stargazerCount": 4495,
+      "stargazerCount": 4510,
       "description": "Free JavaScript form builder library with integration for React, Angular, Vue, jQuery, and Knockout.",
       "primaryLanguage": "TypeScript",
       "starredAt": "2019-07-22T04:25:41Z"
@@ -8914,7 +9025,7 @@
     {
       "nameWithOwner": "rwaldron/johnny-five",
       "url": "https://github.com/rwaldron/johnny-five",
-      "stargazerCount": 13368,
+      "stargazerCount": 13369,
       "description": "JavaScript Robotics and IoT programming framework, developed at Bocoup.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2019-07-22T04:25:09Z"
@@ -8930,7 +9041,7 @@
     {
       "nameWithOwner": "knative/serving",
       "url": "https://github.com/knative/serving",
-      "stargazerCount": 5793,
+      "stargazerCount": 5800,
       "description": "Kubernetes-based, scale-to-zero, request-driven compute",
       "primaryLanguage": "Go",
       "starredAt": "2019-07-17T11:21:14Z"
@@ -8946,7 +9057,7 @@
     {
       "nameWithOwner": "fnproject/fn",
       "url": "https://github.com/fnproject/fn",
-      "stargazerCount": 5842,
+      "stargazerCount": 5849,
       "description": "The container native, cloud agnostic serverless platform.",
       "primaryLanguage": "Go",
       "starredAt": "2019-07-16T23:12:38Z"
@@ -8954,7 +9065,7 @@
     {
       "nameWithOwner": "kubernetes/kubernetes",
       "url": "https://github.com/kubernetes/kubernetes",
-      "stargazerCount": 116487,
+      "stargazerCount": 116654,
       "description": "Production-Grade Container Scheduling and Management",
       "primaryLanguage": "Go",
       "starredAt": "2019-07-16T23:11:17Z"
@@ -8962,7 +9073,7 @@
     {
       "nameWithOwner": "openfaas/openfaas-cloud",
       "url": "https://github.com/openfaas/openfaas-cloud",
-      "stargazerCount": 771,
+      "stargazerCount": 772,
       "description": "The Multi-user OpenFaaS Platform",
       "primaryLanguage": "Go",
       "starredAt": "2019-07-16T22:40:00Z"
@@ -8994,7 +9105,7 @@
     {
       "nameWithOwner": "opendatacube/datacube-core",
       "url": "https://github.com/opendatacube/datacube-core",
-      "stargazerCount": 544,
+      "stargazerCount": 545,
       "description": "Open Data Cube analyses continental scale Earth Observation data through time",
       "primaryLanguage": "Python",
       "starredAt": "2019-07-15T01:49:32Z"
@@ -9010,7 +9121,7 @@
     {
       "nameWithOwner": "dougmoscrop/serverless-http",
       "url": "https://github.com/dougmoscrop/serverless-http",
-      "stargazerCount": 1763,
+      "stargazerCount": 1762,
       "description": "Use your existing middleware framework (e.g. Express, Koa) in AWS Lambda 🎉",
       "primaryLanguage": "JavaScript",
       "starredAt": "2019-07-14T09:07:48Z"
@@ -9018,7 +9129,7 @@
     {
       "nameWithOwner": "kitze/react-hanger",
       "url": "https://github.com/kitze/react-hanger",
-      "stargazerCount": 1932,
+      "stargazerCount": 1933,
       "description": "A collection of useful React hooks ",
       "primaryLanguage": "TypeScript",
       "starredAt": "2019-07-13T06:23:51Z"
@@ -9034,7 +9145,7 @@
     {
       "nameWithOwner": "motiondivision/motion",
       "url": "https://github.com/motiondivision/motion",
-      "stargazerCount": 29251,
+      "stargazerCount": 29354,
       "description": "A modern animation library for React and JavaScript",
       "primaryLanguage": "TypeScript",
       "starredAt": "2019-07-13T00:46:52Z"
@@ -9042,7 +9153,7 @@
     {
       "nameWithOwner": "sindresorhus/p-queue",
       "url": "https://github.com/sindresorhus/p-queue",
-      "stargazerCount": 3781,
+      "stargazerCount": 3793,
       "description": "Promise queue with concurrency control",
       "primaryLanguage": "TypeScript",
       "starredAt": "2019-07-11T07:50:28Z"
@@ -9050,7 +9161,7 @@
     {
       "nameWithOwner": "OptimalBits/bull",
       "url": "https://github.com/OptimalBits/bull",
-      "stargazerCount": 16043,
+      "stargazerCount": 16059,
       "description": "Premium Queue package for handling distributed jobs and messages in NodeJS.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2019-07-11T07:10:24Z"
@@ -9090,7 +9201,7 @@
     {
       "nameWithOwner": "bentoml/BentoML",
       "url": "https://github.com/bentoml/BentoML",
-      "stargazerCount": 7916,
+      "stargazerCount": 7949,
       "description": "The easiest way to serve AI apps and models - Build Model Inference APIs, Job queues, LLM apps, Multi-model pipelines, and more!",
       "primaryLanguage": "Python",
       "starredAt": "2019-07-10T10:04:03Z"
@@ -9098,7 +9209,7 @@
     {
       "nameWithOwner": "paulmillr/chokidar",
       "url": "https://github.com/paulmillr/chokidar",
-      "stargazerCount": 11523,
+      "stargazerCount": 11539,
       "description": "Minimal and efficient cross-platform file watching library",
       "primaryLanguage": "TypeScript",
       "starredAt": "2019-07-10T04:10:01Z"
@@ -9114,7 +9225,7 @@
     {
       "nameWithOwner": "stackshareio/awesome-stacks",
       "url": "https://github.com/stackshareio/awesome-stacks",
-      "stargazerCount": 3716,
+      "stargazerCount": 3720,
       "description": "A curated list of tech stacks for building different applications & features",
       "primaryLanguage": "JavaScript",
       "starredAt": "2019-07-03T04:03:18Z"
@@ -9122,7 +9233,7 @@
     {
       "nameWithOwner": "joyeecheung/dark-channel-prior-dehazing",
       "url": "https://github.com/joyeecheung/dark-channel-prior-dehazing",
-      "stargazerCount": 85,
+      "stargazerCount": 84,
       "description": "Python implementation of \"Single Image Haze Removal Using Dark Channel Prior\"",
       "primaryLanguage": "TeX",
       "starredAt": "2019-07-03T01:40:24Z"
@@ -9170,7 +9281,7 @@
     {
       "nameWithOwner": "nuclio/nuclio",
       "url": "https://github.com/nuclio/nuclio",
-      "stargazerCount": 5512,
+      "stargazerCount": 5521,
       "description": "High-Performance Serverless event and data processing platform",
       "primaryLanguage": "Go",
       "starredAt": "2019-07-01T23:13:41Z"
@@ -9178,7 +9289,7 @@
     {
       "nameWithOwner": "openfaas/faas",
       "url": "https://github.com/openfaas/faas",
-      "stargazerCount": 25790,
+      "stargazerCount": 25812,
       "description": "OpenFaaS - Serverless Functions Made Simple",
       "primaryLanguage": "Go",
       "starredAt": "2019-07-01T11:24:56Z"
@@ -9186,7 +9297,7 @@
     {
       "nameWithOwner": "kedacore/keda",
       "url": "https://github.com/kedacore/keda",
-      "stargazerCount": 9280,
+      "stargazerCount": 9309,
       "description": " KEDA is a Kubernetes-based Event Driven Autoscaling component. It provides event driven scale for any container running in Kubernetes ",
       "primaryLanguage": "Go",
       "starredAt": "2019-07-01T10:43:13Z"
@@ -9210,7 +9321,7 @@
     {
       "nameWithOwner": "fission/fission",
       "url": "https://github.com/fission/fission",
-      "stargazerCount": 8703,
+      "stargazerCount": 8710,
       "description": "Fast and Simple Serverless Functions for Kubernetes",
       "primaryLanguage": "Go",
       "starredAt": "2019-07-01T09:20:31Z"
@@ -9218,7 +9329,7 @@
     {
       "nameWithOwner": "Kong/insomnia",
       "url": "https://github.com/Kong/insomnia",
-      "stargazerCount": 36772,
+      "stargazerCount": 36851,
       "description": "The open-source, cross-platform API client for GraphQL, REST, WebSockets, SSE and gRPC. With Cloud, Local and Git storage.",
       "primaryLanguage": "TypeScript",
       "starredAt": "2019-07-01T08:45:14Z"
@@ -9226,7 +9337,7 @@
     {
       "nameWithOwner": "kubernetes/minikube",
       "url": "https://github.com/kubernetes/minikube",
-      "stargazerCount": 30725,
+      "stargazerCount": 30752,
       "description": "Run Kubernetes locally",
       "primaryLanguage": "Go",
       "starredAt": "2019-07-01T05:25:23Z"
@@ -9234,7 +9345,7 @@
     {
       "nameWithOwner": "foolwood/SiamMask",
       "url": "https://github.com/foolwood/SiamMask",
-      "stargazerCount": 3515,
+      "stargazerCount": 3517,
       "description": "[CVPR19/TPAMI23] SiamMask: A Framework for Fast Online Object Tracking and Segmentation",
       "primaryLanguage": "Python",
       "starredAt": "2019-07-01T04:01:51Z"
@@ -9242,7 +9353,7 @@
     {
       "nameWithOwner": "helm/helm",
       "url": "https://github.com/helm/helm",
-      "stargazerCount": 28263,
+      "stargazerCount": 28299,
       "description": "The Kubernetes Package Manager",
       "primaryLanguage": "Go",
       "starredAt": "2019-07-01T01:18:30Z"
@@ -9250,7 +9361,7 @@
     {
       "nameWithOwner": "minio/minio",
       "url": "https://github.com/minio/minio",
-      "stargazerCount": 53955,
+      "stargazerCount": 54296,
       "description": "MinIO is a high-performance, S3 compatible object store, open sourced under GNU AGPLv3 license.",
       "primaryLanguage": "Go",
       "starredAt": "2019-07-01T01:15:07Z"
@@ -9258,7 +9369,7 @@
     {
       "nameWithOwner": "vmware-archive/kubeless",
       "url": "https://github.com/vmware-archive/kubeless",
-      "stargazerCount": 6869,
+      "stargazerCount": 6872,
       "description": "Kubernetes Native Serverless Framework",
       "primaryLanguage": "Go",
       "starredAt": "2019-07-01T01:14:15Z"
@@ -9274,7 +9385,7 @@
     {
       "nameWithOwner": "fastify/fastify-swagger",
       "url": "https://github.com/fastify/fastify-swagger",
-      "stargazerCount": 1011,
+      "stargazerCount": 1015,
       "description": "Swagger documentation generator for Fastify",
       "primaryLanguage": "JavaScript",
       "starredAt": "2019-06-30T07:07:22Z"
@@ -9282,7 +9393,7 @@
     {
       "nameWithOwner": "spec-first/connexion",
       "url": "https://github.com/spec-first/connexion",
-      "stargazerCount": 4553,
+      "stargazerCount": 4555,
       "description": "Connexion is a modern Python web framework that makes spec-first and api-first development easy.",
       "primaryLanguage": "Python",
       "starredAt": "2019-06-30T01:35:38Z"
@@ -9306,7 +9417,7 @@
     {
       "nameWithOwner": "opencv/opencv",
       "url": "https://github.com/opencv/opencv",
-      "stargazerCount": 83203,
+      "stargazerCount": 83347,
       "description": "Open Source Computer Vision Library",
       "primaryLanguage": "C++",
       "starredAt": "2019-06-29T00:28:43Z"
@@ -9314,7 +9425,7 @@
     {
       "nameWithOwner": "cvat-ai/cvat",
       "url": "https://github.com/cvat-ai/cvat",
-      "stargazerCount": 14115,
+      "stargazerCount": 14172,
       "description": "Annotate better with CVAT, the industry-leading data engine for machine learning. Used and trusted by teams at any scale, for data of any scale.",
       "primaryLanguage": "Python",
       "starredAt": "2019-06-29T00:16:05Z"
@@ -9330,7 +9441,7 @@
     {
       "nameWithOwner": "VIAME/VIAME",
       "url": "https://github.com/VIAME/VIAME",
-      "stargazerCount": 308,
+      "stargazerCount": 309,
       "description": "Video and Image Analytics for Multiple Environments",
       "primaryLanguage": "Python",
       "starredAt": "2019-06-26T18:41:00Z"
@@ -9354,7 +9465,7 @@
     {
       "nameWithOwner": "microsoft/just",
       "url": "https://github.com/microsoft/just",
-      "stargazerCount": 1970,
+      "stargazerCount": 1972,
       "description": "The task library that just works",
       "primaryLanguage": "TypeScript",
       "starredAt": "2019-06-26T02:34:36Z"
@@ -9362,7 +9473,7 @@
     {
       "nameWithOwner": "pydoit/doit",
       "url": "https://github.com/pydoit/doit",
-      "stargazerCount": 1954,
+      "stargazerCount": 1955,
       "description": "CLI task management & automation tool",
       "primaryLanguage": "Python",
       "starredAt": "2019-06-25T20:59:43Z"
@@ -9370,7 +9481,7 @@
     {
       "nameWithOwner": "jspreadsheet/ce",
       "url": "https://github.com/jspreadsheet/ce",
-      "stargazerCount": 6954,
+      "stargazerCount": 6966,
       "description": "Jspreadsheet is a lightweight JavaScript data grid component for creating interactive data grids with advanced spreadsheet controls.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2019-06-21T07:54:04Z"
@@ -9378,7 +9489,7 @@
     {
       "nameWithOwner": "matryer/xbar",
       "url": "https://github.com/matryer/xbar",
-      "stargazerCount": 17865,
+      "stargazerCount": 17878,
       "description": "Put the output from any script or program into your macOS Menu Bar (the BitBar reboot)",
       "primaryLanguage": "Go",
       "starredAt": "2019-06-21T02:13:21Z"
@@ -9386,7 +9497,7 @@
     {
       "nameWithOwner": "OpenDroneMap/WebODM",
       "url": "https://github.com/OpenDroneMap/WebODM",
-      "stargazerCount": 3276,
+      "stargazerCount": 3288,
       "description": "User-friendly, commercial-grade software for processing aerial imagery. ✈️",
       "primaryLanguage": "JavaScript",
       "starredAt": "2019-06-19T01:00:03Z"
@@ -9394,7 +9505,7 @@
     {
       "nameWithOwner": "OpenDroneMap/ODM",
       "url": "https://github.com/OpenDroneMap/ODM",
-      "stargazerCount": 5299,
+      "stargazerCount": 5319,
       "description": "A command line toolkit to generate maps, point clouds, 3D models and DEMs from drone, balloon or kite images. 📷",
       "primaryLanguage": "Python",
       "starredAt": "2019-06-19T00:58:35Z"
@@ -9402,7 +9513,7 @@
     {
       "nameWithOwner": "tradingview/lightweight-charts",
       "url": "https://github.com/tradingview/lightweight-charts",
-      "stargazerCount": 11919,
+      "stargazerCount": 12000,
       "description": "Performant financial charts built with HTML5 canvas",
       "primaryLanguage": "TypeScript",
       "starredAt": "2019-06-18T21:29:39Z"
@@ -9410,7 +9521,7 @@
     {
       "nameWithOwner": "kefranabg/readme-md-generator",
       "url": "https://github.com/kefranabg/readme-md-generator",
-      "stargazerCount": 11053,
+      "stargazerCount": 11054,
       "description": "📄 CLI that generates beautiful README.md files",
       "primaryLanguage": "JavaScript",
       "starredAt": "2019-06-18T21:28:01Z"
@@ -9434,7 +9545,7 @@
     {
       "nameWithOwner": "iCHAIT/awesome-macOS",
       "url": "https://github.com/iCHAIT/awesome-macOS",
-      "stargazerCount": 16911,
+      "stargazerCount": 16940,
       "description": "  A curated list of awesome applications, softwares, tools and shiny things for macOS.",
       "primaryLanguage": null,
       "starredAt": "2019-06-13T00:01:07Z"
@@ -9442,7 +9553,7 @@
     {
       "nameWithOwner": "johnyanarella/MaterialDesignColorPicker",
       "url": "https://github.com/johnyanarella/MaterialDesignColorPicker",
-      "stargazerCount": 167,
+      "stargazerCount": 170,
       "description": "Material Design Color Picker for macOS",
       "primaryLanguage": "Swift",
       "starredAt": "2019-06-12T23:44:08Z"
@@ -9450,7 +9561,7 @@
     {
       "nameWithOwner": "viktorstrate/color-picker-plus",
       "url": "https://github.com/viktorstrate/color-picker-plus",
-      "stargazerCount": 138,
+      "stargazerCount": 140,
       "description": "An Improved Color Picker for macOS",
       "primaryLanguage": "Swift",
       "starredAt": "2019-06-12T23:42:40Z"
@@ -9458,7 +9569,7 @@
     {
       "nameWithOwner": "nvzqz/Menubar-Colors",
       "url": "https://github.com/nvzqz/Menubar-Colors",
-      "stargazerCount": 187,
+      "stargazerCount": 186,
       "description": "A macOS app for convenient access to the system color panel",
       "primaryLanguage": "Swift",
       "starredAt": "2019-06-12T23:37:11Z"
@@ -9466,7 +9577,7 @@
     {
       "nameWithOwner": "Leaflet/Leaflet",
       "url": "https://github.com/Leaflet/Leaflet",
-      "stargazerCount": 43219,
+      "stargazerCount": 43292,
       "description": "🍃 JavaScript library for mobile-friendly interactive maps 🇺🇦",
       "primaryLanguage": "JavaScript",
       "starredAt": "2019-06-12T23:12:24Z"
@@ -9474,7 +9585,7 @@
     {
       "nameWithOwner": "keplergl/kepler.gl",
       "url": "https://github.com/keplergl/kepler.gl",
-      "stargazerCount": 11091,
+      "stargazerCount": 11140,
       "description": "Kepler.gl is a powerful open source geospatial analysis tool for large-scale data sets.",
       "primaryLanguage": "TypeScript",
       "starredAt": "2019-06-12T22:54:49Z"
@@ -9482,7 +9593,7 @@
     {
       "nameWithOwner": "yihui/servr",
       "url": "https://github.com/yihui/servr",
-      "stargazerCount": 285,
+      "stargazerCount": 286,
       "description": "A simple HTTP server in R",
       "primaryLanguage": "R",
       "starredAt": "2019-06-12T22:32:22Z"
@@ -9490,7 +9601,7 @@
     {
       "nameWithOwner": "rstudio/httpuv",
       "url": "https://github.com/rstudio/httpuv",
-      "stargazerCount": 242,
+      "stargazerCount": 243,
       "description": "HTTP and WebSocket server package for R",
       "primaryLanguage": "C",
       "starredAt": "2019-06-12T22:30:26Z"
@@ -9522,7 +9633,7 @@
     {
       "nameWithOwner": "udacity/deep-learning-v2-pytorch",
       "url": "https://github.com/udacity/deep-learning-v2-pytorch",
-      "stargazerCount": 5408,
+      "stargazerCount": 5415,
       "description": "Projects and exercises for the latest Deep Learning ND program https://www.udacity.com/course/deep-learning-nanodegree--nd101",
       "primaryLanguage": "Jupyter Notebook",
       "starredAt": "2019-06-10T21:31:28Z"
@@ -9530,7 +9641,7 @@
     {
       "nameWithOwner": "nyu-mll/jiant",
       "url": "https://github.com/nyu-mll/jiant",
-      "stargazerCount": 1671,
+      "stargazerCount": 1670,
       "description": "jiant is an nlp toolkit",
       "primaryLanguage": "Python",
       "starredAt": "2019-06-10T03:37:28Z"
@@ -9538,7 +9649,7 @@
     {
       "nameWithOwner": "microsoft/AirSim",
       "url": "https://github.com/microsoft/AirSim",
-      "stargazerCount": 17334,
+      "stargazerCount": 17367,
       "description": "Open source simulator for autonomous vehicles built on Unreal Engine / Unity, from Microsoft AI & Research",
       "primaryLanguage": "C++",
       "starredAt": "2019-06-10T03:37:08Z"
@@ -9546,7 +9657,7 @@
     {
       "nameWithOwner": "openvinotoolkit/open_model_zoo",
       "url": "https://github.com/openvinotoolkit/open_model_zoo",
-      "stargazerCount": 4275,
+      "stargazerCount": 4278,
       "description": "Pre-trained Deep Learning models and demos (high quality and extremely fast)",
       "primaryLanguage": "Python",
       "starredAt": "2019-06-10T03:36:52Z"
@@ -9554,7 +9665,7 @@
     {
       "nameWithOwner": "huggingface/pytorch-image-models",
       "url": "https://github.com/huggingface/pytorch-image-models",
-      "stargazerCount": 34844,
+      "stargazerCount": 34936,
       "description": "The largest collection of PyTorch image encoders / backbones. Including train, eval, inference, export scripts, and pretrained weights -- ResNet, ResNeXT, EfficientNet, NFNet, Vision Transformer (ViT), MobileNetV4, MobileNet-V3 & V2, RegNet, DPN, CSPNet, Swin Transformer, MaxViT, CoAtNet, ConvNeXt, and more",
       "primaryLanguage": "Python",
       "starredAt": "2019-06-10T03:35:53Z"
@@ -9562,7 +9673,7 @@
     {
       "nameWithOwner": "shap/shap",
       "url": "https://github.com/shap/shap",
-      "stargazerCount": 24174,
+      "stargazerCount": 24224,
       "description": "A game theoretic approach to explain the output of any machine learning model.",
       "primaryLanguage": "Jupyter Notebook",
       "starredAt": "2019-06-10T03:35:01Z"
@@ -9570,7 +9681,7 @@
     {
       "nameWithOwner": "kedro-org/kedro",
       "url": "https://github.com/kedro-org/kedro",
-      "stargazerCount": 10457,
+      "stargazerCount": 10471,
       "description": "Kedro is a toolbox for production-ready data science. It uses software engineering best practices to help you create data engineering and data science pipelines that are reproducible, maintainable, and modular.",
       "primaryLanguage": "Python",
       "starredAt": "2019-06-09T23:33:29Z"
@@ -9586,7 +9697,7 @@
     {
       "nameWithOwner": "mapbox/pixelmatch",
       "url": "https://github.com/mapbox/pixelmatch",
-      "stargazerCount": 6495,
+      "stargazerCount": 6505,
       "description": "The smallest, simplest and fastest JavaScript pixel-level image comparison library",
       "primaryLanguage": "JavaScript",
       "starredAt": "2019-06-09T22:41:59Z"
@@ -9594,7 +9705,7 @@
     {
       "nameWithOwner": "vercel/ms",
       "url": "https://github.com/vercel/ms",
-      "stargazerCount": 5311,
+      "stargazerCount": 5318,
       "description": "Tiny millisecond conversion utility",
       "primaryLanguage": "TypeScript",
       "starredAt": "2019-06-09T22:41:29Z"
@@ -9602,7 +9713,7 @@
     {
       "nameWithOwner": "lukeed/tinydate",
       "url": "https://github.com/lukeed/tinydate",
-      "stargazerCount": 1068,
+      "stargazerCount": 1069,
       "description": "A tiny (349B) reusable date formatter. Extremely fast!",
       "primaryLanguage": "JavaScript",
       "starredAt": "2019-06-09T22:41:08Z"
@@ -9626,7 +9737,7 @@
     {
       "nameWithOwner": "allenai/ai2thor",
       "url": "https://github.com/allenai/ai2thor",
-      "stargazerCount": 1454,
+      "stargazerCount": 1468,
       "description": "An open-source platform for Visual AI.",
       "primaryLanguage": "C#",
       "starredAt": "2019-06-04T01:37:04Z"
@@ -9634,7 +9745,7 @@
     {
       "nameWithOwner": "allenai/allennlp",
       "url": "https://github.com/allenai/allennlp",
-      "stargazerCount": 11861,
+      "stargazerCount": 11862,
       "description": "An open-source NLP research library, built on PyTorch.",
       "primaryLanguage": "Python",
       "starredAt": "2019-06-04T01:24:39Z"
@@ -9642,7 +9753,7 @@
     {
       "nameWithOwner": "lukemelas/EfficientNet-PyTorch",
       "url": "https://github.com/lukemelas/EfficientNet-PyTorch",
-      "stargazerCount": 8141,
+      "stargazerCount": 8139,
       "description": "A PyTorch implementation of EfficientNet",
       "primaryLanguage": "Python",
       "starredAt": "2019-06-04T01:22:26Z"
@@ -9650,7 +9761,7 @@
     {
       "nameWithOwner": "joelshepherd/tabliss",
       "url": "https://github.com/joelshepherd/tabliss",
-      "stargazerCount": 2548,
+      "stargazerCount": 2550,
       "description": "A beautiful, customisable New Tab page for Firefox, Chrome, and Edge.",
       "primaryLanguage": "TypeScript",
       "starredAt": "2019-06-03T01:53:35Z"
@@ -9666,7 +9777,7 @@
     {
       "nameWithOwner": "gorhill/uBlock",
       "url": "https://github.com/gorhill/uBlock",
-      "stargazerCount": 56700,
+      "stargazerCount": 57133,
       "description": "uBlock Origin - An efficient blocker for Chromium and Firefox. Fast and lean.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2019-06-03T00:29:11Z"
@@ -9698,7 +9809,7 @@
     {
       "nameWithOwner": "kjw0612/awesome-deep-vision",
       "url": "https://github.com/kjw0612/awesome-deep-vision",
-      "stargazerCount": 11010,
+      "stargazerCount": 11015,
       "description": "A curated list of deep learning resources for computer vision ",
       "primaryLanguage": null,
       "starredAt": "2019-05-28T03:36:49Z"
@@ -9706,7 +9817,7 @@
     {
       "nameWithOwner": "terryum/awesome-deep-learning-papers",
       "url": "https://github.com/terryum/awesome-deep-learning-papers",
-      "stargazerCount": 25916,
+      "stargazerCount": 25928,
       "description": "The most cited deep learning papers",
       "primaryLanguage": "TeX",
       "starredAt": "2019-05-28T03:36:23Z"
@@ -9714,7 +9825,7 @@
     {
       "nameWithOwner": "ChristosChristofidis/awesome-deep-learning",
       "url": "https://github.com/ChristosChristofidis/awesome-deep-learning",
-      "stargazerCount": 25824,
+      "stargazerCount": 25923,
       "description": "A curated list of awesome Deep Learning tutorials, projects and communities.",
       "primaryLanguage": null,
       "starredAt": "2019-05-28T03:36:19Z"
@@ -9722,7 +9833,7 @@
     {
       "nameWithOwner": "jbhuang0604/awesome-computer-vision",
       "url": "https://github.com/jbhuang0604/awesome-computer-vision",
-      "stargazerCount": 22205,
+      "stargazerCount": 22241,
       "description": "A curated list of awesome computer vision resources",
       "primaryLanguage": null,
       "starredAt": "2019-05-28T03:36:15Z"
@@ -9730,7 +9841,7 @@
     {
       "nameWithOwner": "1j01/jspaint",
       "url": "https://github.com/1j01/jspaint",
-      "stargazerCount": 7489,
+      "stargazerCount": 7501,
       "description": "🎨 Classic MS Paint, ＲＥＶＩＶＥＤ + ✨Extras",
       "primaryLanguage": "JavaScript",
       "starredAt": "2019-05-27T21:33:06Z"
@@ -9738,7 +9849,7 @@
     {
       "nameWithOwner": "explosion/spaCy",
       "url": "https://github.com/explosion/spaCy",
-      "stargazerCount": 32024,
+      "stargazerCount": 32086,
       "description": "💫 Industrial-strength Natural Language Processing (NLP) in Python",
       "primaryLanguage": "Python",
       "starredAt": "2019-05-26T22:14:21Z"
@@ -9746,7 +9857,7 @@
     {
       "nameWithOwner": "Alluxio/alluxio",
       "url": "https://github.com/Alluxio/alluxio",
-      "stargazerCount": 7038,
+      "stargazerCount": 7044,
       "description": "Alluxio, data orchestration for analytics and machine learning in the cloud",
       "primaryLanguage": "Java",
       "starredAt": "2019-05-26T22:10:00Z"
@@ -9754,7 +9865,7 @@
     {
       "nameWithOwner": "rough-stuff/rough",
       "url": "https://github.com/rough-stuff/rough",
-      "stargazerCount": 20484,
+      "stargazerCount": 20507,
       "description": "Create graphics with a hand-drawn, sketchy, appearance",
       "primaryLanguage": "HTML",
       "starredAt": "2019-05-26T22:00:24Z"
@@ -9762,7 +9873,7 @@
     {
       "nameWithOwner": "facebookresearch/mmf",
       "url": "https://github.com/facebookresearch/mmf",
-      "stargazerCount": 5581,
+      "stargazerCount": 5582,
       "description": "A modular framework for vision & language multimodal research from Facebook AI Research (FAIR)",
       "primaryLanguage": "Python",
       "starredAt": "2019-05-24T00:11:46Z"
@@ -9778,7 +9889,7 @@
     {
       "nameWithOwner": "glauberfc/awesome-react-hooks",
       "url": "https://github.com/glauberfc/awesome-react-hooks",
-      "stargazerCount": 1214,
+      "stargazerCount": 1216,
       "description": "A curated list about React Hooks",
       "primaryLanguage": null,
       "starredAt": "2019-05-21T22:58:55Z"
@@ -9786,7 +9897,7 @@
     {
       "nameWithOwner": "PavelDoGreat/WebGL-Fluid-Simulation",
       "url": "https://github.com/PavelDoGreat/WebGL-Fluid-Simulation",
-      "stargazerCount": 15628,
+      "stargazerCount": 15653,
       "description": "Play with fluids in your browser (works even on mobile)",
       "primaryLanguage": "JavaScript",
       "starredAt": "2019-05-20T23:51:45Z"
@@ -9802,7 +9913,7 @@
     {
       "nameWithOwner": "zone-eu/wildduck",
       "url": "https://github.com/zone-eu/wildduck",
-      "stargazerCount": 2018,
+      "stargazerCount": 2020,
       "description": "Opinionated email server",
       "primaryLanguage": "JavaScript",
       "starredAt": "2019-05-20T22:10:51Z"
@@ -9810,7 +9921,7 @@
     {
       "nameWithOwner": "instillai/machine-learning-course",
       "url": "https://github.com/instillai/machine-learning-course",
-      "stargazerCount": 7054,
+      "stargazerCount": 7056,
       "description": ":speech_balloon: Machine Learning Course with Python: ",
       "primaryLanguage": "Python",
       "starredAt": "2019-05-20T01:30:27Z"
@@ -9818,7 +9929,7 @@
     {
       "nameWithOwner": "facebookresearch/video-nonlocal-net",
       "url": "https://github.com/facebookresearch/video-nonlocal-net",
-      "stargazerCount": 1985,
+      "stargazerCount": 1986,
       "description": "Non-local Neural Networks for Video Classification",
       "primaryLanguage": "Python",
       "starredAt": "2019-05-17T01:06:39Z"
@@ -9834,7 +9945,7 @@
     {
       "nameWithOwner": "StreisandEffect/streisand",
       "url": "https://github.com/StreisandEffect/streisand",
-      "stargazerCount": 23409,
+      "stargazerCount": 23415,
       "description": "Streisand sets up a new server running your choice of WireGuard, OpenConnect, OpenSSH, OpenVPN, Shadowsocks, sslh, Stunnel, or a Tor bridge. It also generates custom instructions for all of these services. At the end of the run you are given an HTML file with instructions that can be shared with friends, family members, and fellow activists.",
       "primaryLanguage": "Shell",
       "starredAt": "2019-05-16T22:49:48Z"
@@ -9850,7 +9961,7 @@
     {
       "nameWithOwner": "felixrieseberg/windows95",
       "url": "https://github.com/felixrieseberg/windows95",
-      "stargazerCount": 22864,
+      "stargazerCount": 22866,
       "description": "💩🚀 Windows 95 in Electron. Runs on macOS, Linux, and Windows.",
       "primaryLanguage": "TypeScript",
       "starredAt": "2019-05-16T04:45:15Z"
@@ -9858,7 +9969,7 @@
     {
       "nameWithOwner": "mwouts/jupytext",
       "url": "https://github.com/mwouts/jupytext",
-      "stargazerCount": 6940,
+      "stargazerCount": 6951,
       "description": "Jupyter Notebooks as Markdown Documents, Julia, Python or R scripts",
       "primaryLanguage": "Python",
       "starredAt": "2019-05-16T03:10:34Z"
@@ -9866,7 +9977,7 @@
     {
       "nameWithOwner": "NVlabs/FUNIT",
       "url": "https://github.com/NVlabs/FUNIT",
-      "stargazerCount": 1586,
+      "stargazerCount": 1587,
       "description": "Translate images to unseen domains in the test time with few example images.",
       "primaryLanguage": "Python",
       "starredAt": "2019-05-16T02:35:40Z"
@@ -9874,7 +9985,7 @@
     {
       "nameWithOwner": "junyanz/pytorch-CycleGAN-and-pix2pix",
       "url": "https://github.com/junyanz/pytorch-CycleGAN-and-pix2pix",
-      "stargazerCount": 24273,
+      "stargazerCount": 24306,
       "description": "Image-to-Image Translation in PyTorch",
       "primaryLanguage": "Python",
       "starredAt": "2019-05-15T21:01:27Z"
@@ -9914,7 +10025,7 @@
     {
       "nameWithOwner": "minimaxir/gpt-2-simple",
       "url": "https://github.com/minimaxir/gpt-2-simple",
-      "stargazerCount": 3407,
+      "stargazerCount": 3408,
       "description": "Python package to easily retrain OpenAI's GPT-2 text-generating model on new texts",
       "primaryLanguage": "Python",
       "starredAt": "2019-05-15T01:57:06Z"
@@ -9922,7 +10033,7 @@
     {
       "nameWithOwner": "TarekRaafat/autoComplete.js",
       "url": "https://github.com/TarekRaafat/autoComplete.js",
-      "stargazerCount": 3997,
+      "stargazerCount": 3998,
       "description": "Simple autocomplete pure vanilla Javascript library.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2019-05-13T05:39:41Z"
@@ -9946,7 +10057,7 @@
     {
       "nameWithOwner": "atomiks/tippyjs",
       "url": "https://github.com/atomiks/tippyjs",
-      "stargazerCount": 12238,
+      "stargazerCount": 12247,
       "description": "Tooltip, popover, dropdown, and menu library",
       "primaryLanguage": "JavaScript",
       "starredAt": "2019-05-13T05:36:29Z"
@@ -9962,7 +10073,7 @@
     {
       "nameWithOwner": "davidhu2000/react-spinners",
       "url": "https://github.com/davidhu2000/react-spinners",
-      "stargazerCount": 3281,
+      "stargazerCount": 3288,
       "description": "A collection of loading spinner components for react",
       "primaryLanguage": "TypeScript",
       "starredAt": "2019-05-13T01:24:52Z"
@@ -9978,7 +10089,7 @@
     {
       "nameWithOwner": "veltman/flubber",
       "url": "https://github.com/veltman/flubber",
-      "stargazerCount": 6809,
+      "stargazerCount": 6816,
       "description": "Tools for smoother shape animations.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2019-05-08T23:07:33Z"
@@ -9986,7 +10097,7 @@
     {
       "nameWithOwner": "leggett/simplify",
       "url": "https://github.com/leggett/simplify",
-      "stargazerCount": 1637,
+      "stargazerCount": 1636,
       "description": "Issue tracker for Simplify Gmail, a browser extension to simplify Gmail's interface",
       "primaryLanguage": "HTML",
       "starredAt": "2019-05-07T04:26:05Z"
@@ -9994,7 +10105,7 @@
     {
       "nameWithOwner": "sindresorhus/on-change",
       "url": "https://github.com/sindresorhus/on-change",
-      "stargazerCount": 1989,
+      "stargazerCount": 1991,
       "description": "Watch an object or array for changes",
       "primaryLanguage": "JavaScript",
       "starredAt": "2019-05-02T23:54:17Z"
@@ -10002,7 +10113,7 @@
     {
       "nameWithOwner": "glennreyes/react-countup",
       "url": "https://github.com/glennreyes/react-countup",
-      "stargazerCount": 2065,
+      "stargazerCount": 2066,
       "description": "💫 A configurable React component wrapper around CountUp.js",
       "primaryLanguage": "JavaScript",
       "starredAt": "2019-05-02T02:55:27Z"
@@ -10018,7 +10129,7 @@
     {
       "nameWithOwner": "xnimorz/use-debounce",
       "url": "https://github.com/xnimorz/use-debounce",
-      "stargazerCount": 3255,
+      "stargazerCount": 3268,
       "description": "A debounce hook for react",
       "primaryLanguage": "TypeScript",
       "starredAt": "2019-05-02T02:16:01Z"
@@ -10026,7 +10137,7 @@
     {
       "nameWithOwner": "boyney123/mockit",
       "url": "https://github.com/boyney123/mockit",
-      "stargazerCount": 1583,
+      "stargazerCount": 1582,
       "description": "A tool to quickly mock out end points, setup delays and more...",
       "primaryLanguage": "JavaScript",
       "starredAt": "2019-04-30T02:02:16Z"
@@ -10034,7 +10145,7 @@
     {
       "nameWithOwner": "surge-synthesizer/surge",
       "url": "https://github.com/surge-synthesizer/surge",
-      "stargazerCount": 3411,
+      "stargazerCount": 3421,
       "description": "Synthesizer plug-in (previously released as Vember Audio Surge)",
       "primaryLanguage": "C",
       "starredAt": "2019-04-30T01:39:23Z"
@@ -10042,7 +10153,7 @@
     {
       "nameWithOwner": "davidchin/react-input-range",
       "url": "https://github.com/davidchin/react-input-range",
-      "stargazerCount": 714,
+      "stargazerCount": 715,
       "description": "React component for inputting numeric values within a range (range slider)",
       "primaryLanguage": "JavaScript",
       "starredAt": "2019-04-24T05:41:44Z"
@@ -10050,7 +10161,7 @@
     {
       "nameWithOwner": "bowser-js/bowser",
       "url": "https://github.com/bowser-js/bowser",
-      "stargazerCount": 5601,
+      "stargazerCount": 5607,
       "description": "a browser detector",
       "primaryLanguage": "JavaScript",
       "starredAt": "2019-04-24T04:11:22Z"
@@ -10058,7 +10169,7 @@
     {
       "nameWithOwner": "webiny/webiny-js",
       "url": "https://github.com/webiny/webiny-js",
-      "stargazerCount": 7631,
+      "stargazerCount": 7636,
       "description": "Open-source serverless enterprise CMS. Includes a headless CMS, page builder, form builder, and file manager. Easy to customize and expand. Deploys to AWS.",
       "primaryLanguage": "TypeScript",
       "starredAt": "2019-04-23T05:45:22Z"
@@ -10066,7 +10177,7 @@
     {
       "nameWithOwner": "ovity/octotree",
       "url": "https://github.com/ovity/octotree",
-      "stargazerCount": 23024,
+      "stargazerCount": 23028,
       "description": "GitHub on steroids",
       "primaryLanguage": "JavaScript",
       "starredAt": "2019-04-23T03:20:16Z"
@@ -10074,7 +10185,7 @@
     {
       "nameWithOwner": "chrieke/awesome-satellite-imagery-datasets",
       "url": "https://github.com/chrieke/awesome-satellite-imagery-datasets",
-      "stargazerCount": 3784,
+      "stargazerCount": 3786,
       "description": "🛰️ List of satellite image training datasets with annotations for computer vision and deep learning",
       "primaryLanguage": null,
       "starredAt": "2019-04-18T04:31:57Z"
@@ -10082,7 +10193,7 @@
     {
       "nameWithOwner": "tj/commander.js",
       "url": "https://github.com/tj/commander.js",
-      "stargazerCount": 27476,
+      "stargazerCount": 27506,
       "description": "node.js command-line interfaces made easy",
       "primaryLanguage": "JavaScript",
       "starredAt": "2019-04-17T23:58:52Z"
@@ -10106,7 +10217,7 @@
     {
       "nameWithOwner": "netlify/netlify-dev-plugin",
       "url": "https://github.com/netlify/netlify-dev-plugin",
-      "stargazerCount": 178,
+      "stargazerCount": 179,
       "description": "Local dev server with functions, rules engine and add-on support",
       "primaryLanguage": "JavaScript",
       "starredAt": "2019-04-11T01:21:57Z"
@@ -10114,7 +10225,7 @@
     {
       "nameWithOwner": "eugeneware/ffmpeg-static",
       "url": "https://github.com/eugeneware/ffmpeg-static",
-      "stargazerCount": 1224,
+      "stargazerCount": 1229,
       "description": "ffmpeg static binaries for Mac OSX and Linux and Windows",
       "primaryLanguage": "JavaScript",
       "starredAt": "2019-04-10T04:44:57Z"
@@ -10138,7 +10249,7 @@
     {
       "nameWithOwner": "kognise/water.css",
       "url": "https://github.com/kognise/water.css",
-      "stargazerCount": 8463,
+      "stargazerCount": 8475,
       "description": "A drop-in collection of CSS styles to make simple websites just a little nicer",
       "primaryLanguage": "CSS",
       "starredAt": "2019-04-05T17:54:10Z"
@@ -10154,7 +10265,7 @@
     {
       "nameWithOwner": "styled-system/styled-system",
       "url": "https://github.com/styled-system/styled-system",
-      "stargazerCount": 7869,
+      "stargazerCount": 7871,
       "description": "⬢ Style props for rapid UI development",
       "primaryLanguage": "JavaScript",
       "starredAt": "2019-04-04T00:21:18Z"
@@ -10162,7 +10273,7 @@
     {
       "nameWithOwner": "albumentations-team/albumentations",
       "url": "https://github.com/albumentations-team/albumentations",
-      "stargazerCount": 15069,
+      "stargazerCount": 15092,
       "description": "Fast and flexible image augmentation library. Paper about the library: https://www.mdpi.com/2078-2489/11/2/125",
       "primaryLanguage": "Python",
       "starredAt": "2019-04-04T00:03:43Z"
@@ -10170,7 +10281,7 @@
     {
       "nameWithOwner": "inaturalist/iNaturalistAPI",
       "url": "https://github.com/inaturalist/iNaturalistAPI",
-      "stargazerCount": 113,
+      "stargazerCount": 115,
       "description": "Node.js API for iNaturalist.org",
       "primaryLanguage": "JavaScript",
       "starredAt": "2019-04-04T00:01:01Z"
@@ -10178,7 +10289,7 @@
     {
       "nameWithOwner": "EthicalML/awesome-production-machine-learning",
       "url": "https://github.com/EthicalML/awesome-production-machine-learning",
-      "stargazerCount": 18796,
+      "stargazerCount": 18908,
       "description": "A curated list of awesome open source libraries to deploy, monitor, version and scale your machine learning",
       "primaryLanguage": null,
       "starredAt": "2019-04-03T23:37:33Z"
@@ -10194,7 +10305,7 @@
     {
       "nameWithOwner": "ultralytics/yolov3",
       "url": "https://github.com/ultralytics/yolov3",
-      "stargazerCount": 10424,
+      "stargazerCount": 10430,
       "description": "YOLOv3 in PyTorch > ONNX > CoreML > TFLite",
       "primaryLanguage": "Python",
       "starredAt": "2019-04-03T05:47:10Z"
@@ -10210,7 +10321,7 @@
     {
       "nameWithOwner": "pmndrs/react-three-fiber",
       "url": "https://github.com/pmndrs/react-three-fiber",
-      "stargazerCount": 29289,
+      "stargazerCount": 29329,
       "description": "🇨🇭 A React renderer for Three.js",
       "primaryLanguage": "TypeScript",
       "starredAt": "2019-04-03T04:37:36Z"
@@ -10226,7 +10337,7 @@
     {
       "nameWithOwner": "sindresorhus/execa",
       "url": "https://github.com/sindresorhus/execa",
-      "stargazerCount": 7211,
+      "stargazerCount": 7220,
       "description": "Process execution for humans",
       "primaryLanguage": "JavaScript",
       "starredAt": "2019-04-03T01:22:55Z"
@@ -10234,7 +10345,7 @@
     {
       "nameWithOwner": "Raathigesh/majestic",
       "url": "https://github.com/Raathigesh/majestic",
-      "stargazerCount": 7492,
+      "stargazerCount": 7493,
       "description": "⚡ Zero config GUI for Jest",
       "primaryLanguage": "TypeScript",
       "starredAt": "2019-04-02T23:49:10Z"
@@ -10250,7 +10361,7 @@
     {
       "nameWithOwner": "Tonejs/Midi",
       "url": "https://github.com/Tonejs/Midi",
-      "stargazerCount": 950,
+      "stargazerCount": 951,
       "description": "Convert MIDI into Tone.js-friendly JSON",
       "primaryLanguage": "TypeScript",
       "starredAt": "2019-04-02T22:17:35Z"
@@ -10258,7 +10369,7 @@
     {
       "nameWithOwner": "jazz-soft/JZZ",
       "url": "https://github.com/jazz-soft/JZZ",
-      "stargazerCount": 553,
+      "stargazerCount": 554,
       "description": " MIDI library for Node.js and web-browsers",
       "primaryLanguage": "JavaScript",
       "starredAt": "2019-04-02T22:09:57Z"
@@ -10274,7 +10385,7 @@
     {
       "nameWithOwner": "tensorflow/lingvo",
       "url": "https://github.com/tensorflow/lingvo",
-      "stargazerCount": 2845,
+      "stargazerCount": 2848,
       "description": "Lingvo",
       "primaryLanguage": "Python",
       "starredAt": "2019-04-02T04:50:29Z"
@@ -10330,7 +10441,7 @@
     {
       "nameWithOwner": "ramprs/grad-cam",
       "url": "https://github.com/ramprs/grad-cam",
-      "stargazerCount": 1576,
+      "stargazerCount": 1579,
       "description": "[ICCV 2017] Torch code for Grad-CAM",
       "primaryLanguage": "Lua",
       "starredAt": "2019-04-02T01:33:19Z"
@@ -10346,7 +10457,7 @@
     {
       "nameWithOwner": "generativefm/generators",
       "url": "https://github.com/generativefm/generators",
-      "stargazerCount": 567,
+      "stargazerCount": 568,
       "description": "A collection of generative music pieces for generative.fm",
       "primaryLanguage": "JavaScript",
       "starredAt": "2019-04-01T23:46:00Z"
@@ -10354,7 +10465,7 @@
     {
       "nameWithOwner": "FredKSchott/snowpack",
       "url": "https://github.com/FredKSchott/snowpack",
-      "stargazerCount": 19428,
+      "stargazerCount": 19424,
       "description": "ESM-powered frontend build tool. Instant, lightweight, unbundled development. ✌️",
       "primaryLanguage": "JavaScript",
       "starredAt": "2019-04-01T03:31:03Z"
@@ -10370,7 +10481,7 @@
     {
       "nameWithOwner": "React95/React95",
       "url": "https://github.com/React95/React95",
-      "stargazerCount": 3665,
+      "stargazerCount": 3670,
       "description": "A React components library with Win95 UI",
       "primaryLanguage": "TypeScript",
       "starredAt": "2019-03-29T22:38:25Z"
@@ -10386,7 +10497,7 @@
     {
       "nameWithOwner": "dicebear/dicebear",
       "url": "https://github.com/dicebear/dicebear",
-      "stargazerCount": 7303,
+      "stargazerCount": 7320,
       "description": "DiceBear is an avatar library for designers and developers. 🌍",
       "primaryLanguage": "TypeScript",
       "starredAt": "2019-03-26T04:01:06Z"
@@ -10402,7 +10513,7 @@
     {
       "nameWithOwner": "coder/code-server",
       "url": "https://github.com/coder/code-server",
-      "stargazerCount": 73057,
+      "stargazerCount": 73225,
       "description": "VS Code in the browser",
       "primaryLanguage": "TypeScript",
       "starredAt": "2019-03-25T22:42:45Z"
@@ -10418,7 +10529,7 @@
     {
       "nameWithOwner": "aleju/papers",
       "url": "https://github.com/aleju/papers",
-      "stargazerCount": 2505,
+      "stargazerCount": 2506,
       "description": "Summaries of machine learning papers",
       "primaryLanguage": null,
       "starredAt": "2019-03-22T05:38:43Z"
@@ -10426,7 +10537,7 @@
     {
       "nameWithOwner": "GoogleCloudPlatform/gcsfuse",
       "url": "https://github.com/GoogleCloudPlatform/gcsfuse",
-      "stargazerCount": 2142,
+      "stargazerCount": 2144,
       "description": "A user-space file system for interacting with Google Cloud Storage",
       "primaryLanguage": "Go",
       "starredAt": "2019-03-21T22:53:06Z"
@@ -10442,7 +10553,7 @@
     {
       "nameWithOwner": "terkelg/prompts",
       "url": "https://github.com/terkelg/prompts",
-      "stargazerCount": 9109,
+      "stargazerCount": 9122,
       "description": "❯ Lightweight, beautiful and user-friendly interactive prompts",
       "primaryLanguage": "JavaScript",
       "starredAt": "2019-03-21T22:25:05Z"
@@ -10450,7 +10561,7 @@
     {
       "nameWithOwner": "hasura/graphql-engine",
       "url": "https://github.com/hasura/graphql-engine",
-      "stargazerCount": 31619,
+      "stargazerCount": 31629,
       "description": "Blazing fast, instant realtime GraphQL APIs on all your data with fine grained access control, also trigger webhooks on database events.",
       "primaryLanguage": "TypeScript",
       "starredAt": "2019-03-21T22:09:59Z"
@@ -10466,7 +10577,7 @@
     {
       "nameWithOwner": "naver/billboard.js",
       "url": "https://github.com/naver/billboard.js",
-      "stargazerCount": 5926,
+      "stargazerCount": 5927,
       "description": " 📊 Re-usable, easy interface JavaScript chart library based on D3.js",
       "primaryLanguage": "TypeScript",
       "starredAt": "2019-03-18T04:10:25Z"
@@ -10474,7 +10585,7 @@
     {
       "nameWithOwner": "ghosh/microtip",
       "url": "https://github.com/ghosh/microtip",
-      "stargazerCount": 1395,
+      "stargazerCount": 1396,
       "description": "💬  Minimal, accessible, ultra lightweight css tooltip library. Just 1kb.",
       "primaryLanguage": "CSS",
       "starredAt": "2019-03-18T04:07:52Z"
@@ -10482,7 +10593,7 @@
     {
       "nameWithOwner": "pbeshai/use-query-params",
       "url": "https://github.com/pbeshai/use-query-params",
-      "stargazerCount": 2210,
+      "stargazerCount": 2211,
       "description": "React Hook for managing state in URL query parameters with easy serialization.",
       "primaryLanguage": "TypeScript",
       "starredAt": "2019-03-15T23:55:53Z"
@@ -10490,7 +10601,7 @@
     {
       "nameWithOwner": "axa-group/nlp.js",
       "url": "https://github.com/axa-group/nlp.js",
-      "stargazerCount": 6474,
+      "stargazerCount": 6478,
       "description": "An NLP library for building bots, with entity extraction, sentiment analysis, automatic language identify, and so more",
       "primaryLanguage": "JavaScript",
       "starredAt": "2019-03-15T02:34:16Z"
@@ -10506,7 +10617,7 @@
     {
       "nameWithOwner": "WiseLibs/better-sqlite3",
       "url": "https://github.com/WiseLibs/better-sqlite3",
-      "stargazerCount": 6314,
+      "stargazerCount": 6341,
       "description": "The fastest and simplest library for SQLite3 in Node.js.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2019-03-15T02:33:17Z"
@@ -10530,7 +10641,7 @@
     {
       "nameWithOwner": "ufoym/deepo",
       "url": "https://github.com/ufoym/deepo",
-      "stargazerCount": 6291,
+      "stargazerCount": 6292,
       "description": "Setup and customize deep learning environment in seconds.",
       "primaryLanguage": "Python",
       "starredAt": "2019-03-12T01:45:03Z"
@@ -10538,7 +10649,7 @@
     {
       "nameWithOwner": "hamukazu/lets-get-arrested",
       "url": "https://github.com/hamukazu/lets-get-arrested",
-      "stargazerCount": 4133,
+      "stargazerCount": 4132,
       "description": "This project is intended to protest against the police in Japan",
       "primaryLanguage": "HTML",
       "starredAt": "2019-03-11T23:03:19Z"
@@ -10546,7 +10657,7 @@
     {
       "nameWithOwner": "victordibia/handtrack.js",
       "url": "https://github.com/victordibia/handtrack.js",
-      "stargazerCount": 2883,
+      "stargazerCount": 2885,
       "description": "A library for prototyping realtime hand detection (bounding box), directly in the browser. ",
       "primaryLanguage": "JavaScript",
       "starredAt": "2019-03-11T22:53:51Z"
@@ -10554,7 +10665,7 @@
     {
       "nameWithOwner": "mcollina/autocannon",
       "url": "https://github.com/mcollina/autocannon",
-      "stargazerCount": 8191,
+      "stargazerCount": 8195,
       "description": "fast HTTP/1.1 benchmarking tool written in Node.js",
       "primaryLanguage": "JavaScript",
       "starredAt": "2019-03-11T22:50:50Z"
@@ -10570,7 +10681,7 @@
     {
       "nameWithOwner": "foreversd/forever",
       "url": "https://github.com/foreversd/forever",
-      "stargazerCount": 13897,
+      "stargazerCount": 13898,
       "description": "A simple CLI tool for ensuring that a given script runs continuously (i.e. forever)",
       "primaryLanguage": "JavaScript",
       "starredAt": "2019-03-05T06:18:02Z"
@@ -10578,15 +10689,15 @@
     {
       "nameWithOwner": "falconry/falcon",
       "url": "https://github.com/falconry/falcon",
-      "stargazerCount": 9692,
-      "description": "The no-magic web API and microservices framework for Python developers, with an emphasis on reliability and performance at scale.",
+      "stargazerCount": 9694,
+      "description": "The no-magic web API and microservices framework for Python developers, with a focus on reliability and performance at scale.",
       "primaryLanguage": "Python",
       "starredAt": "2019-03-05T04:26:13Z"
     },
     {
       "nameWithOwner": "pyeve/eve",
       "url": "https://github.com/pyeve/eve",
-      "stargazerCount": 6731,
+      "stargazerCount": 6728,
       "description": "REST API framework designed for human beings",
       "primaryLanguage": "Python",
       "starredAt": "2019-03-05T04:19:14Z"
@@ -10602,7 +10713,7 @@
     {
       "nameWithOwner": "gregberge/loadable-components",
       "url": "https://github.com/gregberge/loadable-components",
-      "stargazerCount": 7808,
+      "stargazerCount": 7810,
       "description": "The recommended Code Splitting library for React ✂️✨",
       "primaryLanguage": "JavaScript",
       "starredAt": "2019-03-04T10:16:17Z"
@@ -10642,7 +10753,7 @@
     {
       "nameWithOwner": "swc-project/swc",
       "url": "https://github.com/swc-project/swc",
-      "stargazerCount": 32517,
+      "stargazerCount": 32545,
       "description": "Rust-based platform for the Web",
       "primaryLanguage": "Rust",
       "starredAt": "2019-03-01T09:55:44Z"
@@ -10650,7 +10761,7 @@
     {
       "nameWithOwner": "rbgirshick/yacs",
       "url": "https://github.com/rbgirshick/yacs",
-      "stargazerCount": 1318,
+      "stargazerCount": 1319,
       "description": "YACS -- Yet Another Configuration System",
       "primaryLanguage": "Python",
       "starredAt": "2019-03-01T06:15:34Z"
@@ -10658,7 +10769,7 @@
     {
       "nameWithOwner": "remoteinterview/zero",
       "url": "https://github.com/remoteinterview/zero",
-      "stargazerCount": 5841,
+      "stargazerCount": 5840,
       "description": "Zero is a web server to simplify web development.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2019-03-01T05:20:59Z"
@@ -10666,7 +10777,7 @@
     {
       "nameWithOwner": "facebook/docusaurus",
       "url": "https://github.com/facebook/docusaurus",
-      "stargazerCount": 60926,
+      "stargazerCount": 61128,
       "description": "Easy to maintain open source documentation websites.",
       "primaryLanguage": "TypeScript",
       "starredAt": "2019-02-28T02:37:25Z"
@@ -10698,7 +10809,7 @@
     {
       "nameWithOwner": "nteract/papermill",
       "url": "https://github.com/nteract/papermill",
-      "stargazerCount": 6226,
+      "stargazerCount": 6235,
       "description": "📚 Parameterize, execute, and analyze notebooks",
       "primaryLanguage": "Python",
       "starredAt": "2019-02-27T04:12:51Z"
@@ -10714,7 +10825,7 @@
     {
       "nameWithOwner": "ionic-team/ionic-framework",
       "url": "https://github.com/ionic-team/ionic-framework",
-      "stargazerCount": 51911,
+      "stargazerCount": 51942,
       "description": "A powerful cross-platform UI toolkit for building native-quality iOS, Android, and Progressive Web Apps with HTML, CSS, and JavaScript.",
       "primaryLanguage": "TypeScript",
       "starredAt": "2019-02-25T03:32:01Z"
@@ -10738,7 +10849,7 @@
     {
       "nameWithOwner": "trimstray/the-book-of-secret-knowledge",
       "url": "https://github.com/trimstray/the-book-of-secret-knowledge",
-      "stargazerCount": 179422,
+      "stargazerCount": 180820,
       "description": "A collection of inspiring lists, manuals, cheatsheets, blogs, hacks, one-liners, cli/web tools and more.",
       "primaryLanguage": null,
       "starredAt": "2019-02-25T03:03:10Z"
@@ -10770,7 +10881,7 @@
     {
       "nameWithOwner": "jthegedus/awesome-firebase",
       "url": "https://github.com/jthegedus/awesome-firebase",
-      "stargazerCount": 753,
+      "stargazerCount": 752,
       "description": "🔥 List of Firebase talks, tools, examples & articles! Translations in  🇬🇧 🇷🇺 Contributions welcome!",
       "primaryLanguage": null,
       "starredAt": "2019-02-22T07:01:41Z"
@@ -10778,7 +10889,7 @@
     {
       "nameWithOwner": "beautifier/js-beautify",
       "url": "https://github.com/beautifier/js-beautify",
-      "stargazerCount": 8811,
+      "stargazerCount": 8817,
       "description": "Beautifier for javascript ",
       "primaryLanguage": "JavaScript",
       "starredAt": "2019-02-22T00:00:38Z"
@@ -10786,7 +10897,7 @@
     {
       "nameWithOwner": "leon-ai/leon",
       "url": "https://github.com/leon-ai/leon",
-      "stargazerCount": 16497,
+      "stargazerCount": 16523,
       "description": "🧠 Leon is your open-source personal assistant.",
       "primaryLanguage": "TypeScript",
       "starredAt": "2019-02-21T22:38:26Z"
@@ -10794,7 +10905,7 @@
     {
       "nameWithOwner": "mozilla/send",
       "url": "https://github.com/mozilla/send",
-      "stargazerCount": 13271,
+      "stargazerCount": 13274,
       "description": "Simple, private file sharing from the makers of Firefox",
       "primaryLanguage": "FreeMarker",
       "starredAt": "2019-02-21T06:17:39Z"
@@ -10810,7 +10921,7 @@
     {
       "nameWithOwner": "philhawksworth/eleventyone",
       "url": "https://github.com/philhawksworth/eleventyone",
-      "stargazerCount": 464,
+      "stargazerCount": 463,
       "description": "A scaffold for a quick start building with the Eleventy SSG",
       "primaryLanguage": "JavaScript",
       "starredAt": "2019-02-21T04:11:47Z"
@@ -10818,7 +10929,7 @@
     {
       "nameWithOwner": "ludwig-ai/ludwig",
       "url": "https://github.com/ludwig-ai/ludwig",
-      "stargazerCount": 11536,
+      "stargazerCount": 11544,
       "description": "Low-code framework for building custom LLMs, neural networks, and other AI models",
       "primaryLanguage": "Python",
       "starredAt": "2019-02-20T01:57:47Z"
@@ -10834,7 +10945,7 @@
     {
       "nameWithOwner": "anthonygelibert/QLColorCode",
       "url": "https://github.com/anthonygelibert/QLColorCode",
-      "stargazerCount": 694,
+      "stargazerCount": 690,
       "description": "QuickLook plugin for source code with syntax highlighting.",
       "primaryLanguage": "Objective-C",
       "starredAt": "2019-02-19T06:36:43Z"
@@ -10842,7 +10953,7 @@
     {
       "nameWithOwner": "sindresorhus/quick-look-plugins",
       "url": "https://github.com/sindresorhus/quick-look-plugins",
-      "stargazerCount": 18335,
+      "stargazerCount": 18340,
       "description": "List of useful Quick Look plugins for developers",
       "primaryLanguage": null,
       "starredAt": "2019-02-19T06:32:42Z"
@@ -10858,7 +10969,7 @@
     {
       "nameWithOwner": "nathancahill/split",
       "url": "https://github.com/nathancahill/split",
-      "stargazerCount": 6228,
+      "stargazerCount": 6232,
       "description": "Unopinionated utilities for resizeable split views",
       "primaryLanguage": "JavaScript",
       "starredAt": "2019-02-18T01:02:45Z"
@@ -10866,7 +10977,7 @@
     {
       "nameWithOwner": "Azure/aml-real-time-ai",
       "url": "https://github.com/Azure/aml-real-time-ai",
-      "stargazerCount": 154,
+      "stargazerCount": 155,
       "description": "Easily deploy models to FPGAs for ultra-low latency with Azure Machine Learning powered by Project Brainwave",
       "primaryLanguage": "C#",
       "starredAt": "2019-02-17T23:53:49Z"
@@ -10882,7 +10993,7 @@
     {
       "nameWithOwner": "sugarshin/react-instagram-embed",
       "url": "https://github.com/sugarshin/react-instagram-embed",
-      "stargazerCount": 256,
+      "stargazerCount": 257,
       "description": "The React component for embedding Instagram posts",
       "primaryLanguage": "TypeScript",
       "starredAt": "2019-02-17T01:55:46Z"
@@ -10898,7 +11009,7 @@
     {
       "nameWithOwner": "Azure/MachineLearningNotebooks",
       "url": "https://github.com/Azure/MachineLearningNotebooks",
-      "stargazerCount": 4229,
+      "stargazerCount": 4237,
       "description": "Python notebooks with ML and deep learning examples with Azure Machine Learning Python SDK | Microsoft",
       "primaryLanguage": "Jupyter Notebook",
       "starredAt": "2019-02-15T04:20:31Z"
@@ -10906,7 +11017,7 @@
     {
       "nameWithOwner": "microsoft/onnxruntime",
       "url": "https://github.com/microsoft/onnxruntime",
-      "stargazerCount": 17300,
+      "stargazerCount": 17397,
       "description": "ONNX Runtime: cross-platform, high performance ML inferencing and training accelerator",
       "primaryLanguage": "C++",
       "starredAt": "2019-02-15T02:02:17Z"
@@ -10922,7 +11033,7 @@
     {
       "nameWithOwner": "agalwood/Motrix",
       "url": "https://github.com/agalwood/Motrix",
-      "stargazerCount": 48503,
+      "stargazerCount": 48649,
       "description": "A full-featured download manager.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2019-02-15T01:02:04Z"
@@ -10930,7 +11041,7 @@
     {
       "nameWithOwner": "CSFrequency/react-firebase-hooks",
       "url": "https://github.com/CSFrequency/react-firebase-hooks",
-      "stargazerCount": 3635,
+      "stargazerCount": 3637,
       "description": "React Hooks for Firebase.",
       "primaryLanguage": "TypeScript",
       "starredAt": "2019-02-15T00:52:55Z"
@@ -10946,7 +11057,7 @@
     {
       "nameWithOwner": "sveinbjornt/Sloth",
       "url": "https://github.com/sveinbjornt/Sloth",
-      "stargazerCount": 8518,
+      "stargazerCount": 8521,
       "description": "Mac app that shows all open files, directories, sockets, pipes and devices in use by all running processes. Nice GUI for lsof.",
       "primaryLanguage": "Objective-C",
       "starredAt": "2019-02-14T22:48:37Z"
@@ -10954,7 +11065,7 @@
     {
       "nameWithOwner": "NVlabs/stylegan",
       "url": "https://github.com/NVlabs/stylegan",
-      "stargazerCount": 14353,
+      "stargazerCount": 14356,
       "description": "StyleGAN - Official TensorFlow Implementation",
       "primaryLanguage": "Python",
       "starredAt": "2019-02-12T07:21:16Z"
@@ -10970,7 +11081,7 @@
     {
       "nameWithOwner": "uidotdev/usehooks",
       "url": "https://github.com/uidotdev/usehooks",
-      "stargazerCount": 10837,
+      "stargazerCount": 10858,
       "description": "A collection of modern, server-safe React hooks – from the ui.dev team",
       "primaryLanguage": "MDX",
       "starredAt": "2019-02-12T01:37:39Z"
@@ -10994,7 +11105,7 @@
     {
       "nameWithOwner": "gunthercox/ChatterBot",
       "url": "https://github.com/gunthercox/ChatterBot",
-      "stargazerCount": 14369,
+      "stargazerCount": 14382,
       "description": "ChatterBot is a machine learning, conversational dialog engine for creating chat bots",
       "primaryLanguage": "Python",
       "starredAt": "2019-02-06T04:26:26Z"
@@ -11002,7 +11113,7 @@
     {
       "nameWithOwner": "alexmacarthur/typeit",
       "url": "https://github.com/alexmacarthur/typeit",
-      "stargazerCount": 3144,
+      "stargazerCount": 3147,
       "description": "The most versatile JavaScript typewriter effect library on the planet.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2019-02-06T04:24:49Z"
@@ -11010,7 +11121,7 @@
     {
       "nameWithOwner": "apexcharts/react-apexcharts",
       "url": "https://github.com/apexcharts/react-apexcharts",
-      "stargazerCount": 1368,
+      "stargazerCount": 1369,
       "description": "📊 React Component for ApexCharts",
       "primaryLanguage": "JavaScript",
       "starredAt": "2019-02-06T04:23:23Z"
@@ -11018,7 +11129,7 @@
     {
       "nameWithOwner": "apexcharts/apexcharts.js",
       "url": "https://github.com/apexcharts/apexcharts.js",
-      "stargazerCount": 14841,
+      "stargazerCount": 14850,
       "description": "📊 Interactive JavaScript Charts built on SVG",
       "primaryLanguage": "JavaScript",
       "starredAt": "2019-02-06T04:23:09Z"
@@ -11026,7 +11137,7 @@
     {
       "nameWithOwner": "cjbassi/gotop",
       "url": "https://github.com/cjbassi/gotop",
-      "stargazerCount": 7405,
+      "stargazerCount": 7408,
       "description": "A terminal based graphical activity monitor inspired by gtop and vtop",
       "primaryLanguage": "Go",
       "starredAt": "2019-02-06T04:19:06Z"
@@ -11034,7 +11145,7 @@
     {
       "nameWithOwner": "nextapps-de/flexsearch",
       "url": "https://github.com/nextapps-de/flexsearch",
-      "stargazerCount": 13090,
+      "stargazerCount": 13140,
       "description": "Next-generation full-text search library for Browser and Node.js",
       "primaryLanguage": "JavaScript",
       "starredAt": "2019-02-05T04:52:07Z"
@@ -11042,7 +11153,7 @@
     {
       "nameWithOwner": "ebradyjobory/finance.js",
       "url": "https://github.com/ebradyjobory/finance.js",
-      "stargazerCount": 1257,
+      "stargazerCount": 1258,
       "description": "A JavaScript library for common financial calculations",
       "primaryLanguage": "JavaScript",
       "starredAt": "2019-02-05T04:50:15Z"
@@ -11050,7 +11161,7 @@
     {
       "nameWithOwner": "mozilla/readability",
       "url": "https://github.com/mozilla/readability",
-      "stargazerCount": 10249,
+      "stargazerCount": 10275,
       "description": "A standalone version of the readability lib",
       "primaryLanguage": "JavaScript",
       "starredAt": "2019-02-05T04:49:42Z"
@@ -11058,7 +11169,7 @@
     {
       "nameWithOwner": "plouc/nivo",
       "url": "https://github.com/plouc/nivo",
-      "stargazerCount": 13677,
+      "stargazerCount": 13696,
       "description": "nivo provides a rich set of dataviz components, built on top of the awesome d3 and React libraries",
       "primaryLanguage": "TypeScript",
       "starredAt": "2019-02-04T22:54:07Z"
@@ -11074,7 +11185,7 @@
     {
       "nameWithOwner": "AudioKit/AudioKitSynthOne",
       "url": "https://github.com/AudioKit/AudioKitSynthOne",
-      "stargazerCount": 1737,
+      "stargazerCount": 1739,
       "description": "AudioKit Synth One: Open-Source iOS Synthesizer App",
       "primaryLanguage": "Swift",
       "starredAt": "2019-02-01T04:36:47Z"
@@ -11082,7 +11193,7 @@
     {
       "nameWithOwner": "yershalom/react-wordart",
       "url": "https://github.com/yershalom/react-wordart",
-      "stargazerCount": 300,
+      "stargazerCount": 299,
       "description": "The nostalgic WordArt we know just in react",
       "primaryLanguage": "JavaScript",
       "starredAt": "2019-02-01T02:56:06Z"
@@ -11106,7 +11217,7 @@
     {
       "nameWithOwner": "Annihil/github-spray",
       "url": "https://github.com/Annihil/github-spray",
-      "stargazerCount": 1395,
+      "stargazerCount": 1397,
       "description": ":octocat: Draw on your GitHub contribution graph ░▒▓█",
       "primaryLanguage": "JavaScript",
       "starredAt": "2019-01-30T23:55:55Z"
@@ -11114,7 +11225,7 @@
     {
       "nameWithOwner": "notable/notable",
       "url": "https://github.com/notable/notable",
-      "stargazerCount": 23232,
+      "stargazerCount": 23246,
       "description": "The Markdown-based note-taking app that doesn't suck.",
       "primaryLanguage": null,
       "starredAt": "2019-01-30T23:09:33Z"
@@ -11130,7 +11241,7 @@
     {
       "nameWithOwner": "TheAlgorithms/Python",
       "url": "https://github.com/TheAlgorithms/Python",
-      "stargazerCount": 203180,
+      "stargazerCount": 203505,
       "description": "All Algorithms implemented in Python",
       "primaryLanguage": "Python",
       "starredAt": "2019-01-30T04:33:10Z"
@@ -11138,7 +11249,7 @@
     {
       "nameWithOwner": "facebookresearch/ReAgent",
       "url": "https://github.com/facebookresearch/ReAgent",
-      "stargazerCount": 3641,
+      "stargazerCount": 3651,
       "description": "A platform for Reasoning systems (Reinforcement Learning, Contextual Bandits, etc.)",
       "primaryLanguage": "Python",
       "starredAt": "2019-01-30T04:32:46Z"
@@ -11146,7 +11257,7 @@
     {
       "nameWithOwner": "dunovank/jupyter-themes",
       "url": "https://github.com/dunovank/jupyter-themes",
-      "stargazerCount": 9827,
+      "stargazerCount": 9829,
       "description": "Custom Jupyter Notebook Themes",
       "primaryLanguage": "CSS",
       "starredAt": "2019-01-30T00:18:47Z"
@@ -11154,7 +11265,7 @@
     {
       "nameWithOwner": "abhineet123/Deep-Learning-for-Tracking-and-Detection",
       "url": "https://github.com/abhineet123/Deep-Learning-for-Tracking-and-Detection",
-      "stargazerCount": 2479,
+      "stargazerCount": 2483,
       "description": "Collection of papers, datasets, code and other resources for object tracking and detection using deep learning",
       "primaryLanguage": "HTML",
       "starredAt": "2019-01-29T05:48:24Z"
@@ -11162,7 +11273,7 @@
     {
       "nameWithOwner": "NVIDIA/flownet2-pytorch",
       "url": "https://github.com/NVIDIA/flownet2-pytorch",
-      "stargazerCount": 3246,
+      "stargazerCount": 3247,
       "description": "Pytorch implementation of FlowNet 2.0: Evolution of Optical Flow Estimation with Deep Networks",
       "primaryLanguage": "Python",
       "starredAt": "2019-01-29T05:43:49Z"
@@ -11170,7 +11281,7 @@
     {
       "nameWithOwner": "nwojke/deep_sort",
       "url": "https://github.com/nwojke/deep_sort",
-      "stargazerCount": 5824,
+      "stargazerCount": 5841,
       "description": "Simple Online Realtime Tracking with a Deep Association Metric",
       "primaryLanguage": "Python",
       "starredAt": "2019-01-29T05:27:58Z"
@@ -11178,7 +11289,7 @@
     {
       "nameWithOwner": "abewley/sort",
       "url": "https://github.com/abewley/sort",
-      "stargazerCount": 4219,
+      "stargazerCount": 4221,
       "description": "Simple, online, and realtime tracking of multiple objects in a video sequence.",
       "primaryLanguage": "Python",
       "starredAt": "2019-01-29T05:24:21Z"
@@ -11194,7 +11305,7 @@
     {
       "nameWithOwner": "eriklindernoren/PyTorch-YOLOv3",
       "url": "https://github.com/eriklindernoren/PyTorch-YOLOv3",
-      "stargazerCount": 7415,
+      "stargazerCount": 7419,
       "description": "Minimal PyTorch implementation of YOLOv3",
       "primaryLanguage": "Python",
       "starredAt": "2019-01-29T05:22:49Z"
@@ -11202,7 +11313,7 @@
     {
       "nameWithOwner": "fossasia/visdom",
       "url": "https://github.com/fossasia/visdom",
-      "stargazerCount": 10169,
+      "stargazerCount": 10170,
       "description": "A flexible tool for creating, organizing, and sharing visualizations of live, rich data. Supports Torch and Numpy.",
       "primaryLanguage": "Python",
       "starredAt": "2019-01-29T05:20:19Z"
@@ -11234,7 +11345,7 @@
     {
       "nameWithOwner": "fastai/course-v3",
       "url": "https://github.com/fastai/course-v3",
-      "stargazerCount": 4917,
+      "stargazerCount": 4918,
       "description": "The 3rd edition of course.fast.ai",
       "primaryLanguage": "Jupyter Notebook",
       "starredAt": "2019-01-29T04:01:17Z"
@@ -11250,7 +11361,7 @@
     {
       "nameWithOwner": "Musish/Musish",
       "url": "https://github.com/Musish/Musish",
-      "stargazerCount": 3132,
+      "stargazerCount": 3137,
       "description": "Apple Music...ish ",
       "primaryLanguage": "TypeScript",
       "starredAt": "2019-01-29T01:13:03Z"
@@ -11258,7 +11369,7 @@
     {
       "nameWithOwner": "github/hotkey",
       "url": "https://github.com/github/hotkey",
-      "stargazerCount": 3276,
+      "stargazerCount": 3279,
       "description": "Trigger an action on an element with a keyboard shortcut.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2019-01-29T01:11:37Z"
@@ -11274,7 +11385,7 @@
     {
       "nameWithOwner": "facebookresearch/maskrcnn-benchmark",
       "url": "https://github.com/facebookresearch/maskrcnn-benchmark",
-      "stargazerCount": 9370,
+      "stargazerCount": 9371,
       "description": "Fast, modular reference implementation of Instance Segmentation and Object Detection algorithms in PyTorch.",
       "primaryLanguage": "Python",
       "starredAt": "2019-01-25T04:06:30Z"
@@ -11290,7 +11401,7 @@
     {
       "nameWithOwner": "torch/torch7",
       "url": "https://github.com/torch/torch7",
-      "stargazerCount": 9060,
+      "stargazerCount": 9058,
       "description": "http://torch.ch",
       "primaryLanguage": "C",
       "starredAt": "2019-01-25T03:42:07Z"
@@ -11298,7 +11409,7 @@
     {
       "nameWithOwner": "rikschennink/shiny",
       "url": "https://github.com/rikschennink/shiny",
-      "stargazerCount": 2796,
+      "stargazerCount": 2797,
       "description": "🌟 Shiny reflections for mobile websites",
       "primaryLanguage": "JavaScript",
       "starredAt": "2019-01-25T03:37:39Z"
@@ -11314,7 +11425,7 @@
     {
       "nameWithOwner": "open-mmlab/mmdetection",
       "url": "https://github.com/open-mmlab/mmdetection",
-      "stargazerCount": 31427,
+      "stargazerCount": 31487,
       "description": "OpenMMLab Detection Toolbox and Benchmark",
       "primaryLanguage": "Python",
       "starredAt": "2019-01-25T02:47:05Z"
@@ -11330,7 +11441,7 @@
     {
       "nameWithOwner": "zhaoweicai/cascade-rcnn",
       "url": "https://github.com/zhaoweicai/cascade-rcnn",
-      "stargazerCount": 1050,
+      "stargazerCount": 1051,
       "description": "Caffe implementation of multiple popular object detection frameworks",
       "primaryLanguage": "C++",
       "starredAt": "2019-01-25T02:41:52Z"
@@ -11378,7 +11489,7 @@
     {
       "nameWithOwner": "GoogleChromeLabs/squoosh",
       "url": "https://github.com/GoogleChromeLabs/squoosh",
-      "stargazerCount": 23325,
+      "stargazerCount": 23376,
       "description": "Make images smaller using best-in-class codecs, right in the browser.",
       "primaryLanguage": "TypeScript",
       "starredAt": "2019-01-22T21:44:49Z"
@@ -11418,7 +11529,7 @@
     {
       "nameWithOwner": "zziz/pwc",
       "url": "https://github.com/zziz/pwc",
-      "stargazerCount": 15399,
+      "stargazerCount": 15397,
       "description": "This repository is no longer maintained.",
       "primaryLanguage": null,
       "starredAt": "2019-01-22T05:33:44Z"
@@ -11458,7 +11569,7 @@
     {
       "nameWithOwner": "qqwweee/keras-yolo3",
       "url": "https://github.com/qqwweee/keras-yolo3",
-      "stargazerCount": 7139,
+      "stargazerCount": 7140,
       "description": "A Keras implementation of YOLOv3 (Tensorflow backend)",
       "primaryLanguage": "Python",
       "starredAt": "2019-01-22T02:12:38Z"
@@ -11514,7 +11625,7 @@
     {
       "nameWithOwner": "ivoronin/TomatoBar",
       "url": "https://github.com/ivoronin/TomatoBar",
-      "stargazerCount": 2776,
+      "stargazerCount": 2792,
       "description": "🍅 World's neatest Pomodoro timer for macOS menu bar",
       "primaryLanguage": "Swift",
       "starredAt": "2019-01-17T22:24:17Z"
@@ -11530,7 +11641,7 @@
     {
       "nameWithOwner": "necolas/react-native-web",
       "url": "https://github.com/necolas/react-native-web",
-      "stargazerCount": 21952,
+      "stargazerCount": 21954,
       "description": "Cross-platform React UI packages",
       "primaryLanguage": "JavaScript",
       "starredAt": "2019-01-16T22:36:20Z"
@@ -11554,7 +11665,7 @@
     {
       "nameWithOwner": "googlecreativelab/chrome-music-lab",
       "url": "https://github.com/googlecreativelab/chrome-music-lab",
-      "stargazerCount": 2272,
+      "stargazerCount": 2276,
       "description": "A collection of experiments for exploring how music works, all built with the Web Audio API.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2019-01-15T02:25:14Z"
@@ -11562,7 +11673,7 @@
     {
       "nameWithOwner": "kylemcdonald/FreeWifi",
       "url": "https://github.com/kylemcdonald/FreeWifi",
-      "stargazerCount": 2941,
+      "stargazerCount": 2942,
       "description": "How to get free wifi.",
       "primaryLanguage": "Python",
       "starredAt": "2019-01-15T02:24:56Z"
@@ -11570,7 +11681,7 @@
     {
       "nameWithOwner": "magenta/magenta-studio",
       "url": "https://github.com/magenta/magenta-studio",
-      "stargazerCount": 1135,
+      "stargazerCount": 1137,
       "description": "Magenta Studio is a collection of music plugins built on Magenta’s open source tools and models",
       "primaryLanguage": "JavaScript",
       "starredAt": "2019-01-15T01:27:06Z"
@@ -11578,7 +11689,7 @@
     {
       "nameWithOwner": "TryGhost/gatsby-starter-ghost",
       "url": "https://github.com/TryGhost/gatsby-starter-ghost",
-      "stargazerCount": 1097,
+      "stargazerCount": 1096,
       "description": "A starter template to build lightning fast websites with Ghost & Gatsby",
       "primaryLanguage": "JavaScript",
       "starredAt": "2019-01-10T00:19:33Z"
@@ -11610,7 +11721,7 @@
     {
       "nameWithOwner": "ogham/exa",
       "url": "https://github.com/ogham/exa",
-      "stargazerCount": 24060,
+      "stargazerCount": 24066,
       "description": "A modern replacement for ‘ls’.",
       "primaryLanguage": "Rust",
       "starredAt": "2019-01-08T01:31:17Z"
@@ -11618,7 +11729,7 @@
     {
       "nameWithOwner": "sharkdp/bat",
       "url": "https://github.com/sharkdp/bat",
-      "stargazerCount": 53573,
+      "stargazerCount": 53720,
       "description": "A cat(1) clone with wings.",
       "primaryLanguage": "Rust",
       "starredAt": "2019-01-08T01:25:43Z"
@@ -11626,7 +11737,7 @@
     {
       "nameWithOwner": "junegunn/fzf",
       "url": "https://github.com/junegunn/fzf",
-      "stargazerCount": 72255,
+      "stargazerCount": 72508,
       "description": ":cherry_blossom: A command-line fuzzy finder",
       "primaryLanguage": "Go",
       "starredAt": "2019-01-08T01:18:30Z"
@@ -11634,7 +11745,7 @@
     {
       "nameWithOwner": "rrweb-io/rrweb",
       "url": "https://github.com/rrweb-io/rrweb",
-      "stargazerCount": 18291,
+      "stargazerCount": 18326,
       "description": "record and replay the web",
       "primaryLanguage": "TypeScript",
       "starredAt": "2019-01-02T22:51:04Z"
@@ -11674,7 +11785,7 @@
     {
       "nameWithOwner": "a-type/adjective-adjective-animal",
       "url": "https://github.com/a-type/adjective-adjective-animal",
-      "stargazerCount": 73,
+      "stargazerCount": 74,
       "description": "Suitably random and reasonably unique human readable (and fairly adorable) ids",
       "primaryLanguage": "JavaScript",
       "starredAt": "2018-12-21T20:55:34Z"
@@ -11690,7 +11801,7 @@
     {
       "nameWithOwner": "hashicorp/terraform",
       "url": "https://github.com/hashicorp/terraform",
-      "stargazerCount": 45913,
+      "stargazerCount": 45962,
       "description": "Terraform enables you to safely and predictably create, change, and improve infrastructure. It is a source-available tool that codifies APIs into declarative configuration files that can be shared amongst team members, treated as code, edited, reviewed, and versioned.",
       "primaryLanguage": "Go",
       "starredAt": "2018-12-20T23:33:45Z"
@@ -11698,7 +11809,7 @@
     {
       "nameWithOwner": "hashicorp/packer",
       "url": "https://github.com/hashicorp/packer",
-      "stargazerCount": 15412,
+      "stargazerCount": 15420,
       "description": "Packer is a tool for creating identical machine images for multiple platforms from a single source configuration.",
       "primaryLanguage": "Go",
       "starredAt": "2018-12-20T23:33:39Z"
@@ -11714,7 +11825,7 @@
     {
       "nameWithOwner": "netlify/cli",
       "url": "https://github.com/netlify/cli",
-      "stargazerCount": 1707,
+      "stargazerCount": 1711,
       "description": "Netlify Command Line Interface",
       "primaryLanguage": "TypeScript",
       "starredAt": "2018-12-20T02:40:21Z"
@@ -11722,7 +11833,7 @@
     {
       "nameWithOwner": "infinitered/gluegun",
       "url": "https://github.com/infinitered/gluegun",
-      "stargazerCount": 3018,
+      "stargazerCount": 3021,
       "description": "A delightful toolkit for building TypeScript-powered command-line apps.",
       "primaryLanguage": "TypeScript",
       "starredAt": "2018-12-20T01:47:15Z"
@@ -11730,7 +11841,7 @@
     {
       "nameWithOwner": "avajs/ava",
       "url": "https://github.com/avajs/ava",
-      "stargazerCount": 20813,
+      "stargazerCount": 20818,
       "description": "Node.js test runner that lets you develop with confidence 🚀",
       "primaryLanguage": "JavaScript",
       "starredAt": "2018-12-20T01:16:47Z"
@@ -11770,7 +11881,7 @@
     {
       "nameWithOwner": "obartra/ssim",
       "url": "https://github.com/obartra/ssim",
-      "stargazerCount": 310,
+      "stargazerCount": 311,
       "description": "🖼🔬 JavaScript Image Comparison",
       "primaryLanguage": "TypeScript",
       "starredAt": "2018-12-18T02:21:11Z"
@@ -11802,7 +11913,7 @@
     {
       "nameWithOwner": "developit/htm",
       "url": "https://github.com/developit/htm",
-      "stargazerCount": 8895,
+      "stargazerCount": 8910,
       "description": "Hyperscript Tagged Markup: JSX alternative using standard tagged templates, with compiler support.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2018-12-13T10:36:21Z"
@@ -11818,7 +11929,7 @@
     {
       "nameWithOwner": "kubeflow/kubeflow",
       "url": "https://github.com/kubeflow/kubeflow",
-      "stargazerCount": 15093,
+      "stargazerCount": 15113,
       "description": "Machine Learning Toolkit for Kubernetes",
       "primaryLanguage": "TypeScript",
       "starredAt": "2018-12-13T06:27:13Z"
@@ -11826,7 +11937,7 @@
     {
       "nameWithOwner": "devhubapp/devhub",
       "url": "https://github.com/devhubapp/devhub",
-      "stargazerCount": 9913,
+      "stargazerCount": 9918,
       "description": "TweetDeck for GitHub - Filter Issues, Activities & Notifications - Web, Mobile & Desktop with 99% code sharing between them",
       "primaryLanguage": "TypeScript",
       "starredAt": "2018-12-12T23:44:50Z"
@@ -11834,7 +11945,7 @@
     {
       "nameWithOwner": "supercollider/supercollider",
       "url": "https://github.com/supercollider/supercollider",
-      "stargazerCount": 5975,
+      "stargazerCount": 5994,
       "description": "An audio server, programming language, and IDE for sound synthesis and algorithmic composition.",
       "primaryLanguage": "C++",
       "starredAt": "2018-12-12T23:42:36Z"
@@ -11850,7 +11961,7 @@
     {
       "nameWithOwner": "mattdesl/canvas-sketch-util",
       "url": "https://github.com/mattdesl/canvas-sketch-util",
-      "stargazerCount": 738,
+      "stargazerCount": 739,
       "description": "Utilities for sketching in Canvas, WebGL and generative art",
       "primaryLanguage": "JavaScript",
       "starredAt": "2018-12-10T23:52:38Z"
@@ -11858,7 +11969,7 @@
     {
       "nameWithOwner": "regl-project/regl",
       "url": "https://github.com/regl-project/regl",
-      "stargazerCount": 5420,
+      "stargazerCount": 5430,
       "description": "👑 Functional WebGL",
       "primaryLanguage": "JavaScript",
       "starredAt": "2018-12-10T23:37:47Z"
@@ -11866,7 +11977,7 @@
     {
       "nameWithOwner": "mattdesl/canvas-sketch",
       "url": "https://github.com/mattdesl/canvas-sketch",
-      "stargazerCount": 5175,
+      "stargazerCount": 5178,
       "description": "[beta] A framework for making generative artwork in JavaScript and the browser.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2018-12-10T23:32:11Z"
@@ -11874,7 +11985,7 @@
     {
       "nameWithOwner": "davidbau/seedrandom",
       "url": "https://github.com/davidbau/seedrandom",
-      "stargazerCount": 2099,
+      "stargazerCount": 2101,
       "description": "seeded random number generator for Javascript",
       "primaryLanguage": "JavaScript",
       "starredAt": "2018-12-10T19:34:16Z"
@@ -11882,7 +11993,7 @@
     {
       "nameWithOwner": "rtyley/bfg-repo-cleaner",
       "url": "https://github.com/rtyley/bfg-repo-cleaner",
-      "stargazerCount": 11645,
+      "stargazerCount": 11663,
       "description": "Removes large or troublesome blobs like git-filter-branch does, but faster. And written in Scala",
       "primaryLanguage": "Scala",
       "starredAt": "2018-12-10T03:49:46Z"
@@ -11922,7 +12033,7 @@
     {
       "nameWithOwner": "elementor/wp2static",
       "url": "https://github.com/elementor/wp2static",
-      "stargazerCount": 1453,
+      "stargazerCount": 1454,
       "description": "WordPress static site generator for security, performance and cost benefits",
       "primaryLanguage": "PHP",
       "starredAt": "2018-12-05T04:33:53Z"
@@ -11954,7 +12065,7 @@
     {
       "nameWithOwner": "GitSquared/edex-ui",
       "url": "https://github.com/GitSquared/edex-ui",
-      "stargazerCount": 42680,
+      "stargazerCount": 42725,
       "description": "A cross-platform, customizable science fiction terminal emulator with advanced monitoring & touchscreen support.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2018-12-03T03:55:12Z"
@@ -11962,7 +12073,7 @@
     {
       "nameWithOwner": "jarun/nnn",
       "url": "https://github.com/jarun/nnn",
-      "stargazerCount": 20357,
+      "stargazerCount": 20390,
       "description": "n³ The unorthodox terminal file manager",
       "primaryLanguage": "C",
       "starredAt": "2018-12-03T03:27:27Z"
@@ -12026,7 +12137,7 @@
     {
       "nameWithOwner": "tensorflow/adanet",
       "url": "https://github.com/tensorflow/adanet",
-      "stargazerCount": 3460,
+      "stargazerCount": 3459,
       "description": "Fast and flexible AutoML with learning guarantees.",
       "primaryLanguage": "Jupyter Notebook",
       "starredAt": "2018-11-19T06:23:00Z"
@@ -12034,7 +12145,7 @@
     {
       "nameWithOwner": "amusi/awesome-object-detection",
       "url": "https://github.com/amusi/awesome-object-detection",
-      "stargazerCount": 7479,
+      "stargazerCount": 7486,
       "description": "Awesome Object Detection based on handong1587 github: https://handong1587.github.io/deep_learning/2015/10/09/object-detection.html",
       "primaryLanguage": null,
       "starredAt": "2018-11-19T05:02:48Z"
@@ -12042,7 +12153,7 @@
     {
       "nameWithOwner": "Toxblh/MTMR",
       "url": "https://github.com/Toxblh/MTMR",
-      "stargazerCount": 4259,
+      "stargazerCount": 4261,
       "description": "🌟 [My TouchBar My rules]. The Touch Bar Customisation App for your MacBook Pro",
       "primaryLanguage": "Swift",
       "starredAt": "2018-11-19T02:14:33Z"
@@ -12050,7 +12161,7 @@
     {
       "nameWithOwner": "sindresorhus/ky",
       "url": "https://github.com/sindresorhus/ky",
-      "stargazerCount": 15103,
+      "stargazerCount": 15144,
       "description": "🌳 Tiny & elegant JavaScript HTTP client based on the Fetch API",
       "primaryLanguage": "TypeScript",
       "starredAt": "2018-11-19T02:12:31Z"
@@ -12058,7 +12169,7 @@
     {
       "nameWithOwner": "tensorspace-team/tensorspace",
       "url": "https://github.com/tensorspace-team/tensorspace",
-      "stargazerCount": 5140,
+      "stargazerCount": 5141,
       "description": "Neural network 3D visualization framework, build interactive and intuitive model in browsers, support pre-trained deep learning models from TensorFlow, Keras, TensorFlow.js ",
       "primaryLanguage": "JavaScript",
       "starredAt": "2018-11-19T01:26:59Z"
@@ -12074,7 +12185,7 @@
     {
       "nameWithOwner": "opencpu/opencpu",
       "url": "https://github.com/opencpu/opencpu",
-      "stargazerCount": 747,
+      "stargazerCount": 748,
       "description": "OpenCPU system for embedded scientific computation and reproducible research",
       "primaryLanguage": "R",
       "starredAt": "2018-11-13T04:59:53Z"
@@ -12082,7 +12193,7 @@
     {
       "nameWithOwner": "davrodpin/mole",
       "url": "https://github.com/davrodpin/mole",
-      "stargazerCount": 1715,
+      "stargazerCount": 1714,
       "description": "CLI application to create ssh tunnels focused on resiliency and user experience.",
       "primaryLanguage": "Go",
       "starredAt": "2018-11-13T03:30:32Z"
@@ -12098,7 +12209,7 @@
     {
       "nameWithOwner": "antonmedv/fx",
       "url": "https://github.com/antonmedv/fx",
-      "stargazerCount": 19702,
+      "stargazerCount": 19729,
       "description": "Terminal JSON viewer & processor",
       "primaryLanguage": "Go",
       "starredAt": "2018-11-13T01:35:17Z"
@@ -12106,7 +12217,7 @@
     {
       "nameWithOwner": "bokuweb/react-rnd",
       "url": "https://github.com/bokuweb/react-rnd",
-      "stargazerCount": 4169,
+      "stargazerCount": 4178,
       "description": "🖱  A resizable and draggable component for React.",
       "primaryLanguage": "TypeScript",
       "starredAt": "2018-11-09T03:18:48Z"
@@ -12114,7 +12225,7 @@
     {
       "nameWithOwner": "bokuweb/re-resizable",
       "url": "https://github.com/bokuweb/re-resizable",
-      "stargazerCount": 2610,
+      "stargazerCount": 2615,
       "description": "📏  A resizable component for React.",
       "primaryLanguage": "TypeScript",
       "starredAt": "2018-11-09T01:31:22Z"
@@ -12122,7 +12233,7 @@
     {
       "nameWithOwner": "Cartucho/mAP",
       "url": "https://github.com/Cartucho/mAP",
-      "stargazerCount": 2955,
+      "stargazerCount": 2956,
       "description": "mean Average Precision - This code evaluates the performance of your neural net for object recognition.",
       "primaryLanguage": "Python",
       "starredAt": "2018-10-15T02:47:07Z"
@@ -12130,7 +12241,7 @@
     {
       "nameWithOwner": "retejs/rete",
       "url": "https://github.com/retejs/rete",
-      "stargazerCount": 10719,
+      "stargazerCount": 10736,
       "description": "JavaScript framework for visual programming",
       "primaryLanguage": "TypeScript",
       "starredAt": "2018-10-15T01:46:20Z"
@@ -12138,7 +12249,7 @@
     {
       "nameWithOwner": "oscarmorrison/md-page",
       "url": "https://github.com/oscarmorrison/md-page",
-      "stargazerCount": 1300,
+      "stargazerCount": 1301,
       "description": "📝 create a webpage with just markdown",
       "primaryLanguage": "JavaScript",
       "starredAt": "2018-10-15T01:43:28Z"
@@ -12186,7 +12297,7 @@
     {
       "nameWithOwner": "inaturalist/inaturalist",
       "url": "https://github.com/inaturalist/inaturalist",
-      "stargazerCount": 739,
+      "stargazerCount": 741,
       "description": "The Rails app behind iNaturalist.org",
       "primaryLanguage": "JavaScript",
       "starredAt": "2018-10-03T23:53:03Z"
@@ -12194,7 +12305,7 @@
     {
       "nameWithOwner": "visipedia/inat_comp",
       "url": "https://github.com/visipedia/inat_comp",
-      "stargazerCount": 776,
+      "stargazerCount": 779,
       "description": "iNaturalist competition details",
       "primaryLanguage": "Python",
       "starredAt": "2018-10-03T04:03:22Z"
@@ -12210,7 +12321,7 @@
     {
       "nameWithOwner": "rlabbe/Kalman-and-Bayesian-Filters-in-Python",
       "url": "https://github.com/rlabbe/Kalman-and-Bayesian-Filters-in-Python",
-      "stargazerCount": 18062,
+      "stargazerCount": 18086,
       "description": "Kalman Filter book using Jupyter Notebook. Focuses on building intuition and experience, not formal proofs.  Includes Kalman filters,extended Kalman filters, unscented Kalman filters, particle filters, and more. All exercises include solutions.",
       "primaryLanguage": "Jupyter Notebook",
       "starredAt": "2018-09-25T03:22:21Z"
@@ -12218,7 +12329,7 @@
     {
       "nameWithOwner": "afshinea/stanford-cs-229-machine-learning",
       "url": "https://github.com/afshinea/stanford-cs-229-machine-learning",
-      "stargazerCount": 18334,
+      "stargazerCount": 18348,
       "description": "VIP cheatsheets for Stanford's CS 229 Machine Learning",
       "primaryLanguage": null,
       "starredAt": "2018-09-19T20:56:48Z"
@@ -12234,7 +12345,7 @@
     {
       "nameWithOwner": "bbc/r-audio",
       "url": "https://github.com/bbc/r-audio",
-      "stargazerCount": 183,
+      "stargazerCount": 182,
       "description": "  A library of React components for building Web Audio graphs.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2018-09-14T03:48:36Z"
@@ -12250,7 +12361,7 @@
     {
       "nameWithOwner": "google/earthengine-api",
       "url": "https://github.com/google/earthengine-api",
-      "stargazerCount": 2909,
+      "stargazerCount": 2948,
       "description": "Python and JavaScript bindings for calling the Earth Engine API.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2018-09-12T02:30:53Z"
@@ -12266,7 +12377,7 @@
     {
       "nameWithOwner": "plotly/react-plotly.js",
       "url": "https://github.com/plotly/react-plotly.js",
-      "stargazerCount": 1065,
+      "stargazerCount": 1068,
       "description": "A plotly.js React component from Plotly 📈 ",
       "primaryLanguage": "JavaScript",
       "starredAt": "2018-09-11T00:13:46Z"
@@ -12274,7 +12385,7 @@
     {
       "nameWithOwner": "rafaelpadilla/Object-Detection-Metrics",
       "url": "https://github.com/rafaelpadilla/Object-Detection-Metrics",
-      "stargazerCount": 5065,
+      "stargazerCount": 5068,
       "description": "Most popular metrics used to evaluate object detection algorithms.",
       "primaryLanguage": "Python",
       "starredAt": "2018-09-06T05:28:08Z"
@@ -12290,7 +12401,7 @@
     {
       "nameWithOwner": "janishar/mit-deep-learning-book-pdf",
       "url": "https://github.com/janishar/mit-deep-learning-book-pdf",
-      "stargazerCount": 13460,
+      "stargazerCount": 13482,
       "description": "MIT Deep Learning Book in PDF format (complete and parts) by Ian Goodfellow, Yoshua Bengio and Aaron Courville",
       "primaryLanguage": "Java",
       "starredAt": "2018-08-29T10:39:38Z"
@@ -12298,7 +12409,7 @@
     {
       "nameWithOwner": "plotly/plotly.py",
       "url": "https://github.com/plotly/plotly.py",
-      "stargazerCount": 17487,
+      "stargazerCount": 17540,
       "description": "The interactive graphing library for Python :sparkles:",
       "primaryLanguage": "Python",
       "starredAt": "2018-08-29T02:18:05Z"
@@ -12306,7 +12417,7 @@
     {
       "nameWithOwner": "Azure/azure-storage-fuse",
       "url": "https://github.com/Azure/azure-storage-fuse",
-      "stargazerCount": 758,
+      "stargazerCount": 764,
       "description": "A virtual file system adapter for Azure Blob storage",
       "primaryLanguage": "Go",
       "starredAt": "2018-08-29T00:25:38Z"
@@ -12314,7 +12425,7 @@
     {
       "nameWithOwner": "pachyderm/pachyderm",
       "url": "https://github.com/pachyderm/pachyderm",
-      "stargazerCount": 6243,
+      "stargazerCount": 6249,
       "description": "Data-Centric Pipelines and Data Versioning",
       "primaryLanguage": "Go",
       "starredAt": "2018-08-29T00:10:08Z"
@@ -12322,7 +12433,7 @@
     {
       "nameWithOwner": "openml/OpenML",
       "url": "https://github.com/openml/OpenML",
-      "stargazerCount": 698,
+      "stargazerCount": 702,
       "description": "Open Machine Learning",
       "primaryLanguage": "PHP",
       "starredAt": "2018-08-29T00:03:19Z"
@@ -12330,7 +12441,7 @@
     {
       "nameWithOwner": "Kaggle/kaggle-api",
       "url": "https://github.com/Kaggle/kaggle-api",
-      "stargazerCount": 6744,
+      "stargazerCount": 6765,
       "description": "Official Kaggle API",
       "primaryLanguage": "Python",
       "starredAt": "2018-08-26T23:01:51Z"
@@ -12362,7 +12473,7 @@
     {
       "nameWithOwner": "AlexeyAB/darknet",
       "url": "https://github.com/AlexeyAB/darknet",
-      "stargazerCount": 22095,
+      "stargazerCount": 22113,
       "description": "YOLOv4 / Scaled-YOLOv4 / YOLO - Neural Networks for Object Detection (Windows and Linux version of Darknet )",
       "primaryLanguage": "C",
       "starredAt": "2018-08-23T02:39:43Z"
@@ -12378,7 +12489,7 @@
     {
       "nameWithOwner": "PyAV-Org/PyAV",
       "url": "https://github.com/PyAV-Org/PyAV",
-      "stargazerCount": 2877,
+      "stargazerCount": 2892,
       "description": "﻿﻿Pythonic bindings for FFmpeg's libraries.",
       "primaryLanguage": "Python",
       "starredAt": "2018-08-21T01:35:13Z"
@@ -12386,7 +12497,7 @@
     {
       "nameWithOwner": "NVIDIA/vid2vid",
       "url": "https://github.com/NVIDIA/vid2vid",
-      "stargazerCount": 8684,
+      "stargazerCount": 8688,
       "description": "Pytorch implementation of our method for high-resolution (e.g. 2048x1024) photorealistic video-to-video translation.",
       "primaryLanguage": "Python",
       "starredAt": "2018-08-20T19:27:19Z"
@@ -12402,7 +12513,7 @@
     {
       "nameWithOwner": "ipython-contrib/jupyter_contrib_nbextensions",
       "url": "https://github.com/ipython-contrib/jupyter_contrib_nbextensions",
-      "stargazerCount": 5276,
+      "stargazerCount": 5277,
       "description": "A collection of various notebook extensions for Jupyter",
       "primaryLanguage": "JavaScript",
       "starredAt": "2018-08-16T05:13:44Z"
@@ -12426,7 +12537,7 @@
     {
       "nameWithOwner": "horovod/horovod",
       "url": "https://github.com/horovod/horovod",
-      "stargazerCount": 14552,
+      "stargazerCount": 14559,
       "description": "Distributed training framework for TensorFlow, Keras, PyTorch, and Apache MXNet.",
       "primaryLanguage": "Python",
       "starredAt": "2018-08-16T01:39:40Z"
@@ -12434,7 +12545,7 @@
     {
       "nameWithOwner": "tensorflow/tensorboard",
       "url": "https://github.com/tensorflow/tensorboard",
-      "stargazerCount": 6940,
+      "stargazerCount": 6953,
       "description": "TensorFlow's Visualization Toolkit",
       "primaryLanguage": "TypeScript",
       "starredAt": "2018-08-14T22:19:29Z"
@@ -12458,7 +12569,7 @@
     {
       "nameWithOwner": "keras-team/autokeras",
       "url": "https://github.com/keras-team/autokeras",
-      "stargazerCount": 9250,
+      "stargazerCount": 9256,
       "description": "AutoML library for deep learning",
       "primaryLanguage": "Python",
       "starredAt": "2018-08-13T07:34:35Z"
@@ -12474,7 +12585,7 @@
     {
       "nameWithOwner": "forem/forem",
       "url": "https://github.com/forem/forem",
-      "stargazerCount": 22379,
+      "stargazerCount": 22401,
       "description": "For empowering community 🌱",
       "primaryLanguage": "Ruby",
       "starredAt": "2018-08-10T08:37:42Z"
@@ -12482,7 +12593,7 @@
     {
       "nameWithOwner": "waspinator/pycococreator",
       "url": "https://github.com/waspinator/pycococreator",
-      "stargazerCount": 784,
+      "stargazerCount": 783,
       "description": "Helper functions to create COCO datasets",
       "primaryLanguage": "Python",
       "starredAt": "2018-08-09T03:38:59Z"
@@ -12490,7 +12601,7 @@
     {
       "nameWithOwner": "EdjeElectronics/TensorFlow-Object-Detection-API-Tutorial-Train-Multiple-Objects-Windows-10",
       "url": "https://github.com/EdjeElectronics/TensorFlow-Object-Detection-API-Tutorial-Train-Multiple-Objects-Windows-10",
-      "stargazerCount": 2937,
+      "stargazerCount": 2938,
       "description": "How to train a TensorFlow Object Detection Classifier for multiple object detection on Windows",
       "primaryLanguage": "Python",
       "starredAt": "2018-08-08T22:45:41Z"
@@ -12498,7 +12609,7 @@
     {
       "nameWithOwner": "tzutalin/ImageNet_Utils",
       "url": "https://github.com/tzutalin/ImageNet_Utils",
-      "stargazerCount": 640,
+      "stargazerCount": 641,
       "description": ":arrow_double_down:  Utils to help download images by id, crop bounding box, label images, etc.",
       "primaryLanguage": "Python",
       "starredAt": "2018-08-08T22:43:41Z"
@@ -12506,7 +12617,7 @@
     {
       "nameWithOwner": "HumanSignal/labelImg",
       "url": "https://github.com/HumanSignal/labelImg",
-      "stargazerCount": 24051,
+      "stargazerCount": 24097,
       "description": "LabelImg is now part of the Label Studio community. The popular image annotation tool created by Tzutalin is no longer actively being developed, but you can check out Label Studio, the open source data labeling tool for images, text, hypertext, audio, video and time-series data.",
       "primaryLanguage": "Python",
       "starredAt": "2018-08-08T22:41:04Z"
@@ -12514,7 +12625,7 @@
     {
       "nameWithOwner": "tensorflow/models",
       "url": "https://github.com/tensorflow/models",
-      "stargazerCount": 77618,
+      "stargazerCount": 77616,
       "description": "Models and examples built with TensorFlow",
       "primaryLanguage": "Python",
       "starredAt": "2018-08-08T10:03:50Z"
@@ -12538,7 +12649,7 @@
     {
       "nameWithOwner": "tensorlayer/SRGAN",
       "url": "https://github.com/tensorlayer/SRGAN",
-      "stargazerCount": 3425,
+      "stargazerCount": 3427,
       "description": "Photo-Realistic Single Image Super-Resolution Using a Generative Adversarial Network",
       "primaryLanguage": "Python",
       "starredAt": "2018-08-07T00:26:57Z"
@@ -12546,7 +12657,7 @@
     {
       "nameWithOwner": "jwyang/faster-rcnn.pytorch",
       "url": "https://github.com/jwyang/faster-rcnn.pytorch",
-      "stargazerCount": 7819,
+      "stargazerCount": 7823,
       "description": "A faster pytorch implementation of faster r-cnn",
       "primaryLanguage": "Python",
       "starredAt": "2018-08-07T00:25:08Z"
@@ -12554,7 +12665,7 @@
     {
       "nameWithOwner": "fizyr/keras-retinanet",
       "url": "https://github.com/fizyr/keras-retinanet",
-      "stargazerCount": 4395,
+      "stargazerCount": 4397,
       "description": "Keras implementation of RetinaNet object detection.",
       "primaryLanguage": "Python",
       "starredAt": "2018-08-06T23:56:42Z"
@@ -12570,7 +12681,7 @@
     {
       "nameWithOwner": "openimages/dataset",
       "url": "https://github.com/openimages/dataset",
-      "stargazerCount": 4325,
+      "stargazerCount": 4328,
       "description": "The Open Images dataset",
       "primaryLanguage": "Python",
       "starredAt": "2018-08-04T22:34:05Z"
@@ -12586,7 +12697,7 @@
     {
       "nameWithOwner": "jupyterhub/jupyterhub",
       "url": "https://github.com/jupyterhub/jupyterhub",
-      "stargazerCount": 8072,
+      "stargazerCount": 8083,
       "description": "Multi-user server for Jupyter notebooks",
       "primaryLanguage": "Python",
       "starredAt": "2018-08-02T18:40:11Z"
@@ -12594,7 +12705,7 @@
     {
       "nameWithOwner": "jupyterlab/jupyterlab",
       "url": "https://github.com/jupyterlab/jupyterlab",
-      "stargazerCount": 14709,
+      "stargazerCount": 14727,
       "description": "JupyterLab computational environment.",
       "primaryLanguage": "TypeScript",
       "starredAt": "2018-08-02T18:20:57Z"
@@ -12602,7 +12713,7 @@
     {
       "nameWithOwner": "ytdl-org/youtube-dl",
       "url": "https://github.com/ytdl-org/youtube-dl",
-      "stargazerCount": 136603,
+      "stargazerCount": 136738,
       "description": "Command-line program to download videos from YouTube.com and other video sites",
       "primaryLanguage": "Python",
       "starredAt": "2018-08-02T06:49:30Z"
@@ -12610,7 +12721,7 @@
     {
       "nameWithOwner": "fastai/fastai",
       "url": "https://github.com/fastai/fastai",
-      "stargazerCount": 27245,
+      "stargazerCount": 27300,
       "description": "The fastai deep learning library",
       "primaryLanguage": "Jupyter Notebook",
       "starredAt": "2018-08-02T02:44:05Z"
@@ -12618,7 +12729,7 @@
     {
       "nameWithOwner": "ryouchinsa/Rectlabel-support",
       "url": "https://github.com/ryouchinsa/Rectlabel-support",
-      "stargazerCount": 535,
+      "stargazerCount": 536,
       "description": "RectLabel is an offline image annotation tool for object detection and segmentation.",
       "primaryLanguage": "Python",
       "starredAt": "2018-08-02T01:33:50Z"
@@ -12626,7 +12737,7 @@
     {
       "nameWithOwner": "cocodataset/cocoapi",
       "url": "https://github.com/cocodataset/cocoapi",
-      "stargazerCount": 6276,
+      "stargazerCount": 6281,
       "description": "COCO API - Dataset @ http://cocodataset.org/ ",
       "primaryLanguage": "Jupyter Notebook",
       "starredAt": "2018-08-02T01:16:10Z"
@@ -12634,7 +12745,7 @@
     {
       "nameWithOwner": "tensorflow/tensorflow",
       "url": "https://github.com/tensorflow/tensorflow",
-      "stargazerCount": 190874,
+      "stargazerCount": 191021,
       "description": "An Open Source Machine Learning Framework for Everyone",
       "primaryLanguage": "C++",
       "starredAt": "2018-08-01T01:40:04Z"
@@ -12642,7 +12753,7 @@
     {
       "nameWithOwner": "onnx/onnx",
       "url": "https://github.com/onnx/onnx",
-      "stargazerCount": 19313,
+      "stargazerCount": 19372,
       "description": "Open standard for machine learning interoperability",
       "primaryLanguage": "Python",
       "starredAt": "2018-08-01T01:31:02Z"
@@ -12650,7 +12761,7 @@
     {
       "nameWithOwner": "hanskrupakar/COCO-Style-Dataset-Generator-GUI",
       "url": "https://github.com/hanskrupakar/COCO-Style-Dataset-Generator-GUI",
-      "stargazerCount": 144,
+      "stargazerCount": 143,
       "description": "A simple GUI-based COCO-style JSON Polygon masks' annotation tool to facilitate quick and efficient crowd-sourced generation of annotation masks and bounding boxes. Optionally, one could choose to use a pretrained Mask RCNN model to come up with initial segmentations. ",
       "primaryLanguage": "Python",
       "starredAt": "2018-07-31T23:48:07Z"
@@ -12658,7 +12769,7 @@
     {
       "nameWithOwner": "pjreddie/darknet",
       "url": "https://github.com/pjreddie/darknet",
-      "stargazerCount": 26251,
+      "stargazerCount": 26261,
       "description": "Convolutional Neural Networks",
       "primaryLanguage": "C",
       "starredAt": "2018-07-31T01:12:44Z"
@@ -12666,7 +12777,7 @@
     {
       "nameWithOwner": "thtrieu/darkflow",
       "url": "https://github.com/thtrieu/darkflow",
-      "stargazerCount": 6157,
+      "stargazerCount": 6158,
       "description": "Translate darknet to tensorflow. Load trained weights, retrain/fine-tune using tensorflow, export constant graph def to mobile devices",
       "primaryLanguage": "Python",
       "starredAt": "2018-07-30T23:51:33Z"
@@ -12690,7 +12801,7 @@
     {
       "nameWithOwner": "matterport/Mask_RCNN",
       "url": "https://github.com/matterport/Mask_RCNN",
-      "stargazerCount": 25248,
+      "stargazerCount": 25260,
       "description": "Mask R-CNN for object detection and instance segmentation on Keras and TensorFlow",
       "primaryLanguage": "Python",
       "starredAt": "2018-07-30T04:47:49Z"
@@ -12746,7 +12857,7 @@
     {
       "nameWithOwner": "plibither8/markdown-new-tab",
       "url": "https://github.com/plibither8/markdown-new-tab",
-      "stargazerCount": 828,
+      "stargazerCount": 830,
       "description": "🗒️ ⏰ ✅ Save notes in Markdown directly in the 'New Tab' page",
       "primaryLanguage": "JavaScript",
       "starredAt": "2018-07-16T02:36:13Z"
@@ -12754,7 +12865,7 @@
     {
       "nameWithOwner": "browsh-org/browsh",
       "url": "https://github.com/browsh-org/browsh",
-      "stargazerCount": 17692,
+      "stargazerCount": 17709,
       "description": "A fully-modern text-based browser, rendering to TTY and browsers",
       "primaryLanguage": "JavaScript",
       "starredAt": "2018-07-12T22:43:30Z"
@@ -12762,7 +12873,7 @@
     {
       "nameWithOwner": "creativetimofficial/material-dashboard",
       "url": "https://github.com/creativetimofficial/material-dashboard",
-      "stargazerCount": 11157,
+      "stargazerCount": 11161,
       "description": "Material Dashboard - Open Source Bootstrap 5 Material Design Admin",
       "primaryLanguage": "SCSS",
       "starredAt": "2018-07-09T00:46:04Z"
@@ -12770,7 +12881,7 @@
     {
       "nameWithOwner": "weixsong/elasticlunr.js",
       "url": "https://github.com/weixsong/elasticlunr.js",
-      "stargazerCount": 2070,
+      "stargazerCount": 2072,
       "description": "Based on lunr.js, but more flexible and customized.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2018-07-09T00:21:32Z"
@@ -12778,7 +12889,7 @@
     {
       "nameWithOwner": "nbedos/termtosvg",
       "url": "https://github.com/nbedos/termtosvg",
-      "stargazerCount": 9731,
+      "stargazerCount": 9733,
       "description": "Record terminal sessions as SVG animations",
       "primaryLanguage": "Python",
       "starredAt": "2018-07-08T22:36:22Z"
@@ -12786,7 +12897,7 @@
     {
       "nameWithOwner": "GetPublii/Publii",
       "url": "https://github.com/GetPublii/Publii",
-      "stargazerCount": 6825,
+      "stargazerCount": 6833,
       "description": "The most intuitive Static Site CMS designed for SEO-optimized and privacy-focused websites.",
       "primaryLanguage": "HTML",
       "starredAt": "2018-07-08T22:32:46Z"
@@ -12866,7 +12977,7 @@
     {
       "nameWithOwner": "justadudewhohacks/face-api.js",
       "url": "https://github.com/justadudewhohacks/face-api.js",
-      "stargazerCount": 17387,
+      "stargazerCount": 17406,
       "description": "JavaScript API for face detection and face recognition in the browser and nodejs with tensorflow.js",
       "primaryLanguage": "TypeScript",
       "starredAt": "2018-07-04T00:30:33Z"
@@ -12874,7 +12985,7 @@
     {
       "nameWithOwner": "FiloSottile/mkcert",
       "url": "https://github.com/FiloSottile/mkcert",
-      "stargazerCount": 54845,
+      "stargazerCount": 55025,
       "description": "A simple zero-config tool to make locally trusted development certificates with any names you'd like.",
       "primaryLanguage": "Go",
       "starredAt": "2018-07-04T00:27:38Z"
@@ -12890,7 +13001,7 @@
     {
       "nameWithOwner": "mdx-js/mdx",
       "url": "https://github.com/mdx-js/mdx",
-      "stargazerCount": 18643,
+      "stargazerCount": 18683,
       "description": "Markdown for the component era",
       "primaryLanguage": "JavaScript",
       "starredAt": "2018-07-03T23:34:51Z"
@@ -12906,7 +13017,7 @@
     {
       "nameWithOwner": "doczjs/docz",
       "url": "https://github.com/doczjs/docz",
-      "stargazerCount": 23686,
+      "stargazerCount": 23685,
       "description": "✍ It has never been so easy to document your things!",
       "primaryLanguage": "TypeScript",
       "starredAt": "2018-07-03T23:31:48Z"
@@ -12922,7 +13033,7 @@
     {
       "nameWithOwner": "observablehq/runtime",
       "url": "https://github.com/observablehq/runtime",
-      "stargazerCount": 1046,
+      "stargazerCount": 1048,
       "description": "The reactive dataflow runtime that powers Observable Framework and Observable notebooks",
       "primaryLanguage": "JavaScript",
       "starredAt": "2018-06-26T06:47:10Z"
@@ -12938,7 +13049,7 @@
     {
       "nameWithOwner": "tensorflow/tfjs-models",
       "url": "https://github.com/tensorflow/tfjs-models",
-      "stargazerCount": 14578,
+      "stargazerCount": 14591,
       "description": "Pretrained models for TensorFlow.js",
       "primaryLanguage": "TypeScript",
       "starredAt": "2018-06-25T03:54:22Z"
@@ -12946,7 +13057,7 @@
     {
       "nameWithOwner": "russellsamora/scrollama",
       "url": "https://github.com/russellsamora/scrollama",
-      "stargazerCount": 5879,
+      "stargazerCount": 5884,
       "description": "Scrollytelling with IntersectionObserver.",
       "primaryLanguage": "HTML",
       "starredAt": "2018-06-25T01:24:42Z"
@@ -12954,7 +13065,7 @@
     {
       "nameWithOwner": "swup/swup",
       "url": "https://github.com/swup/swup",
-      "stargazerCount": 4959,
+      "stargazerCount": 4965,
       "description": "Versatile and extensible page transition library for server-rendered websites 🎉",
       "primaryLanguage": "TypeScript",
       "starredAt": "2018-06-25T01:23:01Z"
@@ -12962,7 +13073,7 @@
     {
       "nameWithOwner": "dylanaraps/pure-bash-bible",
       "url": "https://github.com/dylanaraps/pure-bash-bible",
-      "stargazerCount": 39707,
+      "stargazerCount": 39784,
       "description": "📖 A collection of pure bash alternatives to external processes.",
       "primaryLanguage": "Shell",
       "starredAt": "2018-06-25T00:08:57Z"
@@ -12978,7 +13089,7 @@
     {
       "nameWithOwner": "vibora-io/vibora",
       "url": "https://github.com/vibora-io/vibora",
-      "stargazerCount": 5639,
+      "stargazerCount": 5637,
       "description": "Fast, asynchronous and elegant Python web framework.",
       "primaryLanguage": "Python",
       "starredAt": "2018-06-24T23:10:21Z"
@@ -12986,7 +13097,7 @@
     {
       "nameWithOwner": "kasper/phoenix",
       "url": "https://github.com/kasper/phoenix",
-      "stargazerCount": 4481,
+      "stargazerCount": 4486,
       "description": "A lightweight macOS window and app manager scriptable with JavaScript",
       "primaryLanguage": "Objective-C",
       "starredAt": "2018-06-24T22:41:43Z"
@@ -13018,7 +13129,7 @@
     {
       "nameWithOwner": "d3/d3",
       "url": "https://github.com/d3/d3",
-      "stargazerCount": 111107,
+      "stargazerCount": 111180,
       "description": "Bring data to life with SVG, Canvas and HTML. :bar_chart::chart_with_upwards_trend::tada:",
       "primaryLanguage": "Shell",
       "starredAt": "2018-06-20T05:52:27Z"
@@ -13026,7 +13137,7 @@
     {
       "nameWithOwner": "tensorflow/tfjs-examples",
       "url": "https://github.com/tensorflow/tfjs-examples",
-      "stargazerCount": 6732,
+      "stargazerCount": 6733,
       "description": "Examples built with TensorFlow.js",
       "primaryLanguage": "JavaScript",
       "starredAt": "2018-06-17T06:46:59Z"
@@ -13034,7 +13145,7 @@
     {
       "nameWithOwner": "keras-team/keras",
       "url": "https://github.com/keras-team/keras",
-      "stargazerCount": 63233,
+      "stargazerCount": 63264,
       "description": "Deep Learning for humans",
       "primaryLanguage": "Python",
       "starredAt": "2018-06-17T01:52:34Z"
@@ -13042,7 +13153,7 @@
     {
       "nameWithOwner": "Theano/Theano",
       "url": "https://github.com/Theano/Theano",
-      "stargazerCount": 9951,
+      "stargazerCount": 9952,
       "description": "Theano was a Python library that allows you to define, optimize, and evaluate mathematical expressions involving multi-dimensional arrays efficiently. It is being continued as PyTensor: www.github.com/pymc-devs/pytensor",
       "primaryLanguage": "Python",
       "starredAt": "2018-06-17T01:23:19Z"
@@ -13050,7 +13161,7 @@
     {
       "nameWithOwner": "ml5js/ml5-library",
       "url": "https://github.com/ml5js/ml5-library",
-      "stargazerCount": 6568,
+      "stargazerCount": 6569,
       "description": "Friendly machine learning for the web! 🤖 ",
       "primaryLanguage": "JavaScript",
       "starredAt": "2018-06-16T22:29:08Z"
@@ -13074,7 +13185,7 @@
     {
       "nameWithOwner": "cazala/synaptic",
       "url": "https://github.com/cazala/synaptic",
-      "stargazerCount": 6925,
+      "stargazerCount": 6922,
       "description": "architecture-free neural network library for node.js and the browser",
       "primaryLanguage": "JavaScript",
       "starredAt": "2018-06-16T08:38:53Z"
@@ -13090,7 +13201,7 @@
     {
       "nameWithOwner": "mil-tokyo/webdnn",
       "url": "https://github.com/mil-tokyo/webdnn",
-      "stargazerCount": 1995,
+      "stargazerCount": 1996,
       "description": "The Fastest DNN Running Framework on Web Browser",
       "primaryLanguage": "TypeScript",
       "starredAt": "2018-06-16T08:38:42Z"
@@ -13098,7 +13209,7 @@
     {
       "nameWithOwner": "stevenmiller888/mind",
       "url": "https://github.com/stevenmiller888/mind",
-      "stargazerCount": 1508,
+      "stargazerCount": 1509,
       "description": "A neural network library built in JavaScript",
       "primaryLanguage": "JavaScript",
       "starredAt": "2018-06-16T08:36:04Z"
@@ -13106,7 +13217,7 @@
     {
       "nameWithOwner": "teambit/bit",
       "url": "https://github.com/teambit/bit",
-      "stargazerCount": 18144,
+      "stargazerCount": 18154,
       "description": "AI-powered development workspaces with reusable components, architectural clarity and zero overhead.",
       "primaryLanguage": "TypeScript",
       "starredAt": "2018-06-16T08:30:20Z"
@@ -13114,7 +13225,7 @@
     {
       "nameWithOwner": "nenadmarkus/picojs",
       "url": "https://github.com/nenadmarkus/picojs",
-      "stargazerCount": 6313,
+      "stargazerCount": 6312,
       "description": "A face detection library in 200 lines of JavaScript",
       "primaryLanguage": "JavaScript",
       "starredAt": "2018-06-16T08:28:12Z"
@@ -13138,7 +13249,7 @@
     {
       "nameWithOwner": "freeCodeCamp/devdocs",
       "url": "https://github.com/freeCodeCamp/devdocs",
-      "stargazerCount": 36749,
+      "stargazerCount": 36796,
       "description": "API Documentation Browser",
       "primaryLanguage": "Ruby",
       "starredAt": "2018-06-16T03:56:04Z"
@@ -13154,7 +13265,7 @@
     {
       "nameWithOwner": "davidjbradshaw/iframe-resizer",
       "url": "https://github.com/davidjbradshaw/iframe-resizer",
-      "stargazerCount": 6810,
+      "stargazerCount": 6815,
       "description": "Keep iframes sized to their content",
       "primaryLanguage": "JavaScript",
       "starredAt": "2018-06-14T01:27:43Z"
@@ -13170,7 +13281,7 @@
     {
       "nameWithOwner": "jwagner/simplex-noise.js",
       "url": "https://github.com/jwagner/simplex-noise.js",
-      "stargazerCount": 1756,
+      "stargazerCount": 1761,
       "description": "A fast simplex noise implementation in Javascript / Typescript.",
       "primaryLanguage": "TypeScript",
       "starredAt": "2018-06-13T04:30:23Z"
@@ -13178,7 +13289,7 @@
     {
       "nameWithOwner": "spite/THREE.MeshLine",
       "url": "https://github.com/spite/THREE.MeshLine",
-      "stargazerCount": 2266,
+      "stargazerCount": 2268,
       "description": "Mesh replacement for THREE.Line",
       "primaryLanguage": "JavaScript",
       "starredAt": "2018-06-13T00:37:45Z"
@@ -13194,7 +13305,7 @@
     {
       "nameWithOwner": "scikit-learn/scikit-learn",
       "url": "https://github.com/scikit-learn/scikit-learn",
-      "stargazerCount": 62750,
+      "stargazerCount": 62870,
       "description": "scikit-learn: machine learning in Python",
       "primaryLanguage": "Python",
       "starredAt": "2018-06-12T21:09:55Z"
@@ -13202,7 +13313,7 @@
     {
       "nameWithOwner": "mnielsen/neural-networks-and-deep-learning",
       "url": "https://github.com/mnielsen/neural-networks-and-deep-learning",
-      "stargazerCount": 16882,
+      "stargazerCount": 16906,
       "description": "Code samples for my book \"Neural Networks and Deep Learning\"",
       "primaryLanguage": "Python",
       "starredAt": "2018-06-12T09:04:31Z"
@@ -13210,7 +13321,7 @@
     {
       "nameWithOwner": "gnuns/allOrigins",
       "url": "https://github.com/gnuns/allOrigins",
-      "stargazerCount": 878,
+      "stargazerCount": 888,
       "description": ":alien: Pull content from any page as JSON via API",
       "primaryLanguage": "JavaScript",
       "starredAt": "2018-06-09T12:03:32Z"
@@ -13226,7 +13337,7 @@
     {
       "nameWithOwner": "lodash/lodash",
       "url": "https://github.com/lodash/lodash",
-      "stargazerCount": 60753,
+      "stargazerCount": 60795,
       "description": "A modern JavaScript utility library delivering modularity, performance, & extras.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2018-06-07T12:22:15Z"
@@ -13234,7 +13345,7 @@
     {
       "nameWithOwner": "sanity-io/sanity",
       "url": "https://github.com/sanity-io/sanity",
-      "stargazerCount": 5738,
+      "stargazerCount": 5744,
       "description": "Sanity Studio – Rapidly configure content workspaces powered by structured content",
       "primaryLanguage": "TypeScript",
       "starredAt": "2018-06-07T10:45:36Z"
@@ -13266,7 +13377,7 @@
     {
       "nameWithOwner": "Vagr9K/gatsby-advanced-starter",
       "url": "https://github.com/Vagr9K/gatsby-advanced-starter",
-      "stargazerCount": 1564,
+      "stargazerCount": 1563,
       "description": "A high performance skeleton starter for GatsbyJS with an advanced feature set.",
       "primaryLanguage": "TypeScript",
       "starredAt": "2018-06-06T06:47:54Z"
@@ -13274,7 +13385,7 @@
     {
       "nameWithOwner": "nosir/cleave.js",
       "url": "https://github.com/nosir/cleave.js",
-      "stargazerCount": 17933,
+      "stargazerCount": 17932,
       "description": "Format input text content when you are typing...",
       "primaryLanguage": "JavaScript",
       "starredAt": "2018-06-06T00:17:10Z"
@@ -13282,7 +13393,7 @@
     {
       "nameWithOwner": "jmhobbs/cultofthepartyparrot.com",
       "url": "https://github.com/jmhobbs/cultofthepartyparrot.com",
-      "stargazerCount": 1514,
+      "stargazerCount": 1512,
       "description": "PARTY OR DIE",
       "primaryLanguage": "HTML",
       "starredAt": "2018-06-05T00:44:47Z"
@@ -13290,7 +13401,7 @@
     {
       "nameWithOwner": "hendricius/the-bread-code",
       "url": "https://github.com/hendricius/the-bread-code",
-      "stargazerCount": 4111,
+      "stargazerCount": 4114,
       "description": "Learn how to master the art of baking the programmer way.",
       "primaryLanguage": "Shell",
       "starredAt": "2018-06-04T04:24:59Z"
@@ -13298,7 +13409,7 @@
     {
       "nameWithOwner": "azirbel/npoint",
       "url": "https://github.com/azirbel/npoint",
-      "stargazerCount": 433,
+      "stargazerCount": 435,
       "description": "JSON storage bins with schema validation",
       "primaryLanguage": "JavaScript",
       "starredAt": "2018-06-04T04:24:38Z"
@@ -13314,7 +13425,7 @@
     {
       "nameWithOwner": "pytorch/pytorch",
       "url": "https://github.com/pytorch/pytorch",
-      "stargazerCount": 91731,
+      "stargazerCount": 92006,
       "description": "Tensors and Dynamic neural networks in Python with strong GPU acceleration",
       "primaryLanguage": "Python",
       "starredAt": "2018-06-04T02:18:32Z"
@@ -13322,7 +13433,7 @@
     {
       "nameWithOwner": "facebookarchive/caffe2",
       "url": "https://github.com/facebookarchive/caffe2",
-      "stargazerCount": 8419,
+      "stargazerCount": 8418,
       "description": "Caffe2 is a lightweight, modular, and scalable deep learning framework.",
       "primaryLanguage": "Shell",
       "starredAt": "2018-06-04T02:17:44Z"
@@ -13330,7 +13441,7 @@
     {
       "nameWithOwner": "psf/black",
       "url": "https://github.com/psf/black",
-      "stargazerCount": 40715,
+      "stargazerCount": 40748,
       "description": "The uncompromising Python code formatter",
       "primaryLanguage": "Python",
       "starredAt": "2018-06-03T21:46:16Z"
@@ -13338,7 +13449,7 @@
     {
       "nameWithOwner": "NVIDIA/nvidia-docker",
       "url": "https://github.com/NVIDIA/nvidia-docker",
-      "stargazerCount": 17399,
+      "stargazerCount": 17410,
       "description": "Build and run Docker containers leveraging NVIDIA GPUs",
       "primaryLanguage": null,
       "starredAt": "2018-06-01T22:10:57Z"
@@ -13362,7 +13473,7 @@
     {
       "nameWithOwner": "microsoft/VoTT",
       "url": "https://github.com/microsoft/VoTT",
-      "stargazerCount": 4398,
+      "stargazerCount": 4400,
       "description": "Visual Object Tagging Tool: An electron app for building end to end Object Detection Models from Images and Videos. ",
       "primaryLanguage": "TypeScript",
       "starredAt": "2018-06-01T11:57:47Z"
@@ -13370,7 +13481,7 @@
     {
       "nameWithOwner": "pallets/flask",
       "url": "https://github.com/pallets/flask",
-      "stargazerCount": 70031,
+      "stargazerCount": 70103,
       "description": "The Python micro framework for building web applications.",
       "primaryLanguage": "Python",
       "starredAt": "2018-06-01T10:53:29Z"
@@ -13394,7 +13505,7 @@
     {
       "nameWithOwner": "sindresorhus/got",
       "url": "https://github.com/sindresorhus/got",
-      "stargazerCount": 14685,
+      "stargazerCount": 14696,
       "description": "🌐 Human-friendly and powerful HTTP request library for Node.js",
       "primaryLanguage": "TypeScript",
       "starredAt": "2018-05-22T04:12:16Z"
@@ -13458,7 +13569,7 @@
     {
       "nameWithOwner": "tabler/tabler-react",
       "url": "https://github.com/tabler/tabler-react",
-      "stargazerCount": 2299,
+      "stargazerCount": 2298,
       "description": "React components and demo for the Tabler UI theme.",
       "primaryLanguage": "CSS",
       "starredAt": "2018-05-11T03:47:38Z"
@@ -13466,7 +13577,7 @@
     {
       "nameWithOwner": "Shopify/storefront-api-examples",
       "url": "https://github.com/Shopify/storefront-api-examples",
-      "stargazerCount": 1132,
+      "stargazerCount": 1133,
       "description": "Example custom storefront applications built on Shopify's Storefront API",
       "primaryLanguage": "JavaScript",
       "starredAt": "2018-05-11T00:49:25Z"
@@ -13490,7 +13601,7 @@
     {
       "nameWithOwner": "martinlaxenaire/curtainsjs",
       "url": "https://github.com/martinlaxenaire/curtainsjs",
-      "stargazerCount": 1750,
+      "stargazerCount": 1752,
       "description": "curtains.js is a lightweight vanilla WebGL javascript library that turns HTML DOM elements into interactive textured planes.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2018-05-09T04:43:02Z"
@@ -13498,7 +13609,7 @@
     {
       "nameWithOwner": "BVLC/caffe",
       "url": "https://github.com/BVLC/caffe",
-      "stargazerCount": 34463,
+      "stargazerCount": 34473,
       "description": "Caffe: a fast open framework for deep learning.",
       "primaryLanguage": "C++",
       "starredAt": "2018-05-04T10:14:31Z"
@@ -13506,7 +13617,7 @@
     {
       "nameWithOwner": "magenta/magenta-js",
       "url": "https://github.com/magenta/magenta-js",
-      "stargazerCount": 2065,
+      "stargazerCount": 2068,
       "description": "Magenta.js: Music and Art Generation with Machine Learning in the browser",
       "primaryLanguage": "TypeScript",
       "starredAt": "2018-05-02T12:19:59Z"
@@ -13514,7 +13625,7 @@
     {
       "nameWithOwner": "magenta/magenta",
       "url": "https://github.com/magenta/magenta",
-      "stargazerCount": 19576,
+      "stargazerCount": 19599,
       "description": "Magenta: Music and Art Generation with Machine Intelligence",
       "primaryLanguage": "Python",
       "starredAt": "2018-05-02T11:46:00Z"
@@ -13522,7 +13633,7 @@
     {
       "nameWithOwner": "RelaxedJS/ReLaXed",
       "url": "https://github.com/RelaxedJS/ReLaXed",
-      "stargazerCount": 11794,
+      "stargazerCount": 11795,
       "description": "Create PDF documents using web technologies",
       "primaryLanguage": "JavaScript",
       "starredAt": "2018-05-02T04:19:18Z"
@@ -13538,7 +13649,7 @@
     {
       "nameWithOwner": "11ty/eleventy",
       "url": "https://github.com/11ty/eleventy",
-      "stargazerCount": 18497,
+      "stargazerCount": 18557,
       "description": "A simpler site generator. Transforms a directory of templates (of varying types) into HTML.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2018-05-01T23:32:28Z"
@@ -13578,7 +13689,7 @@
     {
       "nameWithOwner": "zuchka/remove-markdown",
       "url": "https://github.com/zuchka/remove-markdown",
-      "stargazerCount": 347,
+      "stargazerCount": 346,
       "description": "Strip Markdown stuff from text",
       "primaryLanguage": "JavaScript",
       "starredAt": "2018-04-28T02:02:48Z"
@@ -13594,7 +13705,7 @@
     {
       "nameWithOwner": "Relaxed-Theme/relaxed-terminal-themes",
       "url": "https://github.com/Relaxed-Theme/relaxed-terminal-themes",
-      "stargazerCount": 458,
+      "stargazerCount": 457,
       "description": "🕶️ A relaxed terminal theme to take a more relaxed view of things. For iTerm, Hyper, the macOS Terminal and a bunch of others.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2018-04-26T07:47:41Z"
@@ -13602,7 +13713,7 @@
     {
       "nameWithOwner": "GitZip/chrome-extension",
       "url": "https://github.com/GitZip/chrome-extension",
-      "stargazerCount": 41,
+      "stargazerCount": 42,
       "description": "",
       "primaryLanguage": "JavaScript",
       "starredAt": "2018-04-26T04:29:15Z"
@@ -13626,7 +13737,7 @@
     {
       "nameWithOwner": "jscottsmith/react-scroll-parallax",
       "url": "https://github.com/jscottsmith/react-scroll-parallax",
-      "stargazerCount": 2947,
+      "stargazerCount": 2952,
       "description": "🔮  React hooks and components to create parallax scroll effects for banners, images or any other DOM elements.",
       "primaryLanguage": "TypeScript",
       "starredAt": "2018-04-26T00:15:41Z"
@@ -13650,7 +13761,7 @@
     {
       "nameWithOwner": "JohnCoates/Aerial",
       "url": "https://github.com/JohnCoates/Aerial",
-      "stargazerCount": 20879,
+      "stargazerCount": 20880,
       "description": "Apple TV Aerial Screensaver for Mac",
       "primaryLanguage": "Swift",
       "starredAt": "2018-04-23T23:12:02Z"
@@ -13698,7 +13809,7 @@
     {
       "nameWithOwner": "sindresorhus/slugify",
       "url": "https://github.com/sindresorhus/slugify",
-      "stargazerCount": 2626,
+      "stargazerCount": 2625,
       "description": "Slugify a string",
       "primaryLanguage": "JavaScript",
       "starredAt": "2018-04-22T22:24:16Z"
@@ -13706,7 +13817,7 @@
     {
       "nameWithOwner": "kyleneideck/BackgroundMusic",
       "url": "https://github.com/kyleneideck/BackgroundMusic",
-      "stargazerCount": 17633,
+      "stargazerCount": 17690,
       "description": "Background Music, a macOS audio utility: automatically pause your music, set individual apps' volumes and record system audio.",
       "primaryLanguage": "C++",
       "starredAt": "2018-04-20T05:33:42Z"
@@ -13722,7 +13833,7 @@
     {
       "nameWithOwner": "hugomd/parrot.live",
       "url": "https://github.com/hugomd/parrot.live",
-      "stargazerCount": 4213,
+      "stargazerCount": 4224,
       "description": "🐦  Bringing animated parrots to terminals everywhere",
       "primaryLanguage": "JavaScript",
       "starredAt": "2018-04-18T05:36:49Z"
@@ -13730,7 +13841,7 @@
     {
       "nameWithOwner": "VCVRack/Rack",
       "url": "https://github.com/VCVRack/Rack",
-      "stargazerCount": 4196,
+      "stargazerCount": 4200,
       "description": "The virtual Eurorack studio",
       "primaryLanguage": "C++",
       "starredAt": "2018-04-16T22:27:34Z"
@@ -13738,7 +13849,7 @@
     {
       "nameWithOwner": "vuejs/vuepress",
       "url": "https://github.com/vuejs/vuepress",
-      "stargazerCount": 22793,
+      "stargazerCount": 22788,
       "description": "📝 Minimalistic Vue-powered static site generator",
       "primaryLanguage": "JavaScript",
       "starredAt": "2018-04-16T03:34:24Z"
@@ -13746,7 +13857,7 @@
     {
       "nameWithOwner": "pmndrs/react-spring",
       "url": "https://github.com/pmndrs/react-spring",
-      "stargazerCount": 28797,
+      "stargazerCount": 28812,
       "description": "✌️ A spring physics based React animation library",
       "primaryLanguage": "TypeScript",
       "starredAt": "2018-04-16T00:22:35Z"
@@ -13762,7 +13873,7 @@
     {
       "nameWithOwner": "postmanlabs/httpbin",
       "url": "https://github.com/postmanlabs/httpbin",
-      "stargazerCount": 13210,
+      "stargazerCount": 13225,
       "description": "HTTP Request & Response Service, written in Python + Flask.",
       "primaryLanguage": "Python",
       "starredAt": "2018-04-12T03:08:37Z"
@@ -13770,7 +13881,7 @@
     {
       "nameWithOwner": "glidejs/glide",
       "url": "https://github.com/glidejs/glide",
-      "stargazerCount": 7628,
+      "stargazerCount": 7633,
       "description": "A dependency-free JavaScript ES6 slider and carousel. It’s lightweight, flexible and fast. Designed to slide. No less, no more",
       "primaryLanguage": "JavaScript",
       "starredAt": "2018-04-12T01:55:30Z"
@@ -13826,7 +13937,7 @@
     {
       "nameWithOwner": "withspectrum/spectrum",
       "url": "https://github.com/withspectrum/spectrum",
-      "stargazerCount": 10869,
+      "stargazerCount": 10872,
       "description": "Simple, powerful online communities.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2018-04-04T03:24:35Z"
@@ -13834,7 +13945,7 @@
     {
       "nameWithOwner": "unjs/consola",
       "url": "https://github.com/unjs/consola",
-      "stargazerCount": 6755,
+      "stargazerCount": 6772,
       "description": "🐨 Elegant Console Logger for Node.js and Browser ",
       "primaryLanguage": "TypeScript",
       "starredAt": "2018-04-04T02:35:14Z"
@@ -13850,7 +13961,7 @@
     {
       "nameWithOwner": "tensorflow/tfjs",
       "url": "https://github.com/tensorflow/tfjs",
-      "stargazerCount": 18898,
+      "stargazerCount": 18911,
       "description": "A WebGL accelerated JavaScript library for training and deploying ML models.",
       "primaryLanguage": "TypeScript",
       "starredAt": "2018-04-04T02:32:42Z"
@@ -13858,7 +13969,7 @@
     {
       "nameWithOwner": "tabler/tabler",
       "url": "https://github.com/tabler/tabler",
-      "stargazerCount": 39734,
+      "stargazerCount": 39835,
       "description": "Tabler is free and open-source HTML Dashboard UI Kit built on Bootstrap",
       "primaryLanguage": "HTML",
       "starredAt": "2018-04-03T22:36:24Z"
@@ -13866,7 +13977,7 @@
     {
       "nameWithOwner": "jaywcjlove/hotkeys-js",
       "url": "https://github.com/jaywcjlove/hotkeys-js",
-      "stargazerCount": 6914,
+      "stargazerCount": 6931,
       "description": "➷ A robust Javascript library for capturing keyboard input. It has no dependencies. ",
       "primaryLanguage": "JavaScript",
       "starredAt": "2018-04-03T22:35:10Z"
@@ -13874,7 +13985,7 @@
     {
       "nameWithOwner": "amaroteam/react-credit-cards",
       "url": "https://github.com/amaroteam/react-credit-cards",
-      "stargazerCount": 2610,
+      "stargazerCount": 2611,
       "description": "Beautiful credit cards for your payment forms",
       "primaryLanguage": "SCSS",
       "starredAt": "2018-04-03T21:40:47Z"
@@ -13898,7 +14009,7 @@
     {
       "nameWithOwner": "Popmotion/popmotion",
       "url": "https://github.com/Popmotion/popmotion",
-      "stargazerCount": 20148,
+      "stargazerCount": 20145,
       "description": "Simple animation libraries for delightful user interfaces",
       "primaryLanguage": "JavaScript",
       "starredAt": "2018-03-29T03:33:29Z"
@@ -13922,7 +14033,7 @@
     {
       "nameWithOwner": "dataarts/dat.gui",
       "url": "https://github.com/dataarts/dat.gui",
-      "stargazerCount": 7665,
+      "stargazerCount": 7666,
       "description": "Lightweight controller library for JavaScript.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2018-03-23T00:39:26Z"
@@ -13978,7 +14089,7 @@
     {
       "nameWithOwner": "marktext/marktext",
       "url": "https://github.com/marktext/marktext",
-      "stargazerCount": 50606,
+      "stargazerCount": 50722,
       "description": "📝A simple and elegant markdown editor, available for Linux, macOS and Windows.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2018-03-18T23:54:01Z"
@@ -14018,7 +14129,7 @@
     {
       "nameWithOwner": "typicode/jsonplaceholder",
       "url": "https://github.com/typicode/jsonplaceholder",
-      "stargazerCount": 5159,
+      "stargazerCount": 5163,
       "description": "A simple online fake REST API server",
       "primaryLanguage": "HTML",
       "starredAt": "2018-03-12T04:15:04Z"
@@ -14058,7 +14169,7 @@
     {
       "nameWithOwner": "formsy/formsy-react",
       "url": "https://github.com/formsy/formsy-react",
-      "stargazerCount": 762,
+      "stargazerCount": 763,
       "description": "A form input builder and validator for React JS",
       "primaryLanguage": "TypeScript",
       "starredAt": "2018-03-07T21:34:26Z"
@@ -14066,7 +14177,7 @@
     {
       "nameWithOwner": "sureskumar/sketch-isometric",
       "url": "https://github.com/sureskumar/sketch-isometric",
-      "stargazerCount": 1643,
+      "stargazerCount": 1644,
       "description": " Generate Isometric and 3D Rotation views from Artboards and Rectangles in Sketch app.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2018-03-07T21:30:31Z"
@@ -14082,7 +14193,7 @@
     {
       "nameWithOwner": "googlearchive/code-prettify",
       "url": "https://github.com/googlearchive/code-prettify",
-      "stargazerCount": 5793,
+      "stargazerCount": 5792,
       "description": "An embeddable script that makes source-code snippets in HTML prettier.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2018-03-07T07:28:20Z"
@@ -14090,7 +14201,7 @@
     {
       "nameWithOwner": "graphql-hive/graphql-yoga",
       "url": "https://github.com/graphql-hive/graphql-yoga",
-      "stargazerCount": 8401,
+      "stargazerCount": 8411,
       "description": "🧘 Rewrite of a fully-featured GraphQL Server with focus on easy setup, performance & great developer experience.  The core of Yoga implements WHATWG Fetch API and can run/deploy on any JS environment.",
       "primaryLanguage": "TypeScript",
       "starredAt": "2018-03-06T04:02:35Z"
@@ -14098,7 +14209,7 @@
     {
       "nameWithOwner": "wp-graphql/wp-graphql",
       "url": "https://github.com/wp-graphql/wp-graphql",
-      "stargazerCount": 3732,
+      "stargazerCount": 3735,
       "description": ":rocket: GraphQL API for WordPress",
       "primaryLanguage": "PHP",
       "starredAt": "2018-03-06T02:59:34Z"
@@ -14106,7 +14217,7 @@
     {
       "nameWithOwner": "dylanaraps/neofetch",
       "url": "https://github.com/dylanaraps/neofetch",
-      "stargazerCount": 23093,
+      "stargazerCount": 23125,
       "description": "🖼️  A command-line system information tool written in bash 3.2+",
       "primaryLanguage": "Shell",
       "starredAt": "2018-03-06T01:56:13Z"
@@ -14130,7 +14241,7 @@
     {
       "nameWithOwner": "go-shiori/shiori",
       "url": "https://github.com/go-shiori/shiori",
-      "stargazerCount": 10678,
+      "stargazerCount": 10712,
       "description": "Simple bookmark manager built with Go",
       "primaryLanguage": "Go",
       "starredAt": "2018-03-05T22:21:52Z"
@@ -14154,7 +14265,7 @@
     {
       "nameWithOwner": "pqina/filepond",
       "url": "https://github.com/pqina/filepond",
-      "stargazerCount": 16008,
+      "stargazerCount": 16034,
       "description": "🌊 A flexible and fun JavaScript file upload library",
       "primaryLanguage": "JavaScript",
       "starredAt": "2018-03-05T00:53:57Z"
@@ -14162,7 +14273,7 @@
     {
       "nameWithOwner": "pi-hole/pi-hole",
       "url": "https://github.com/pi-hole/pi-hole",
-      "stargazerCount": 52681,
+      "stargazerCount": 52788,
       "description": "A black hole for Internet advertisements",
       "primaryLanguage": "Shell",
       "starredAt": "2018-03-03T02:50:04Z"
@@ -14194,7 +14305,7 @@
     {
       "nameWithOwner": "reactjs/react-transition-group",
       "url": "https://github.com/reactjs/react-transition-group",
-      "stargazerCount": 10243,
+      "stargazerCount": 10244,
       "description": "An easy way to perform animations when a React component enters or leaves the DOM",
       "primaryLanguage": "JavaScript",
       "starredAt": "2018-03-01T00:55:32Z"
@@ -14202,7 +14313,7 @@
     {
       "nameWithOwner": "paulirish/git-open",
       "url": "https://github.com/paulirish/git-open",
-      "stargazerCount": 3377,
+      "stargazerCount": 3383,
       "description": "Type `git open` to open the GitHub page or website for a repository in your browser.",
       "primaryLanguage": "Shell",
       "starredAt": "2018-02-28T23:16:30Z"
@@ -14218,7 +14329,7 @@
     {
       "nameWithOwner": "sindresorhus/Gifski",
       "url": "https://github.com/sindresorhus/Gifski",
-      "stargazerCount": 8112,
+      "stargazerCount": 8127,
       "description": "🌈 Convert videos to high-quality GIFs on your Mac",
       "primaryLanguage": "Swift",
       "starredAt": "2018-02-28T23:00:31Z"
@@ -14226,7 +14337,7 @@
     {
       "nameWithOwner": "flutter/flutter",
       "url": "https://github.com/flutter/flutter",
-      "stargazerCount": 171506,
+      "stargazerCount": 171647,
       "description": "Flutter makes it easy and fast to build beautiful apps for mobile and beyond",
       "primaryLanguage": "Dart",
       "starredAt": "2018-02-28T18:41:23Z"
@@ -14234,7 +14345,7 @@
     {
       "nameWithOwner": "clauderic/react-tiny-virtual-list",
       "url": "https://github.com/clauderic/react-tiny-virtual-list",
-      "stargazerCount": 2484,
+      "stargazerCount": 2490,
       "description": "A tiny but mighty 3kb list virtualization library, with zero dependencies 💪 Supports variable heights/widths, sticky items, scrolling to index, and more!",
       "primaryLanguage": "TypeScript",
       "starredAt": "2018-02-28T06:55:07Z"
@@ -14242,7 +14353,7 @@
     {
       "nameWithOwner": "javve/list.js",
       "url": "https://github.com/javve/list.js",
-      "stargazerCount": 11229,
+      "stargazerCount": 11230,
       "description": "The perfect library for adding search, sort, filters and flexibility to tables, lists and various HTML elements. Built to be invisible and work on existing HTML.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2018-02-28T06:53:28Z"
@@ -14266,7 +14377,7 @@
     {
       "nameWithOwner": "FormidableLabs/nuka-carousel",
       "url": "https://github.com/FormidableLabs/nuka-carousel",
-      "stargazerCount": 3101,
+      "stargazerCount": 3104,
       "description": "Small, fast, and accessibility-first React carousel library with an easily customizable UI and behavior to fit your brand and site.",
       "primaryLanguage": "TypeScript",
       "starredAt": "2018-02-28T04:36:16Z"
@@ -14274,7 +14385,7 @@
     {
       "nameWithOwner": "raphamorim/awesome-canvas",
       "url": "https://github.com/raphamorim/awesome-canvas",
-      "stargazerCount": 1734,
+      "stargazerCount": 1736,
       "description": "A curated list of awesome HTML5 Canvas with examples, related articles and posts.",
       "primaryLanguage": "Markdown",
       "starredAt": "2018-02-28T02:40:29Z"
@@ -14282,7 +14393,7 @@
     {
       "nameWithOwner": "Flipboard/react-canvas",
       "url": "https://github.com/Flipboard/react-canvas",
-      "stargazerCount": 13213,
+      "stargazerCount": 13212,
       "description": "High performance <canvas> rendering for React components",
       "primaryLanguage": "JavaScript",
       "starredAt": "2018-02-28T02:39:59Z"
@@ -14306,7 +14417,7 @@
     {
       "nameWithOwner": "jonobr1/two.js",
       "url": "https://github.com/jonobr1/two.js",
-      "stargazerCount": 8500,
+      "stargazerCount": 8506,
       "description": "A renderer agnostic two-dimensional drawing api for the web",
       "primaryLanguage": "JavaScript",
       "starredAt": "2018-02-23T04:39:56Z"
@@ -14322,7 +14433,7 @@
     {
       "nameWithOwner": "carbon-app/carbon",
       "url": "https://github.com/carbon-app/carbon",
-      "stargazerCount": 35523,
+      "stargazerCount": 35567,
       "description": ":black_heart: Create and share beautiful images of your source code",
       "primaryLanguage": "JavaScript",
       "starredAt": "2018-02-23T03:13:28Z"
@@ -14330,7 +14441,7 @@
     {
       "nameWithOwner": "thedevs-network/kutt",
       "url": "https://github.com/thedevs-network/kutt",
-      "stargazerCount": 9956,
+      "stargazerCount": 9982,
       "description": "Free Modern URL Shortener.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2018-02-20T23:46:30Z"
@@ -14338,7 +14449,7 @@
     {
       "nameWithOwner": "kusti8/proton-native",
       "url": "https://github.com/kusti8/proton-native",
-      "stargazerCount": 10921,
+      "stargazerCount": 10924,
       "description": "A React environment for cross platform desktop apps",
       "primaryLanguage": "TypeScript",
       "starredAt": "2018-02-20T23:43:38Z"
@@ -14354,7 +14465,7 @@
     {
       "nameWithOwner": "nodeca/pica",
       "url": "https://github.com/nodeca/pica",
-      "stargazerCount": 3934,
+      "stargazerCount": 3942,
       "description": "Resize image in browser with high quality and high speed",
       "primaryLanguage": "JavaScript",
       "starredAt": "2018-02-20T01:54:06Z"
@@ -14362,7 +14473,7 @@
     {
       "nameWithOwner": "linasmnew/react-graceful-image",
       "url": "https://github.com/linasmnew/react-graceful-image",
-      "stargazerCount": 319,
+      "stargazerCount": 320,
       "description": "An image component for gracefully dealing with image errors by providing optional lazy loading, optional placeholder and configurable retries on failure",
       "primaryLanguage": "JavaScript",
       "starredAt": "2018-02-19T06:30:22Z"
@@ -14370,7 +14481,7 @@
     {
       "nameWithOwner": "jaredpalmer/formik",
       "url": "https://github.com/jaredpalmer/formik",
-      "stargazerCount": 34256,
+      "stargazerCount": 34271,
       "description": "Build forms in React, without the tears 😭 ",
       "primaryLanguage": "TypeScript",
       "starredAt": "2018-02-19T06:18:25Z"
@@ -14410,7 +14521,7 @@
     {
       "nameWithOwner": "bradley/Blotter",
       "url": "https://github.com/bradley/Blotter",
-      "stargazerCount": 3072,
+      "stargazerCount": 3071,
       "description": "A JavaScript API for drawing unconventional text effects on the web.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2018-02-19T01:38:16Z"
@@ -14434,7 +14545,7 @@
     {
       "nameWithOwner": "kimmobrunfeldt/progressbar.js",
       "url": "https://github.com/kimmobrunfeldt/progressbar.js",
-      "stargazerCount": 7864,
+      "stargazerCount": 7866,
       "description": "Responsive and slick progress bars ",
       "primaryLanguage": "JavaScript",
       "starredAt": "2018-02-16T00:21:48Z"
@@ -14450,7 +14561,7 @@
     {
       "nameWithOwner": "github-tools/github",
       "url": "https://github.com/github-tools/github",
-      "stargazerCount": 3650,
+      "stargazerCount": 3653,
       "description": "A higher-level wrapper around the Github API. Intended for the browser.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2018-02-15T05:03:33Z"
@@ -14458,7 +14569,7 @@
     {
       "nameWithOwner": "bvaughn/react-highlight-words",
       "url": "https://github.com/bvaughn/react-highlight-words",
-      "stargazerCount": 2260,
+      "stargazerCount": 2264,
       "description": "React component to highlight words within a larger body of text",
       "primaryLanguage": "JavaScript",
       "starredAt": "2018-02-13T06:49:27Z"
@@ -14474,7 +14585,7 @@
     {
       "nameWithOwner": "hotwired/stimulus",
       "url": "https://github.com/hotwired/stimulus",
-      "stargazerCount": 12922,
+      "stargazerCount": 12930,
       "description": "A modest JavaScript framework for the HTML you already have",
       "primaryLanguage": "TypeScript",
       "starredAt": "2018-02-13T05:30:45Z"
@@ -14482,7 +14593,7 @@
     {
       "nameWithOwner": "WebThingsIO/gateway",
       "url": "https://github.com/WebThingsIO/gateway",
-      "stargazerCount": 2627,
+      "stargazerCount": 2624,
       "description": "WebThings Gateway - a self-hosted web application for monitoring and controlling a building over the web",
       "primaryLanguage": "TypeScript",
       "starredAt": "2018-02-12T03:47:16Z"
@@ -14490,7 +14601,7 @@
     {
       "nameWithOwner": "sindresorhus/modern-normalize",
       "url": "https://github.com/sindresorhus/modern-normalize",
-      "stargazerCount": 6896,
+      "stargazerCount": 6919,
       "description": "🐒 Normalize browsers' default style",
       "primaryLanguage": "TypeScript",
       "starredAt": "2018-02-12T02:14:28Z"
@@ -14514,7 +14625,7 @@
     {
       "nameWithOwner": "browser-update/browser-update",
       "url": "https://github.com/browser-update/browser-update",
-      "stargazerCount": 382,
+      "stargazerCount": 383,
       "description": "Remind users to update their browser in an unobtrusive way",
       "primaryLanguage": "JavaScript",
       "starredAt": "2018-02-09T05:14:51Z"
@@ -14522,7 +14633,7 @@
     {
       "nameWithOwner": "cashmusic/platform",
       "url": "https://github.com/cashmusic/platform",
-      "stargazerCount": 1372,
+      "stargazerCount": 1373,
       "description": "A free and open platform giving all musicians access to tools that let them manage, promote, and sell their music online.",
       "primaryLanguage": "PHP",
       "starredAt": "2018-02-09T04:04:59Z"
@@ -14530,7 +14641,7 @@
     {
       "nameWithOwner": "overtone/overtone",
       "url": "https://github.com/overtone/overtone",
-      "stargazerCount": 6038,
+      "stargazerCount": 6040,
       "description": "Collaborative Programmable Music ",
       "primaryLanguage": "Clojure",
       "starredAt": "2018-02-09T04:04:28Z"
@@ -14538,7 +14649,7 @@
     {
       "nameWithOwner": "CreateJS/SoundJS",
       "url": "https://github.com/CreateJS/SoundJS",
-      "stargazerCount": 4512,
+      "stargazerCount": 4513,
       "description": "A Javascript library for working with Audio. It provides a consistent API for loading and playing audio on different browsers and devices. Currently supports WebAudio, HTML5 Audio, Cordova / PhoneGap, and a Flash fallback.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2018-02-09T04:04:03Z"
@@ -14562,7 +14673,7 @@
     {
       "nameWithOwner": "mysticatea/npm-run-all",
       "url": "https://github.com/mysticatea/npm-run-all",
-      "stargazerCount": 5808,
+      "stargazerCount": 5810,
       "description": "A CLI tool to run multiple npm-scripts in parallel or sequential.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2018-02-08T21:49:01Z"
@@ -14602,7 +14713,7 @@
     {
       "nameWithOwner": "michaelvillar/timer-app",
       "url": "https://github.com/michaelvillar/timer-app",
-      "stargazerCount": 2638,
+      "stargazerCount": 2640,
       "description": "A simple Timer app for Mac",
       "primaryLanguage": "Swift",
       "starredAt": "2018-02-06T21:43:27Z"
@@ -14642,7 +14753,7 @@
     {
       "nameWithOwner": "mrvautin/expressCart",
       "url": "https://github.com/mrvautin/expressCart",
-      "stargazerCount": 2259,
+      "stargazerCount": 2258,
       "description": "A fully functioning Node.js shopping cart with Stripe, PayPal, Authorize.net, PayWay, Blockonomics, Adyen, Zip and Instore payments.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2018-02-02T00:00:09Z"
@@ -14650,7 +14761,7 @@
     {
       "nameWithOwner": "yjose/reactjs-popup",
       "url": "https://github.com/yjose/reactjs-popup",
-      "stargazerCount": 1817,
+      "stargazerCount": 1819,
       "description": "React Popup Component - Modals,Tooltips and Menus —  All in one",
       "primaryLanguage": "TypeScript",
       "starredAt": "2018-02-01T10:32:45Z"
@@ -14658,7 +14769,7 @@
     {
       "nameWithOwner": "parallax/jsPDF",
       "url": "https://github.com/parallax/jsPDF",
-      "stargazerCount": 30395,
+      "stargazerCount": 30427,
       "description": "Client-side JavaScript PDF generation for everyone.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2018-02-01T04:04:02Z"
@@ -14682,7 +14793,7 @@
     {
       "nameWithOwner": "enso-org/enso",
       "url": "https://github.com/enso-org/enso",
-      "stargazerCount": 7435,
+      "stargazerCount": 7430,
       "description": "Enso Analytics is a self-service data prep and analysis platform designed for data teams.",
       "primaryLanguage": "Java",
       "starredAt": "2018-02-01T02:53:41Z"
@@ -14690,7 +14801,7 @@
     {
       "nameWithOwner": "thumbor/thumbor",
       "url": "https://github.com/thumbor/thumbor",
-      "stargazerCount": 10306,
+      "stargazerCount": 10310,
       "description": "thumbor is an open-source photo thumbnail service by globo.com",
       "primaryLanguage": "Python",
       "starredAt": "2018-01-31T21:47:50Z"
@@ -14706,7 +14817,7 @@
     {
       "nameWithOwner": "hundredrabbits/Left",
       "url": "https://github.com/hundredrabbits/Left",
-      "stargazerCount": 1813,
+      "stargazerCount": 1814,
       "description": "Distractionless Writing Tool",
       "primaryLanguage": "JavaScript",
       "starredAt": "2018-01-30T03:38:14Z"
@@ -14722,7 +14833,7 @@
     {
       "nameWithOwner": "edent/SuperTinyIcons",
       "url": "https://github.com/edent/SuperTinyIcons",
-      "stargazerCount": 14986,
+      "stargazerCount": 14990,
       "description": "Under 1KB each! Super Tiny Icons are miniscule SVG versions of your favourite website and app logos",
       "primaryLanguage": "HTML",
       "starredAt": "2018-01-30T02:13:50Z"
@@ -14738,7 +14849,7 @@
     {
       "nameWithOwner": "strapi/strapi",
       "url": "https://github.com/strapi/strapi",
-      "stargazerCount": 68725,
+      "stargazerCount": 68900,
       "description": "🚀 Strapi is the leading open-source headless CMS. It’s 100% JavaScript/TypeScript, fully customizable, and developer-first.",
       "primaryLanguage": "TypeScript",
       "starredAt": "2018-01-29T06:33:08Z"
@@ -14770,7 +14881,7 @@
     {
       "nameWithOwner": "facebookresearch/Detectron",
       "url": "https://github.com/facebookresearch/Detectron",
-      "stargazerCount": 26360,
+      "stargazerCount": 26363,
       "description": "FAIR's research platform for object detection research, implementing popular algorithms like Mask R-CNN and RetinaNet.",
       "primaryLanguage": "Python",
       "starredAt": "2018-01-28T03:56:49Z"
@@ -14778,7 +14889,7 @@
     {
       "nameWithOwner": "relativty/Relativty",
       "url": "https://github.com/relativty/Relativty",
-      "stargazerCount": 6839,
+      "stargazerCount": 6843,
       "description": "An open source VR headset with SteamVR supports for $200",
       "primaryLanguage": "C++",
       "starredAt": "2018-01-28T03:47:49Z"
@@ -14786,7 +14897,7 @@
     {
       "nameWithOwner": "highcharts/highcharts",
       "url": "https://github.com/highcharts/highcharts",
-      "stargazerCount": 12303,
+      "stargazerCount": 12306,
       "description": "Highcharts JS, the JavaScript charting framework",
       "primaryLanguage": "TypeScript",
       "starredAt": "2018-01-25T05:54:28Z"
@@ -14802,7 +14913,7 @@
     {
       "nameWithOwner": "react-navigation/react-navigation",
       "url": "https://github.com/react-navigation/react-navigation",
-      "stargazerCount": 24093,
+      "stargazerCount": 24105,
       "description": "Routing and navigation for React Native and Web apps",
       "primaryLanguage": "TypeScript",
       "starredAt": "2018-01-25T01:26:58Z"
@@ -14810,7 +14921,7 @@
     {
       "nameWithOwner": "amark/gun",
       "url": "https://github.com/amark/gun",
-      "stargazerCount": 18509,
+      "stargazerCount": 18523,
       "description": "An open source cybersecurity protocol for syncing decentralized graph data.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2018-01-25T01:23:56Z"
@@ -14818,7 +14929,7 @@
     {
       "nameWithOwner": "fastify/fastify",
       "url": "https://github.com/fastify/fastify",
-      "stargazerCount": 34208,
+      "stargazerCount": 34264,
       "description": "Fast and low overhead web framework, for Node.js",
       "primaryLanguage": "JavaScript",
       "starredAt": "2018-01-25T01:23:33Z"
@@ -14850,7 +14961,7 @@
     {
       "nameWithOwner": "BrainJS/brain.js",
       "url": "https://github.com/BrainJS/brain.js",
-      "stargazerCount": 14780,
+      "stargazerCount": 14783,
       "description": "🤖 GPU accelerated Neural networks in JavaScript for Browsers and Node.js",
       "primaryLanguage": "TypeScript",
       "starredAt": "2018-01-24T03:09:22Z"
@@ -14858,7 +14969,7 @@
     {
       "nameWithOwner": "tensorflow/tfjs-core",
       "url": "https://github.com/tensorflow/tfjs-core",
-      "stargazerCount": 8471,
+      "stargazerCount": 8468,
       "description": "WebGL-accelerated ML // linear algebra // automatic differentiation for JavaScript.",
       "primaryLanguage": "TypeScript",
       "starredAt": "2018-01-24T03:05:30Z"
@@ -14890,7 +15001,7 @@
     {
       "nameWithOwner": "karpathy/reinforcejs",
       "url": "https://github.com/karpathy/reinforcejs",
-      "stargazerCount": 1382,
+      "stargazerCount": 1390,
       "description": "Reinforcement Learning Agents in Javascript (Dynamic Programming, Temporal Difference, Deep Q-Learning, Stochastic/Deterministic Policy Gradients)",
       "primaryLanguage": "HTML",
       "starredAt": "2018-01-24T00:14:36Z"
@@ -14898,7 +15009,7 @@
     {
       "nameWithOwner": "mljs/ml",
       "url": "https://github.com/mljs/ml",
-      "stargazerCount": 2689,
+      "stargazerCount": 2688,
       "description": "Machine learning tools in JavaScript",
       "primaryLanguage": "JavaScript",
       "starredAt": "2018-01-24T00:12:29Z"
@@ -14930,7 +15041,7 @@
     {
       "nameWithOwner": "rakannimer/react-google-charts",
       "url": "https://github.com/rakannimer/react-google-charts",
-      "stargazerCount": 1686,
+      "stargazerCount": 1688,
       "description": "A thin, typed, React wrapper over Google Charts Visualization and Charts API.",
       "primaryLanguage": "TypeScript",
       "starredAt": "2018-01-22T07:30:50Z"
@@ -14938,7 +15049,7 @@
     {
       "nameWithOwner": "recharts/recharts",
       "url": "https://github.com/recharts/recharts",
-      "stargazerCount": 25622,
+      "stargazerCount": 25671,
       "description": "Redefined chart library built with React and D3",
       "primaryLanguage": "TypeScript",
       "starredAt": "2018-01-22T07:18:54Z"
@@ -14946,7 +15057,7 @@
     {
       "nameWithOwner": "michaelwittig/node-i18n-iso-countries",
       "url": "https://github.com/michaelwittig/node-i18n-iso-countries",
-      "stargazerCount": 853,
+      "stargazerCount": 855,
       "description": "i18n for ISO 3166-1 country codes",
       "primaryLanguage": "JavaScript",
       "starredAt": "2018-01-19T05:00:35Z"
@@ -14994,7 +15105,7 @@
     {
       "nameWithOwner": "danilowoz/react-content-loader",
       "url": "https://github.com/danilowoz/react-content-loader",
-      "stargazerCount": 13931,
+      "stargazerCount": 13936,
       "description": "⚪ SVG-Powered component to easily create skeleton loadings.",
       "primaryLanguage": "TypeScript",
       "starredAt": "2018-01-15T03:36:44Z"
@@ -15010,7 +15121,7 @@
     {
       "nameWithOwner": "NervJS/nerv",
       "url": "https://github.com/NervJS/nerv",
-      "stargazerCount": 5429,
+      "stargazerCount": 5430,
       "description": "A blazing fast React alternative, compatible with IE8 and React 16.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2018-01-15T00:31:54Z"
@@ -15034,7 +15145,7 @@
     {
       "nameWithOwner": "firebase/firebaseui-web",
       "url": "https://github.com/firebase/firebaseui-web",
-      "stargazerCount": 4734,
+      "stargazerCount": 4737,
       "description": "FirebaseUI is an open-source JavaScript library for Web that provides simple, customizable UI bindings on top of Firebase SDKs to eliminate boilerplate code and promote best practices.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2018-01-11T10:25:50Z"
@@ -15042,7 +15153,7 @@
     {
       "nameWithOwner": "coinpride/CryptoList",
       "url": "https://github.com/coinpride/CryptoList",
-      "stargazerCount": 4299,
+      "stargazerCount": 4302,
       "description": "Curated collection of blockchain & cryptocurrency resources.",
       "primaryLanguage": null,
       "starredAt": "2018-01-10T05:52:33Z"
@@ -15058,7 +15169,7 @@
     {
       "nameWithOwner": "neptunian/react-photo-gallery",
       "url": "https://github.com/neptunian/react-photo-gallery",
-      "stargazerCount": 1999,
+      "stargazerCount": 2000,
       "description": "React Photo Gallery",
       "primaryLanguage": "JavaScript",
       "starredAt": "2018-01-10T02:23:33Z"
@@ -15074,7 +15185,7 @@
     {
       "nameWithOwner": "sdras/array-explorer",
       "url": "https://github.com/sdras/array-explorer",
-      "stargazerCount": 2618,
+      "stargazerCount": 2617,
       "description": "⚡️ A resource to help figure out what JavaScript array method would be best to use at any given time",
       "primaryLanguage": "JavaScript",
       "starredAt": "2018-01-09T04:55:04Z"
@@ -15082,7 +15193,7 @@
     {
       "nameWithOwner": "ajusa/lit",
       "url": "https://github.com/ajusa/lit",
-      "stargazerCount": 2012,
+      "stargazerCount": 2013,
       "description": "World's smallest responsive 🔥 css framework (395 bytes) ",
       "primaryLanguage": "CSS",
       "starredAt": "2018-01-07T23:59:46Z"
@@ -15090,7 +15201,7 @@
     {
       "nameWithOwner": "transloadit/uppy",
       "url": "https://github.com/transloadit/uppy",
-      "stargazerCount": 29973,
+      "stargazerCount": 29997,
       "description": "The next open source file uploader for web browsers :dog: ",
       "primaryLanguage": "TypeScript",
       "starredAt": "2018-01-05T23:13:50Z"
@@ -15106,7 +15217,7 @@
     {
       "nameWithOwner": "humanmade/S3-Uploads",
       "url": "https://github.com/humanmade/S3-Uploads",
-      "stargazerCount": 2040,
+      "stargazerCount": 2041,
       "description": "The WordPress Plugin to Store Uploads on Amazon S3",
       "primaryLanguage": "PHP",
       "starredAt": "2018-01-04T23:57:17Z"
@@ -15114,7 +15225,7 @@
     {
       "nameWithOwner": "dogecoin/dogecoin",
       "url": "https://github.com/dogecoin/dogecoin",
-      "stargazerCount": 15039,
+      "stargazerCount": 15038,
       "description": "very currency",
       "primaryLanguage": "C++",
       "starredAt": "2017-12-21T22:43:34Z"
@@ -15138,7 +15249,7 @@
     {
       "nameWithOwner": "ccxt/ccxt",
       "url": "https://github.com/ccxt/ccxt",
-      "stargazerCount": 37347,
+      "stargazerCount": 37459,
       "description": "A JavaScript / TypeScript / Python / C# / PHP / Go cryptocurrency trading API with support for more than 100 bitcoin/altcoin exchanges",
       "primaryLanguage": "Python",
       "starredAt": "2017-12-15T21:59:31Z"
@@ -15154,7 +15265,7 @@
     {
       "nameWithOwner": "epicmaxco/epic-spinners",
       "url": "https://github.com/epicmaxco/epic-spinners",
-      "stargazerCount": 3889,
+      "stargazerCount": 3890,
       "description": "Easy to use css spinners collection with Vue.js integration",
       "primaryLanguage": "Vue",
       "starredAt": "2017-12-13T23:45:52Z"
@@ -15202,7 +15313,7 @@
     {
       "nameWithOwner": "Chalarangelo/30-seconds-of-code",
       "url": "https://github.com/Chalarangelo/30-seconds-of-code",
-      "stargazerCount": 124665,
+      "stargazerCount": 124797,
       "description": "Coding articles to level up your development skills",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-12-11T22:58:06Z"
@@ -15218,7 +15329,7 @@
     {
       "nameWithOwner": "hql287/Manta",
       "url": "https://github.com/hql287/Manta",
-      "stargazerCount": 5332,
+      "stargazerCount": 5336,
       "description": "🎉 Flexible invoicing desktop app with beautiful & customizable templates.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-12-11T00:32:21Z"
@@ -15226,7 +15337,7 @@
     {
       "nameWithOwner": "pat310/google-trends-api",
       "url": "https://github.com/pat310/google-trends-api",
-      "stargazerCount": 934,
+      "stargazerCount": 935,
       "description": "An API layer on top of google trends",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-12-06T12:11:41Z"
@@ -15250,7 +15361,7 @@
     {
       "nameWithOwner": "open-sauced/open-sauced",
       "url": "https://github.com/open-sauced/open-sauced",
-      "stargazerCount": 951,
+      "stargazerCount": 952,
       "description": "🍕  This is a project to identify your next open source contribution. ",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-12-04T10:54:53Z"
@@ -15258,7 +15369,7 @@
     {
       "nameWithOwner": "worldveil/dejavu",
       "url": "https://github.com/worldveil/dejavu",
-      "stargazerCount": 6596,
+      "stargazerCount": 6595,
       "description": "Audio fingerprinting and recognition in Python",
       "primaryLanguage": "Python",
       "starredAt": "2017-12-04T00:09:54Z"
@@ -15266,7 +15377,7 @@
     {
       "nameWithOwner": "adblockradio/stream-audio-fingerprint",
       "url": "https://github.com/adblockradio/stream-audio-fingerprint",
-      "stargazerCount": 773,
+      "stargazerCount": 774,
       "description": "Audio landmark fingerprinting as a Node Stream module",
       "primaryLanguage": "TypeScript",
       "starredAt": "2017-12-04T00:09:45Z"
@@ -15290,7 +15401,7 @@
     {
       "nameWithOwner": "appleple/lite-editor",
       "url": "https://github.com/appleple/lite-editor",
-      "stargazerCount": 178,
+      "stargazerCount": 179,
       "description": "A Modern WYSIWYG Editor especially for inline elements",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-12-03T21:59:57Z"
@@ -15298,7 +15409,7 @@
     {
       "nameWithOwner": "luangjokaj/wordpressify",
       "url": "https://github.com/luangjokaj/wordpressify",
-      "stargazerCount": 1630,
+      "stargazerCount": 1631,
       "description": "🎈 Automate your WordPress development workflow.",
       "primaryLanguage": "PHP",
       "starredAt": "2017-12-03T21:56:57Z"
@@ -15306,7 +15417,7 @@
     {
       "nameWithOwner": "akaunting/akaunting",
       "url": "https://github.com/akaunting/akaunting",
-      "stargazerCount": 8980,
+      "stargazerCount": 9043,
       "description": "Online Accounting Software",
       "primaryLanguage": "PHP",
       "starredAt": "2017-12-03T21:51:44Z"
@@ -15314,7 +15425,7 @@
     {
       "nameWithOwner": "reactopt/reactopt",
       "url": "https://github.com/reactopt/reactopt",
-      "stargazerCount": 1985,
+      "stargazerCount": 1984,
       "description": "A CLI React performance optimization tool that identifies potential unnecessary re-rendering",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-12-01T01:36:57Z"
@@ -15322,7 +15433,7 @@
     {
       "nameWithOwner": "woocommerce/woocommerce-gateway-stripe",
       "url": "https://github.com/woocommerce/woocommerce-gateway-stripe",
-      "stargazerCount": 261,
+      "stargazerCount": 262,
       "description": "The official Stripe Payment Gateway for WooCommerce",
       "primaryLanguage": "PHP",
       "starredAt": "2017-11-29T10:06:42Z"
@@ -15330,7 +15441,7 @@
     {
       "nameWithOwner": "k88hudson/git-flight-rules",
       "url": "https://github.com/k88hudson/git-flight-rules",
-      "stargazerCount": 42394,
+      "stargazerCount": 42398,
       "description": "Flight rules for git",
       "primaryLanguage": null,
       "starredAt": "2017-11-27T22:02:13Z"
@@ -15338,7 +15449,7 @@
     {
       "nameWithOwner": "final-form/react-final-form",
       "url": "https://github.com/final-form/react-final-form",
-      "stargazerCount": 7413,
+      "stargazerCount": 7414,
       "description": "🏁 High performance subscription-based form state management for React",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-11-27T21:49:05Z"
@@ -15346,7 +15457,7 @@
     {
       "nameWithOwner": "Pau1fitz/react-spotify",
       "url": "https://github.com/Pau1fitz/react-spotify",
-      "stargazerCount": 1292,
+      "stargazerCount": 1295,
       "description": "Spotify React / Redux   🎤🎺🎸🎷  ",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-11-27T21:46:35Z"
@@ -15362,7 +15473,7 @@
     {
       "nameWithOwner": "vanila-io/wireflow",
       "url": "https://github.com/vanila-io/wireflow",
-      "stargazerCount": 4105,
+      "stargazerCount": 4111,
       "description": "Wireflow - user flow chart real-time collaborative tool",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-11-26T23:42:33Z"
@@ -15370,7 +15481,7 @@
     {
       "nameWithOwner": "jaredpalmer/react-fns",
       "url": "https://github.com/jaredpalmer/react-fns",
-      "stargazerCount": 3720,
+      "stargazerCount": 3721,
       "description": "Browser API's turned into declarative React components and HoC's",
       "primaryLanguage": "TypeScript",
       "starredAt": "2017-11-26T22:48:29Z"
@@ -15378,7 +15489,7 @@
     {
       "nameWithOwner": "decaporg/one-click-hugo-cms",
       "url": "https://github.com/decaporg/one-click-hugo-cms",
-      "stargazerCount": 523,
+      "stargazerCount": 524,
       "description": "Hugo template with Decap CMS",
       "primaryLanguage": "SCSS",
       "starredAt": "2017-11-26T01:41:36Z"
@@ -15386,7 +15497,7 @@
     {
       "nameWithOwner": "z11h/awesome-touchbar",
       "url": "https://github.com/z11h/awesome-touchbar",
-      "stargazerCount": 455,
+      "stargazerCount": 456,
       "description": ":point_right: :star2: delightful macOS resources for your touchbar",
       "primaryLanguage": null,
       "starredAt": "2017-11-24T04:24:31Z"
@@ -15394,7 +15505,7 @@
     {
       "nameWithOwner": "grommet/grommet",
       "url": "https://github.com/grommet/grommet",
-      "stargazerCount": 8367,
+      "stargazerCount": 8369,
       "description": "a react-based framework that provides accessibility, modularity, responsiveness, and theming in a tidy package",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-11-24T01:58:50Z"
@@ -15402,7 +15513,7 @@
     {
       "nameWithOwner": "ankane/react-chartkick",
       "url": "https://github.com/ankane/react-chartkick",
-      "stargazerCount": 1201,
+      "stargazerCount": 1202,
       "description": "Create beautiful JavaScript charts with one line of React",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-11-24T01:44:16Z"
@@ -15418,7 +15529,7 @@
     {
       "nameWithOwner": "rstacruz/cheatsheets",
       "url": "https://github.com/rstacruz/cheatsheets",
-      "stargazerCount": 14130,
+      "stargazerCount": 14147,
       "description": "Cheatsheets for web development - devhints.io",
       "primaryLanguage": "SCSS",
       "starredAt": "2017-11-24T01:28:10Z"
@@ -15426,7 +15537,7 @@
     {
       "nameWithOwner": "tj/node-prune",
       "url": "https://github.com/tj/node-prune",
-      "stargazerCount": 4434,
+      "stargazerCount": 4436,
       "description": "Remove unnecessary files from node_modules (.md, .ts, ...)",
       "primaryLanguage": "Go",
       "starredAt": "2017-11-24T01:15:40Z"
@@ -15450,7 +15561,7 @@
     {
       "nameWithOwner": "benbalter/wordpress-to-jekyll-exporter",
       "url": "https://github.com/benbalter/wordpress-to-jekyll-exporter",
-      "stargazerCount": 1052,
+      "stargazerCount": 1053,
       "description": "One-click WordPress plugin that converts all posts, pages, taxonomies, metadata, and settings to Markdown and YAML which can be dropped into Jekyll (or Hugo or any other Markdown and YAML based site engine).",
       "primaryLanguage": "PHP",
       "starredAt": "2017-11-23T07:01:42Z"
@@ -15466,7 +15577,7 @@
     {
       "nameWithOwner": "NARKOZ/hacker-scripts",
       "url": "https://github.com/NARKOZ/hacker-scripts",
-      "stargazerCount": 48609,
+      "stargazerCount": 48614,
       "description": "Based on a true story",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-11-23T03:12:06Z"
@@ -15482,7 +15593,7 @@
     {
       "nameWithOwner": "stripe/elements-examples",
       "url": "https://github.com/stripe/elements-examples",
-      "stargazerCount": 1008,
+      "stargazerCount": 1009,
       "description": "Stripe Elements examples.",
       "primaryLanguage": "HTML",
       "starredAt": "2017-11-21T23:42:23Z"
@@ -15522,7 +15633,7 @@
     {
       "nameWithOwner": "uNmAnNeR/imaskjs",
       "url": "https://github.com/uNmAnNeR/imaskjs",
-      "stargazerCount": 5105,
+      "stargazerCount": 5110,
       "description": "vanilla javascript input mask",
       "primaryLanguage": "TypeScript",
       "starredAt": "2017-11-21T04:24:09Z"
@@ -15546,7 +15657,7 @@
     {
       "nameWithOwner": "timber/timber",
       "url": "https://github.com/timber/timber",
-      "stargazerCount": 5603,
+      "stargazerCount": 5605,
       "description": "Create WordPress themes with beautiful OOP code and the Twig Template Engine",
       "primaryLanguage": "PHP",
       "starredAt": "2017-11-17T01:54:02Z"
@@ -15554,7 +15665,7 @@
     {
       "nameWithOwner": "GoogleChrome/lighthouse",
       "url": "https://github.com/GoogleChrome/lighthouse",
-      "stargazerCount": 29193,
+      "stargazerCount": 29229,
       "description": "Automated auditing, performance metrics, and best practices for the web.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-11-17T00:52:09Z"
@@ -15570,7 +15681,7 @@
     {
       "nameWithOwner": "atlassian/react-beautiful-dnd",
       "url": "https://github.com/atlassian/react-beautiful-dnd",
-      "stargazerCount": 33987,
+      "stargazerCount": 34005,
       "description": "Beautiful and accessible drag and drop for lists with React",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-11-15T03:38:49Z"
@@ -15586,7 +15697,7 @@
     {
       "nameWithOwner": "decaporg/gatsby-starter-decap-cms",
       "url": "https://github.com/decaporg/gatsby-starter-decap-cms",
-      "stargazerCount": 2067,
+      "stargazerCount": 2065,
       "description": "Example Gatsby + Decap CMS project",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-11-14T04:59:19Z"
@@ -15594,7 +15705,7 @@
     {
       "nameWithOwner": "graphql/graphiql",
       "url": "https://github.com/graphql/graphiql",
-      "stargazerCount": 16568,
+      "stargazerCount": 16585,
       "description": "GraphiQL & the GraphQL LSP Reference Ecosystem for building browser & IDE tools.",
       "primaryLanguage": "TypeScript",
       "starredAt": "2017-11-14T03:37:52Z"
@@ -15610,7 +15721,7 @@
     {
       "nameWithOwner": "netlify/gotrue",
       "url": "https://github.com/netlify/gotrue",
-      "stargazerCount": 4128,
+      "stargazerCount": 4136,
       "description": "An SWT based API for managing users and issuing SWT tokens.",
       "primaryLanguage": "Go",
       "starredAt": "2017-11-12T04:16:00Z"
@@ -15618,7 +15729,7 @@
     {
       "nameWithOwner": "nodeca/js-yaml",
       "url": "https://github.com/nodeca/js-yaml",
-      "stargazerCount": 6436,
+      "stargazerCount": 6437,
       "description": "JavaScript YAML parser and dumper. Very fast.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-11-12T00:27:06Z"
@@ -15634,7 +15745,7 @@
     {
       "nameWithOwner": "scottdraves/electricsheep",
       "url": "https://github.com/scottdraves/electricsheep",
-      "stargazerCount": 586,
+      "stargazerCount": 587,
       "description": "infinite evolving crowdsourced artwork",
       "primaryLanguage": "C",
       "starredAt": "2017-11-10T03:14:20Z"
@@ -15642,7 +15753,7 @@
     {
       "nameWithOwner": "xtianmiller/emergence.js",
       "url": "https://github.com/xtianmiller/emergence.js",
-      "stargazerCount": 1884,
+      "stargazerCount": 1885,
       "description": "Detect element visibility in the browser",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-11-10T00:24:30Z"
@@ -15650,7 +15761,7 @@
     {
       "nameWithOwner": "addyosmani/critical",
       "url": "https://github.com/addyosmani/critical",
-      "stargazerCount": 10144,
+      "stargazerCount": 10151,
       "description": "Extract & Inline Critical-path CSS in HTML pages",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-11-10T00:22:11Z"
@@ -15658,7 +15769,7 @@
     {
       "nameWithOwner": "Bogdan-Lyashenko/js-code-to-svg-flowchart",
       "url": "https://github.com/Bogdan-Lyashenko/js-code-to-svg-flowchart",
-      "stargazerCount": 7106,
+      "stargazerCount": 7107,
       "description": "js2flowchart - a visualization library to convert any JavaScript code into beautiful SVG flowchart. Learn other’s code. Design your code. Refactor code. Document code. Explain code.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-11-09T23:58:48Z"
@@ -15674,7 +15785,7 @@
     {
       "nameWithOwner": "julienXX/terminal-notifier",
       "url": "https://github.com/julienXX/terminal-notifier",
-      "stargazerCount": 6586,
+      "stargazerCount": 6610,
       "description": "Send User Notifications on macOS from the command-line.",
       "primaryLanguage": "Objective-C",
       "starredAt": "2017-11-08T22:14:22Z"
@@ -15690,7 +15801,7 @@
     {
       "nameWithOwner": "netlify/gocommerce",
       "url": "https://github.com/netlify/gocommerce",
-      "stargazerCount": 1582,
+      "stargazerCount": 1585,
       "description": "A headless e-commerce for JAMstack sites.",
       "primaryLanguage": "Go",
       "starredAt": "2017-11-08T21:43:54Z"
@@ -15706,7 +15817,7 @@
     {
       "nameWithOwner": "tonaljs/tonal",
       "url": "https://github.com/tonaljs/tonal",
-      "stargazerCount": 4001,
+      "stargazerCount": 4002,
       "description": "A music theory library for Javascript",
       "primaryLanguage": "TypeScript",
       "starredAt": "2017-11-06T21:16:04Z"
@@ -15714,7 +15825,7 @@
     {
       "nameWithOwner": "gregberge/svgr",
       "url": "https://github.com/gregberge/svgr",
-      "stargazerCount": 10867,
+      "stargazerCount": 10873,
       "description": "Transform SVGs into React components 🦁",
       "primaryLanguage": "TypeScript",
       "starredAt": "2017-11-06T03:43:26Z"
@@ -15754,7 +15865,7 @@
     {
       "nameWithOwner": "frappe/charts",
       "url": "https://github.com/frappe/charts",
-      "stargazerCount": 15035,
+      "stargazerCount": 15040,
       "description": "Simple, responsive, modern SVG Charts with zero dependencies",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-11-02T23:21:19Z"
@@ -15778,7 +15889,7 @@
     {
       "nameWithOwner": "tailwindlabs/tailwindcss",
       "url": "https://github.com/tailwindlabs/tailwindcss",
-      "stargazerCount": 89166,
+      "stargazerCount": 89363,
       "description": "A utility-first CSS framework for rapid UI development.",
       "primaryLanguage": "TypeScript",
       "starredAt": "2017-11-01T23:33:49Z"
@@ -15794,7 +15905,7 @@
     {
       "nameWithOwner": "elizabetdev/react-kawaii",
       "url": "https://github.com/elizabetdev/react-kawaii",
-      "stargazerCount": 2937,
+      "stargazerCount": 2938,
       "description": "Cute SVG React Components",
       "primaryLanguage": "TypeScript",
       "starredAt": "2017-11-01T00:43:48Z"
@@ -15802,7 +15913,7 @@
     {
       "nameWithOwner": "stereobooster/react-snap",
       "url": "https://github.com/stereobooster/react-snap",
-      "stargazerCount": 5112,
+      "stargazerCount": 5113,
       "description": "👻 Zero-configuration framework-agnostic static prerendering for SPAs",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-10-31T01:59:12Z"
@@ -15810,7 +15921,7 @@
     {
       "nameWithOwner": "a11yproject/a11yproject.com",
       "url": "https://github.com/a11yproject/a11yproject.com",
-      "stargazerCount": 3809,
+      "stargazerCount": 3811,
       "description": "The A11Y Project is a community-driven effort to make digital accessibility easier.",
       "primaryLanguage": "Nunjucks",
       "starredAt": "2017-10-31T00:36:02Z"
@@ -15834,7 +15945,7 @@
     {
       "nameWithOwner": "jackfranklin/demopack",
       "url": "https://github.com/jackfranklin/demopack",
-      "stargazerCount": 172,
+      "stargazerCount": 173,
       "description": "A prepackaged Webpack for easy frontend demos.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-10-29T22:08:43Z"
@@ -15850,7 +15961,7 @@
     {
       "nameWithOwner": "webpackmonitor/webpackmonitor",
       "url": "https://github.com/webpackmonitor/webpackmonitor",
-      "stargazerCount": 2405,
+      "stargazerCount": 2406,
       "description": "A tool for monitoring webpack optimization metrics through the development process",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-10-29T21:54:45Z"
@@ -15874,7 +15985,7 @@
     {
       "nameWithOwner": "prisma/prisma1",
       "url": "https://github.com/prisma/prisma1",
-      "stargazerCount": 16465,
+      "stargazerCount": 16464,
       "description": "💾 Database Tools incl. ORM, Migrations and Admin UI (Postgres, MySQL & MongoDB) [deprecated]",
       "primaryLanguage": "Scala",
       "starredAt": "2017-10-26T23:31:48Z"
@@ -15890,7 +16001,7 @@
     {
       "nameWithOwner": "axe312ger/sqip",
       "url": "https://github.com/axe312ger/sqip",
-      "stargazerCount": 3405,
+      "stargazerCount": 3407,
       "description": "\"SQIP\" (pronounced \\skwɪb\\ like the non-magical folk of magical descent) is a  SVG-based LQIP technique.",
       "primaryLanguage": "TypeScript",
       "starredAt": "2017-10-25T23:28:57Z"
@@ -15922,7 +16033,7 @@
     {
       "nameWithOwner": "nomcopter/react-mosaic",
       "url": "https://github.com/nomcopter/react-mosaic",
-      "stargazerCount": 4607,
+      "stargazerCount": 4619,
       "description": "A React tiling window manager",
       "primaryLanguage": "TypeScript",
       "starredAt": "2017-10-24T04:29:49Z"
@@ -15930,7 +16041,7 @@
     {
       "nameWithOwner": "github/gitignore",
       "url": "https://github.com/github/gitignore",
-      "stargazerCount": 168184,
+      "stargazerCount": 168410,
       "description": "A collection of useful .gitignore templates",
       "primaryLanguage": null,
       "starredAt": "2017-10-24T04:13:48Z"
@@ -15938,7 +16049,7 @@
     {
       "nameWithOwner": "react-dnd/react-dnd",
       "url": "https://github.com/react-dnd/react-dnd",
-      "stargazerCount": 21516,
+      "stargazerCount": 21521,
       "description": "Drag and Drop for React",
       "primaryLanguage": "TypeScript",
       "starredAt": "2017-10-24T01:24:22Z"
@@ -15954,7 +16065,7 @@
     {
       "nameWithOwner": "sharkdp/fd",
       "url": "https://github.com/sharkdp/fd",
-      "stargazerCount": 38814,
+      "stargazerCount": 38927,
       "description": "A simple, fast and user-friendly alternative to 'find'",
       "primaryLanguage": "Rust",
       "starredAt": "2017-10-24T00:37:48Z"
@@ -15962,7 +16073,7 @@
     {
       "nameWithOwner": "prettier/prettier",
       "url": "https://github.com/prettier/prettier",
-      "stargazerCount": 50759,
+      "stargazerCount": 50794,
       "description": "Prettier is an opinionated code formatter.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-10-23T21:31:52Z"
@@ -15970,7 +16081,7 @@
     {
       "nameWithOwner": "stylelint/stylelint",
       "url": "https://github.com/stylelint/stylelint",
-      "stargazerCount": 11302,
+      "stargazerCount": 11307,
       "description": "A mighty CSS linter that helps you avoid errors and enforce conventions.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-10-23T21:05:11Z"
@@ -15978,7 +16089,7 @@
     {
       "nameWithOwner": "JamieMason/ImageOptim-CLI",
       "url": "https://github.com/JamieMason/ImageOptim-CLI",
-      "stargazerCount": 3505,
+      "stargazerCount": 3508,
       "description": "Make optimisation of images part of your automated build process",
       "primaryLanguage": "TypeScript",
       "starredAt": "2017-10-23T05:59:10Z"
@@ -16010,7 +16121,7 @@
     {
       "nameWithOwner": "josephernest/writing",
       "url": "https://github.com/josephernest/writing",
-      "stargazerCount": 1066,
+      "stargazerCount": 1067,
       "description": "Writing is a lightweight distraction-free text editor, in the browser (Markdown and LaTeX supported).",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-10-22T22:30:48Z"
@@ -16018,7 +16129,7 @@
     {
       "nameWithOwner": "thedaviddias/Front-End-Checklist",
       "url": "https://github.com/thedaviddias/Front-End-Checklist",
-      "stargazerCount": 70452,
+      "stargazerCount": 70483,
       "description": "🗂 The perfect Front-End Checklist for modern websites and meticulous developers",
       "primaryLanguage": null,
       "starredAt": "2017-10-22T22:26:24Z"
@@ -16026,7 +16137,7 @@
     {
       "nameWithOwner": "goldfire/howler.js",
       "url": "https://github.com/goldfire/howler.js",
-      "stargazerCount": 24758,
+      "stargazerCount": 24773,
       "description": "Javascript audio library for the modern web.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-10-22T09:31:41Z"
@@ -16090,7 +16201,7 @@
     {
       "nameWithOwner": "tonsky/FiraCode",
       "url": "https://github.com/tonsky/FiraCode",
-      "stargazerCount": 79494,
+      "stargazerCount": 79758,
       "description": "Free monospaced font with programming ligatures",
       "primaryLanguage": "Clojure",
       "starredAt": "2017-10-21T12:10:01Z"
@@ -16114,7 +16225,7 @@
     {
       "nameWithOwner": "mapbox/geojson.io",
       "url": "https://github.com/mapbox/geojson.io",
-      "stargazerCount": 2016,
+      "stargazerCount": 2024,
       "description": "A quick, simple tool for creating, viewing, and sharing spatial data",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-10-21T00:15:01Z"
@@ -16138,7 +16249,7 @@
     {
       "nameWithOwner": "lysyi3m/macos-terminal-themes",
       "url": "https://github.com/lysyi3m/macos-terminal-themes",
-      "stargazerCount": 6180,
+      "stargazerCount": 6193,
       "description": "Color schemes for default macOS Terminal.app",
       "primaryLanguage": "Swift",
       "starredAt": "2017-10-19T23:59:51Z"
@@ -16234,7 +16345,7 @@
     {
       "nameWithOwner": "nuxt/nuxt",
       "url": "https://github.com/nuxt/nuxt",
-      "stargazerCount": 57736,
+      "stargazerCount": 57809,
       "description": "The Intuitive Vue Framework.",
       "primaryLanguage": "TypeScript",
       "starredAt": "2017-10-18T01:17:32Z"
@@ -16250,7 +16361,7 @@
     {
       "nameWithOwner": "rupa/z",
       "url": "https://github.com/rupa/z",
-      "stargazerCount": 16720,
+      "stargazerCount": 16730,
       "description": "z - jump around",
       "primaryLanguage": "Shell",
       "starredAt": "2017-10-17T03:28:02Z"
@@ -16266,7 +16377,7 @@
     {
       "nameWithOwner": "fish-shell/fish-shell",
       "url": "https://github.com/fish-shell/fish-shell",
-      "stargazerCount": 30403,
+      "stargazerCount": 30489,
       "description": "The user-friendly command line shell.",
       "primaryLanguage": "Rust",
       "starredAt": "2017-10-17T02:00:21Z"
@@ -16282,7 +16393,7 @@
     {
       "nameWithOwner": "felixrieseberg/responsive-images-generator",
       "url": "https://github.com/felixrieseberg/responsive-images-generator",
-      "stargazerCount": 54,
+      "stargazerCount": 55,
       "description": "Generate responsive images from Node",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-10-16T12:05:51Z"
@@ -16298,7 +16409,7 @@
     {
       "nameWithOwner": "CodeHubApp/CodeHub",
       "url": "https://github.com/CodeHubApp/CodeHub",
-      "stargazerCount": 22740,
+      "stargazerCount": 22736,
       "description": "CodeHub is an iOS application written using Xamarin",
       "primaryLanguage": "C#",
       "starredAt": "2017-10-14T12:39:12Z"
@@ -16306,7 +16417,7 @@
     {
       "nameWithOwner": "jonschlinkert/gray-matter",
       "url": "https://github.com/jonschlinkert/gray-matter",
-      "stargazerCount": 4196,
+      "stargazerCount": 4209,
       "description": "Smarter YAML front matter parser, used by metalsmith, Gatsby, Netlify, Assemble, mapbox-gl, phenomic, vuejs vitepress, TinaCMS, Shopify Polaris, Ant Design, Astro,  hashicorp, garden, slidev, saber, sourcegraph, and many others. Simple to use, and battle tested. Parses YAML by default but can also parse JSON Front Matter, Coffee Front Matter, TOML Front Matter, and has support for custom parsers. Please follow gray-matter's author: https://github.com/jonschlinkert",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-10-14T08:27:56Z"
@@ -16314,7 +16425,7 @@
     {
       "nameWithOwner": "jgthms/web-design-in-4-minutes",
       "url": "https://github.com/jgthms/web-design-in-4-minutes",
-      "stargazerCount": 4381,
+      "stargazerCount": 4382,
       "description": "Learn the basics of web design in 4 minutes",
       "primaryLanguage": "HTML",
       "starredAt": "2017-10-14T00:34:06Z"
@@ -16322,7 +16433,7 @@
     {
       "nameWithOwner": "rnosov/react-reveal",
       "url": "https://github.com/rnosov/react-reveal",
-      "stargazerCount": 2725,
+      "stargazerCount": 2726,
       "description": "Easily add reveal on scroll animations to your React app",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-10-14T00:03:06Z"
@@ -16330,7 +16441,7 @@
     {
       "nameWithOwner": "React-Sight/React-Sight",
       "url": "https://github.com/React-Sight/React-Sight",
-      "stargazerCount": 2869,
+      "stargazerCount": 2868,
       "description": "Visualization tool for React, with support for Fiber, Router (v4), and Redux",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-10-13T23:59:23Z"
@@ -16338,7 +16449,7 @@
     {
       "nameWithOwner": "unifiedjs/unified",
       "url": "https://github.com/unifiedjs/unified",
-      "stargazerCount": 4781,
+      "stargazerCount": 4790,
       "description": "Parse, inspect, transform, and serialize content with syntax trees",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-10-12T20:51:09Z"
@@ -16354,7 +16465,7 @@
     {
       "nameWithOwner": "sass/sass",
       "url": "https://github.com/sass/sass",
-      "stargazerCount": 15304,
+      "stargazerCount": 15311,
       "description": "Sass makes CSS fun!",
       "primaryLanguage": "TypeScript",
       "starredAt": "2017-10-12T06:26:38Z"
@@ -16370,7 +16481,7 @@
     {
       "nameWithOwner": "netlify/netlify-identity-widget",
       "url": "https://github.com/netlify/netlify-identity-widget",
-      "stargazerCount": 787,
+      "stargazerCount": 789,
       "description": "A zero config, framework free Netlify Identity widget",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-10-12T03:06:54Z"
@@ -16386,7 +16497,7 @@
     {
       "nameWithOwner": "csstools/sanitize.css",
       "url": "https://github.com/csstools/sanitize.css",
-      "stargazerCount": 5260,
+      "stargazerCount": 5263,
       "description": "A best-practices CSS foundation",
       "primaryLanguage": "CSS",
       "starredAt": "2017-10-10T21:14:25Z"
@@ -16394,7 +16505,7 @@
     {
       "nameWithOwner": "konvajs/react-konva",
       "url": "https://github.com/konvajs/react-konva",
-      "stargazerCount": 6051,
+      "stargazerCount": 6063,
       "description": "React + Canvas = Love. JavaScript library for drawing complex canvas graphics using React.",
       "primaryLanguage": "TypeScript",
       "starredAt": "2017-10-10T05:52:45Z"
@@ -16402,7 +16513,7 @@
     {
       "nameWithOwner": "niklasvh/html2canvas",
       "url": "https://github.com/niklasvh/html2canvas",
-      "stargazerCount": 31395,
+      "stargazerCount": 31427,
       "description": "Screenshots with JavaScript",
       "primaryLanguage": "TypeScript",
       "starredAt": "2017-10-10T04:01:35Z"
@@ -16410,7 +16521,7 @@
     {
       "nameWithOwner": "bestofjs/bestofjs",
       "url": "https://github.com/bestofjs/bestofjs",
-      "stargazerCount": 2906,
+      "stargazerCount": 2912,
       "description": ":star: A place to find the best components to build amazing web applications. The best of JavaScript!",
       "primaryLanguage": "TypeScript",
       "starredAt": "2017-10-10T03:05:54Z"
@@ -16426,7 +16537,7 @@
     {
       "nameWithOwner": "hexojs/hexo",
       "url": "https://github.com/hexojs/hexo",
-      "stargazerCount": 40547,
+      "stargazerCount": 40592,
       "description": "A fast, simple & powerful blog framework, powered by Node.js.",
       "primaryLanguage": "TypeScript",
       "starredAt": "2017-10-09T21:47:52Z"
@@ -16434,7 +16545,7 @@
     {
       "nameWithOwner": "mde/ejs",
       "url": "https://github.com/mde/ejs",
-      "stargazerCount": 7973,
+      "stargazerCount": 7980,
       "description": "Embedded JavaScript templates -- http://ejs.co",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-10-09T11:24:37Z"
@@ -16442,7 +16553,7 @@
     {
       "nameWithOwner": "pugjs/pug",
       "url": "https://github.com/pugjs/pug",
-      "stargazerCount": 21811,
+      "stargazerCount": 21807,
       "description": "Pug – robust, elegant, feature rich template engine for Node.js",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-10-09T07:30:55Z"
@@ -16450,7 +16561,7 @@
     {
       "nameWithOwner": "apex/up",
       "url": "https://github.com/apex/up",
-      "stargazerCount": 8807,
+      "stargazerCount": 8811,
       "description": "Deploy infinitely scalable serverless apps, apis, and sites in seconds to AWS.",
       "primaryLanguage": "Go",
       "starredAt": "2017-10-09T05:05:04Z"
@@ -16458,7 +16569,7 @@
     {
       "nameWithOwner": "vseventer/sharp-cli",
       "url": "https://github.com/vseventer/sharp-cli",
-      "stargazerCount": 196,
+      "stargazerCount": 198,
       "description": "CLI for sharp.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-10-09T04:23:39Z"
@@ -16506,7 +16617,7 @@
     {
       "nameWithOwner": "micromodal/Micromodal",
       "url": "https://github.com/micromodal/Micromodal",
-      "stargazerCount": 3589,
+      "stargazerCount": 3591,
       "description": "⭕   Tiny javascript library for creating accessible modal dialogs",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-10-09T00:17:02Z"
@@ -16522,7 +16633,7 @@
     {
       "nameWithOwner": "alvarcarto/url-to-pdf-api",
       "url": "https://github.com/alvarcarto/url-to-pdf-api",
-      "stargazerCount": 7076,
+      "stargazerCount": 7080,
       "description": "Web page PDF/PNG rendering done right. Self-hosted service for rendering receipts, invoices, or any content.",
       "primaryLanguage": "HTML",
       "starredAt": "2017-10-08T23:16:44Z"
@@ -16530,7 +16641,7 @@
     {
       "nameWithOwner": "fent/node-ytdl",
       "url": "https://github.com/fent/node-ytdl",
-      "stargazerCount": 1272,
+      "stargazerCount": 1273,
       "description": "Command line youtube video downloader.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-10-08T04:12:56Z"
@@ -16546,7 +16657,7 @@
     {
       "nameWithOwner": "react-static/react-static",
       "url": "https://github.com/react-static/react-static",
-      "stargazerCount": 10338,
+      "stargazerCount": 10340,
       "description": "⚛️ 🚀 A progressive static site generator for React.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-10-08T03:50:51Z"
@@ -16554,7 +16665,7 @@
     {
       "nameWithOwner": "jpuri/react-draft-wysiwyg",
       "url": "https://github.com/jpuri/react-draft-wysiwyg",
-      "stargazerCount": 6480,
+      "stargazerCount": 6481,
       "description": "A Wysiwyg editor build on top of ReactJS and DraftJS. https://jpuri.github.io/react-draft-wysiwyg",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-10-06T21:07:53Z"
@@ -16570,7 +16681,7 @@
     {
       "nameWithOwner": "nikgraf/awesome-draft-js",
       "url": "https://github.com/nikgraf/awesome-draft-js",
-      "stargazerCount": 2511,
+      "stargazerCount": 2512,
       "description": "Awesome list of Draft.js resources",
       "primaryLanguage": null,
       "starredAt": "2017-10-06T21:00:09Z"
@@ -16578,7 +16689,7 @@
     {
       "nameWithOwner": "firebase/quickstart-js",
       "url": "https://github.com/firebase/quickstart-js",
-      "stargazerCount": 5252,
+      "stargazerCount": 5261,
       "description": "Firebase Quickstart Samples for Web",
       "primaryLanguage": "TypeScript",
       "starredAt": "2017-10-06T07:16:26Z"
@@ -16594,7 +16705,7 @@
     {
       "nameWithOwner": "gajus/roarr",
       "url": "https://github.com/gajus/roarr",
-      "stargazerCount": 1103,
+      "stargazerCount": 1104,
       "description": "JSON logger for Node.js and browser.",
       "primaryLanguage": "TypeScript",
       "starredAt": "2017-10-06T01:01:24Z"
@@ -16658,7 +16769,7 @@
     {
       "nameWithOwner": "slmgc/react-hint",
       "url": "https://github.com/slmgc/react-hint",
-      "stargazerCount": 335,
+      "stargazerCount": 334,
       "description": "Tooltip component for React, Preact, Inferno",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-10-05T01:02:01Z"
@@ -16674,7 +16785,7 @@
     {
       "nameWithOwner": "insin/nwb",
       "url": "https://github.com/insin/nwb",
-      "stargazerCount": 5564,
+      "stargazerCount": 5565,
       "description": "A toolkit for React, Preact, Inferno & vanilla JS apps, React libraries and other npm modules for the web, with no configuration (until you need it)",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-10-04T04:25:55Z"
@@ -16682,7 +16793,7 @@
     {
       "nameWithOwner": "sindresorhus/file-type",
       "url": "https://github.com/sindresorhus/file-type",
-      "stargazerCount": 4066,
+      "stargazerCount": 4072,
       "description": "Detect the file type of a file, stream, or data",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-10-03T23:59:17Z"
@@ -16690,7 +16801,7 @@
     {
       "nameWithOwner": "mholt/PapaParse",
       "url": "https://github.com/mholt/PapaParse",
-      "stargazerCount": 13109,
+      "stargazerCount": 13128,
       "description": "Fast and powerful CSV (delimited text) parser that gracefully handles large files and malformed input",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-10-03T06:32:03Z"
@@ -16738,7 +16849,7 @@
     {
       "nameWithOwner": "apollographql/react-apollo",
       "url": "https://github.com/apollographql/react-apollo",
-      "stargazerCount": 6826,
+      "stargazerCount": 6827,
       "description": ":recycle: React integration for Apollo Client",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-10-01T04:59:23Z"
@@ -16754,7 +16865,7 @@
     {
       "nameWithOwner": "cronvel/terminal-kit",
       "url": "https://github.com/cronvel/terminal-kit",
-      "stargazerCount": 3236,
+      "stargazerCount": 3243,
       "description": "Terminal utilities for node.js",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-09-29T03:26:21Z"
@@ -16762,7 +16873,7 @@
     {
       "nameWithOwner": "Shopify/draggable",
       "url": "https://github.com/Shopify/draggable",
-      "stargazerCount": 18309,
+      "stargazerCount": 18316,
       "description": "The JavaScript Drag & Drop library your grandparents warned you about.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-09-29T01:33:02Z"
@@ -16770,7 +16881,7 @@
     {
       "nameWithOwner": "dylang/shortid",
       "url": "https://github.com/dylang/shortid",
-      "stargazerCount": 5730,
+      "stargazerCount": 5731,
       "description": "Short id generator. Url-friendly. Non-predictable. Cluster-compatible.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-09-29T00:46:44Z"
@@ -16778,7 +16889,7 @@
     {
       "nameWithOwner": "louischatriot/nedb",
       "url": "https://github.com/louischatriot/nedb",
-      "stargazerCount": 13553,
+      "stargazerCount": 13557,
       "description": "The JavaScript Database, for Node.js, nw.js, electron and the browser",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-09-29T00:16:23Z"
@@ -16802,7 +16913,7 @@
     {
       "nameWithOwner": "zenorocha/clipboard.js",
       "url": "https://github.com/zenorocha/clipboard.js",
-      "stargazerCount": 34150,
+      "stargazerCount": 34154,
       "description": ":scissors: Modern copy to clipboard. No Flash. Just 3kb gzipped :clipboard:",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-09-28T22:59:53Z"
@@ -16810,7 +16921,7 @@
     {
       "nameWithOwner": "hoodiehq/hoodie",
       "url": "https://github.com/hoodiehq/hoodie",
-      "stargazerCount": 4430,
+      "stargazerCount": 4429,
       "description": ":dog: The Offline First JavaScript Backend",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-09-28T05:48:59Z"
@@ -16818,7 +16929,7 @@
     {
       "nameWithOwner": "jprichardson/node-jsonfile",
       "url": "https://github.com/jprichardson/node-jsonfile",
-      "stargazerCount": 1206,
+      "stargazerCount": 1208,
       "description": "Easily read/write JSON files.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-09-28T05:40:44Z"
@@ -16850,7 +16961,7 @@
     {
       "nameWithOwner": "marcuswestin/store.js",
       "url": "https://github.com/marcuswestin/store.js",
-      "stargazerCount": 14039,
+      "stargazerCount": 14037,
       "description": "Cross-browser storage for all use cases, used across the web.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-09-28T00:14:55Z"
@@ -16866,7 +16977,7 @@
     {
       "nameWithOwner": "simov/slugify",
       "url": "https://github.com/simov/slugify",
-      "stargazerCount": 1667,
+      "stargazerCount": 1670,
       "description": "Slugifies a string",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-09-28T00:09:20Z"
@@ -16890,7 +17001,7 @@
     {
       "nameWithOwner": "tachyons-css/tachyons",
       "url": "https://github.com/tachyons-css/tachyons",
-      "stargazerCount": 11669,
+      "stargazerCount": 11672,
       "description": "Functional css for humans",
       "primaryLanguage": "CSS",
       "starredAt": "2017-09-27T22:03:09Z"
@@ -16898,7 +17009,7 @@
     {
       "nameWithOwner": "feathersjs/feathers",
       "url": "https://github.com/feathersjs/feathers",
-      "stargazerCount": 15198,
+      "stargazerCount": 15202,
       "description": "The API and real-time application framework",
       "primaryLanguage": "TypeScript",
       "starredAt": "2017-09-27T09:22:54Z"
@@ -16938,7 +17049,7 @@
     {
       "nameWithOwner": "andrerpena/react-mde",
       "url": "https://github.com/andrerpena/react-mde",
-      "stargazerCount": 1447,
+      "stargazerCount": 1448,
       "description": "📝  React Markdown Editor",
       "primaryLanguage": "TypeScript",
       "starredAt": "2017-09-27T00:46:09Z"
@@ -16970,7 +17081,7 @@
     {
       "nameWithOwner": "validatorjs/validator.js",
       "url": "https://github.com/validatorjs/validator.js",
-      "stargazerCount": 23561,
+      "stargazerCount": 23567,
       "description": "String validation",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-09-26T04:36:27Z"
@@ -16978,7 +17089,7 @@
     {
       "nameWithOwner": "Clipy/Clipy",
       "url": "https://github.com/Clipy/Clipy",
-      "stargazerCount": 8111,
+      "stargazerCount": 8127,
       "description": "Clipboard extension app for macOS.",
       "primaryLanguage": "Swift",
       "starredAt": "2017-09-25T07:04:53Z"
@@ -17002,7 +17113,7 @@
     {
       "nameWithOwner": "ai/nanoevents",
       "url": "https://github.com/ai/nanoevents",
-      "stargazerCount": 1578,
+      "stargazerCount": 1580,
       "description": "Simple and tiny (107 bytes) event emitter library for JavaScript",
       "primaryLanguage": "TypeScript",
       "starredAt": "2017-09-25T01:49:33Z"
@@ -17010,7 +17121,7 @@
     {
       "nameWithOwner": "elbywan/wretch",
       "url": "https://github.com/elbywan/wretch",
-      "stargazerCount": 5002,
+      "stargazerCount": 5008,
       "description": "A tiny wrapper built around fetch with an intuitive syntax. :candy:",
       "primaryLanguage": "TypeScript",
       "starredAt": "2017-09-25T01:48:37Z"
@@ -17018,7 +17129,7 @@
     {
       "nameWithOwner": "dropbox/zxcvbn",
       "url": "https://github.com/dropbox/zxcvbn",
-      "stargazerCount": 15571,
+      "stargazerCount": 15588,
       "description": "Low-Budget Password Strength Estimation",
       "primaryLanguage": "CoffeeScript",
       "starredAt": "2017-09-25T01:46:54Z"
@@ -17050,7 +17161,7 @@
     {
       "nameWithOwner": "gka/chroma.js",
       "url": "https://github.com/gka/chroma.js",
-      "stargazerCount": 10416,
+      "stargazerCount": 10421,
       "description": "JavaScript library for all kinds of color manipulations",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-09-21T04:59:18Z"
@@ -17058,7 +17169,7 @@
     {
       "nameWithOwner": "airbnb/react-sketchapp",
       "url": "https://github.com/airbnb/react-sketchapp",
-      "stargazerCount": 14912,
+      "stargazerCount": 14909,
       "description": "render React components to Sketch ⚛️💎",
       "primaryLanguage": "TypeScript",
       "starredAt": "2017-09-21T04:52:42Z"
@@ -17066,7 +17177,7 @@
     {
       "nameWithOwner": "captbaritone/webamp",
       "url": "https://github.com/captbaritone/webamp",
-      "stargazerCount": 10579,
+      "stargazerCount": 10594,
       "description": "Winamp 2 reimplemented for the browser",
       "primaryLanguage": "TypeScript",
       "starredAt": "2017-09-21T04:39:01Z"
@@ -17082,7 +17193,7 @@
     {
       "nameWithOwner": "mbeaudru/modern-js-cheatsheet",
       "url": "https://github.com/mbeaudru/modern-js-cheatsheet",
-      "stargazerCount": 25639,
+      "stargazerCount": 25642,
       "description": "Cheatsheet for the JavaScript knowledge you will frequently encounter in modern projects.",
       "primaryLanguage": null,
       "starredAt": "2017-09-21T03:21:50Z"
@@ -17098,7 +17209,7 @@
     {
       "nameWithOwner": "b-long/awesome-static-hosting-and-cms",
       "url": "https://github.com/b-long/awesome-static-hosting-and-cms",
-      "stargazerCount": 301,
+      "stargazerCount": 302,
       "description": "A collection of awesome static hosting & CMS providers",
       "primaryLanguage": null,
       "starredAt": "2017-09-21T01:27:55Z"
@@ -17106,7 +17217,7 @@
     {
       "nameWithOwner": "pastelsky/bundlephobia",
       "url": "https://github.com/pastelsky/bundlephobia",
-      "stargazerCount": 9303,
+      "stargazerCount": 9312,
       "description": "🏋️ Find out the cost of adding a new frontend dependency to your project",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-09-20T06:18:17Z"
@@ -17122,7 +17233,7 @@
     {
       "nameWithOwner": "ganlanyuan/tiny-slider",
       "url": "https://github.com/ganlanyuan/tiny-slider",
-      "stargazerCount": 5307,
+      "stargazerCount": 5308,
       "description": "Vanilla javascript slider for all purposes.",
       "primaryLanguage": "HTML",
       "starredAt": "2017-09-20T05:31:53Z"
@@ -17154,7 +17265,7 @@
     {
       "nameWithOwner": "farzher/fuzzysort",
       "url": "https://github.com/farzher/fuzzysort",
-      "stargazerCount": 4168,
+      "stargazerCount": 4177,
       "description": "Fast SublimeText-like fuzzy search for JavaScript.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-09-19T04:30:19Z"
@@ -17170,7 +17281,7 @@
     {
       "nameWithOwner": "immutable-js/immutable-js",
       "url": "https://github.com/immutable-js/immutable-js",
-      "stargazerCount": 33054,
+      "stargazerCount": 33057,
       "description": "Immutable persistent data collections for Javascript which increase efficiency and simplicity.",
       "primaryLanguage": "TypeScript",
       "starredAt": "2017-09-18T22:41:58Z"
@@ -17178,7 +17289,7 @@
     {
       "nameWithOwner": "lit/lit",
       "url": "https://github.com/lit/lit",
-      "stargazerCount": 19967,
+      "stargazerCount": 20002,
       "description": "Lit is a simple library for building fast, lightweight web components.",
       "primaryLanguage": "TypeScript",
       "starredAt": "2017-09-18T22:22:13Z"
@@ -17218,7 +17329,7 @@
     {
       "nameWithOwner": "tweenjs/tween.js",
       "url": "https://github.com/tweenjs/tween.js",
-      "stargazerCount": 10039,
+      "stargazerCount": 10041,
       "description": "JavaScript/TypeScript animation engine",
       "primaryLanguage": "TypeScript",
       "starredAt": "2017-09-17T05:39:57Z"
@@ -17226,7 +17337,7 @@
     {
       "nameWithOwner": "visgl/deck.gl",
       "url": "https://github.com/visgl/deck.gl",
-      "stargazerCount": 13372,
+      "stargazerCount": 13390,
       "description": "WebGL2 powered visualization framework",
       "primaryLanguage": "TypeScript",
       "starredAt": "2017-09-17T05:29:01Z"
@@ -17234,7 +17345,7 @@
     {
       "nameWithOwner": "Thinkmill/react-markings",
       "url": "https://github.com/Thinkmill/react-markings",
-      "stargazerCount": 882,
+      "stargazerCount": 883,
       "description": "**Markdown** in <Components/>, <Components/> in **Markdown**",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-09-14T23:37:45Z"
@@ -17266,7 +17377,7 @@
     {
       "nameWithOwner": "renatorib/react-powerplug",
       "url": "https://github.com/renatorib/react-powerplug",
-      "stargazerCount": 2678,
+      "stargazerCount": 2679,
       "description": ":electric_plug: Renderless Containers",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-09-14T23:07:30Z"
@@ -17282,7 +17393,7 @@
     {
       "nameWithOwner": "docker-archive-public/docker.kitematic",
       "url": "https://github.com/docker-archive-public/docker.kitematic",
-      "stargazerCount": 12203,
+      "stargazerCount": 12205,
       "description": "Visual Docker Container Management on Mac & Windows",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-09-14T01:35:58Z"
@@ -17314,7 +17425,7 @@
     {
       "nameWithOwner": "webpack-contrib/webpack-bundle-analyzer",
       "url": "https://github.com/webpack-contrib/webpack-bundle-analyzer",
-      "stargazerCount": 12643,
+      "stargazerCount": 12645,
       "description": "Webpack plugin and CLI utility that represents bundle content as convenient interactive zoomable treemap",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-09-13T21:45:48Z"
@@ -17322,7 +17433,7 @@
     {
       "nameWithOwner": "webpack-contrib/install-webpack-plugin",
       "url": "https://github.com/webpack-contrib/install-webpack-plugin",
-      "stargazerCount": 1430,
+      "stargazerCount": 1431,
       "description": "Speed up development by automatically installing & saving dependencies with Webpack.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-09-13T03:19:42Z"
@@ -17338,7 +17449,7 @@
     {
       "nameWithOwner": "babel/minify",
       "url": "https://github.com/babel/minify",
-      "stargazerCount": 4391,
+      "stargazerCount": 4394,
       "description": ":scissors: An ES6+ aware minifier based on the Babel toolchain (beta)",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-09-13T01:11:29Z"
@@ -17354,7 +17465,7 @@
     {
       "nameWithOwner": "postcss/postcss",
       "url": "https://github.com/postcss/postcss",
-      "stargazerCount": 28825,
+      "stargazerCount": 28830,
       "description": "Transforming styles with JS plugins",
       "primaryLanguage": "TypeScript",
       "starredAt": "2017-09-12T21:50:48Z"
@@ -17370,7 +17481,7 @@
     {
       "nameWithOwner": "babel/babel-preset-env",
       "url": "https://github.com/babel/babel-preset-env",
-      "stargazerCount": 3492,
+      "stargazerCount": 3493,
       "description": "PSA: this repo has been moved into babel/babel -->",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-09-12T04:41:31Z"
@@ -17378,7 +17489,7 @@
     {
       "nameWithOwner": "webpack-contrib/extract-text-webpack-plugin",
       "url": "https://github.com/webpack-contrib/extract-text-webpack-plugin",
-      "stargazerCount": 4003,
+      "stargazerCount": 4004,
       "description": "[DEPRECATED] Please use https://github.com/webpack-contrib/mini-css-extract-plugin Extracts text from a bundle into a separate file",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-09-11T23:13:59Z"
@@ -17402,7 +17513,7 @@
     {
       "nameWithOwner": "webpack-contrib/sass-loader",
       "url": "https://github.com/webpack-contrib/sass-loader",
-      "stargazerCount": 3903,
+      "stargazerCount": 3904,
       "description": "Compiles Sass to CSS",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-09-11T22:09:19Z"
@@ -17410,7 +17521,7 @@
     {
       "nameWithOwner": "open-cli-tools/chokidar-cli",
       "url": "https://github.com/open-cli-tools/chokidar-cli",
-      "stargazerCount": 854,
+      "stargazerCount": 853,
       "description": "Fast cross-platform cli utility to watch file system changes",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-09-11T21:34:07Z"
@@ -17426,7 +17537,7 @@
     {
       "nameWithOwner": "FormidableLabs/electron-webpack-dashboard",
       "url": "https://github.com/FormidableLabs/electron-webpack-dashboard",
-      "stargazerCount": 2701,
+      "stargazerCount": 2702,
       "description": "Electron Desktop GUI for Webpack Dashboard",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-09-08T06:23:15Z"
@@ -17434,7 +17545,7 @@
     {
       "nameWithOwner": "williamngan/pts",
       "url": "https://github.com/williamngan/pts",
-      "stargazerCount": 5276,
+      "stargazerCount": 5278,
       "description": "A library for visualization and creative-coding",
       "primaryLanguage": "TypeScript",
       "starredAt": "2017-09-08T06:22:15Z"
@@ -17442,7 +17553,7 @@
     {
       "nameWithOwner": "laradock/laradock",
       "url": "https://github.com/laradock/laradock",
-      "stargazerCount": 12592,
+      "stargazerCount": 12599,
       "description": "Full PHP development environment for Docker.",
       "primaryLanguage": "Dockerfile",
       "starredAt": "2017-09-08T04:45:56Z"
@@ -17474,7 +17585,7 @@
     {
       "nameWithOwner": "nitin42/react-imgpro",
       "url": "https://github.com/nitin42/react-imgpro",
-      "stargazerCount": 2170,
+      "stargazerCount": 2171,
       "description": "📷  Image Processing Component for React",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-09-08T00:31:58Z"
@@ -17482,7 +17593,7 @@
     {
       "nameWithOwner": "t4t5/sweetalert",
       "url": "https://github.com/t4t5/sweetalert",
-      "stargazerCount": 22380,
+      "stargazerCount": 22379,
       "description": "A beautiful replacement for JavaScript's \"alert\"",
       "primaryLanguage": "TypeScript",
       "starredAt": "2017-09-07T06:55:57Z"
@@ -17490,7 +17601,7 @@
     {
       "nameWithOwner": "text-mask/text-mask",
       "url": "https://github.com/text-mask/text-mask",
-      "stargazerCount": 8247,
+      "stargazerCount": 8248,
       "description": "Input mask for React, Angular, Ember, Vue, & plain JavaScript",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-09-07T05:31:08Z"
@@ -17506,7 +17617,7 @@
     {
       "nameWithOwner": "ai/nanoid",
       "url": "https://github.com/ai/nanoid",
-      "stargazerCount": 25920,
+      "stargazerCount": 25949,
       "description": "A tiny (124 bytes), secure, URL-friendly, unique string ID generator for JavaScript",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-09-07T04:50:22Z"
@@ -17514,7 +17625,7 @@
     {
       "nameWithOwner": "sass/dart-sass",
       "url": "https://github.com/sass/dart-sass",
-      "stargazerCount": 4106,
+      "stargazerCount": 4112,
       "description": "The reference implementation of Sass, written in Dart.",
       "primaryLanguage": "Dart",
       "starredAt": "2017-09-07T04:14:45Z"
@@ -17522,7 +17633,7 @@
     {
       "nameWithOwner": "nylas/nylas-mail",
       "url": "https://github.com/nylas/nylas-mail",
-      "stargazerCount": 24822,
+      "stargazerCount": 24819,
       "description": ":love_letter: An extensible desktop mail app built on the modern web.  Forks welcome!",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-09-07T04:01:20Z"
@@ -17546,7 +17657,7 @@
     {
       "nameWithOwner": "dutchcoders/transfer.sh",
       "url": "https://github.com/dutchcoders/transfer.sh",
-      "stargazerCount": 15580,
+      "stargazerCount": 15593,
       "description": "Easy and fast file sharing from the command-line.",
       "primaryLanguage": "Go",
       "starredAt": "2017-08-29T08:30:09Z"
@@ -17554,7 +17665,7 @@
     {
       "nameWithOwner": "mjmlio/mjml",
       "url": "https://github.com/mjmlio/mjml",
-      "stargazerCount": 17547,
+      "stargazerCount": 17555,
       "description": "MJML: the only framework that makes responsive-email easy",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-08-24T06:23:14Z"
@@ -17562,7 +17673,7 @@
     {
       "nameWithOwner": "pqrs-org/Karabiner-Elements",
       "url": "https://github.com/pqrs-org/Karabiner-Elements",
-      "stargazerCount": 20390,
+      "stargazerCount": 20450,
       "description": "Karabiner-Elements is a powerful tool for customizing keyboards on macOS",
       "primaryLanguage": "C++",
       "starredAt": "2017-08-23T14:42:49Z"
@@ -17578,7 +17689,7 @@
     {
       "nameWithOwner": "aksakalli/gtop",
       "url": "https://github.com/aksakalli/gtop",
-      "stargazerCount": 9850,
+      "stargazerCount": 9852,
       "description": "System monitoring dashboard for terminal",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-08-18T06:23:00Z"
@@ -17586,7 +17697,7 @@
     {
       "nameWithOwner": "standard-things/esm",
       "url": "https://github.com/standard-things/esm",
-      "stargazerCount": 5265,
+      "stargazerCount": 5263,
       "description": "Tomorrow's ECMAScript modules today!",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-08-18T06:19:57Z"
@@ -17594,7 +17705,7 @@
     {
       "nameWithOwner": "casesandberg/react-color",
       "url": "https://github.com/casesandberg/react-color",
-      "stargazerCount": 12201,
+      "stargazerCount": 12204,
       "description": ":art: Color Pickers from Sketch, Photoshop, Chrome, Github, Twitter & more",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-08-10T06:20:40Z"
@@ -17610,7 +17721,7 @@
     {
       "nameWithOwner": "browserslist/browserslist",
       "url": "https://github.com/browserslist/browserslist",
-      "stargazerCount": 13351,
+      "stargazerCount": 13357,
       "description": "🦔 Share target browsers between different front-end tools, like Autoprefixer, Stylelint and babel-preset-env",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-08-01T22:21:59Z"
@@ -17626,7 +17737,7 @@
     {
       "nameWithOwner": "svg/svgo",
       "url": "https://github.com/svg/svgo",
-      "stargazerCount": 21819,
+      "stargazerCount": 21840,
       "description": "⚙️ Node.js tool for optimizing SVG files",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-08-01T06:57:56Z"
@@ -17642,7 +17753,7 @@
     {
       "nameWithOwner": "WebReflection/dom4",
       "url": "https://github.com/WebReflection/dom4",
-      "stargazerCount": 931,
+      "stargazerCount": 930,
       "description": "Modern DOM functionalities for every browser",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-08-01T05:53:16Z"
@@ -17658,7 +17769,7 @@
     {
       "nameWithOwner": "shoelace-style/shoelace",
       "url": "https://github.com/shoelace-style/shoelace",
-      "stargazerCount": 13594,
+      "stargazerCount": 13613,
       "description": "Web Awesome (\"Shoelace 3\") has been released! Get it here 👇👇👇",
       "primaryLanguage": "TypeScript",
       "starredAt": "2017-08-01T03:20:56Z"
@@ -17666,7 +17777,7 @@
     {
       "nameWithOwner": "spencermountain/spacetime",
       "url": "https://github.com/spencermountain/spacetime",
-      "stargazerCount": 4070,
+      "stargazerCount": 4075,
       "description": "A lightweight javascript timezone library",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-08-01T03:15:35Z"
@@ -17674,7 +17785,7 @@
     {
       "nameWithOwner": "dtao/lazy.js",
       "url": "https://github.com/dtao/lazy.js",
-      "stargazerCount": 5991,
+      "stargazerCount": 5989,
       "description": "Like Underscore, but lazier",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-08-01T03:10:07Z"
@@ -17690,7 +17801,7 @@
     {
       "nameWithOwner": "schickling/chromeless",
       "url": "https://github.com/schickling/chromeless",
-      "stargazerCount": 13228,
+      "stargazerCount": 13229,
       "description": "🖥  Chrome automation made simple. Runs locally or headless on AWS Lambda.",
       "primaryLanguage": "TypeScript",
       "starredAt": "2017-07-31T01:01:31Z"
@@ -17706,7 +17817,7 @@
     {
       "nameWithOwner": "LucasBassetti/react-simple-chatbot",
       "url": "https://github.com/LucasBassetti/react-simple-chatbot",
-      "stargazerCount": 1753,
+      "stargazerCount": 1754,
       "description": ":speech_balloon: Easy way to create conversation chats",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-07-30T23:02:43Z"
@@ -17714,7 +17825,7 @@
     {
       "nameWithOwner": "clangen/musikcube",
       "url": "https://github.com/clangen/musikcube",
-      "stargazerCount": 4485,
+      "stargazerCount": 4494,
       "description": "a cross-platform, terminal-based music player, audio engine, metadata indexer, and server in c++",
       "primaryLanguage": "C++",
       "starredAt": "2017-07-30T23:01:21Z"
@@ -17722,7 +17833,7 @@
     {
       "nameWithOwner": "fengyuanchen/compressorjs",
       "url": "https://github.com/fengyuanchen/compressorjs",
-      "stargazerCount": 5566,
+      "stargazerCount": 5578,
       "description": "JavaScript image compressor.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-07-30T22:59:18Z"
@@ -17746,7 +17857,7 @@
     {
       "nameWithOwner": "zloirock/core-js",
       "url": "https://github.com/zloirock/core-js",
-      "stargazerCount": 25135,
+      "stargazerCount": 25147,
       "description": "Standard Library",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-07-27T05:36:28Z"
@@ -17754,7 +17865,7 @@
     {
       "nameWithOwner": "rikschennink/fitty",
       "url": "https://github.com/rikschennink/fitty",
-      "stargazerCount": 3791,
+      "stargazerCount": 3792,
       "description": "✨ Makes text fit perfectly",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-07-27T03:14:32Z"
@@ -17818,7 +17929,7 @@
     {
       "nameWithOwner": "0xs34n/blockchain-cli",
       "url": "https://github.com/0xs34n/blockchain-cli",
-      "stargazerCount": 1156,
+      "stargazerCount": 1155,
       "description": "⛓️ A minimal blockchain command-line interface.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-07-20T21:58:50Z"
@@ -17826,7 +17937,7 @@
     {
       "nameWithOwner": "WP-API/Basic-Auth",
       "url": "https://github.com/WP-API/Basic-Auth",
-      "stargazerCount": 802,
+      "stargazerCount": 803,
       "description": "Basic Authentication handler for the JSON API, used for development and debugging purposes",
       "primaryLanguage": "PHP",
       "starredAt": "2017-07-20T04:06:29Z"
@@ -17842,7 +17953,7 @@
     {
       "nameWithOwner": "nvbn/thefuck",
       "url": "https://github.com/nvbn/thefuck",
-      "stargazerCount": 93009,
+      "stargazerCount": 93215,
       "description": "Magnificent app which corrects your previous console command.",
       "primaryLanguage": "Python",
       "starredAt": "2017-07-20T01:34:25Z"
@@ -17850,7 +17961,7 @@
     {
       "nameWithOwner": "vuejs/awesome-vue",
       "url": "https://github.com/vuejs/awesome-vue",
-      "stargazerCount": 73113,
+      "stargazerCount": 73128,
       "description": "🎉 A curated list of awesome things related to Vue.js",
       "primaryLanguage": null,
       "starredAt": "2017-07-20T01:30:03Z"
@@ -17858,7 +17969,7 @@
     {
       "nameWithOwner": "cure53/DOMPurify",
       "url": "https://github.com/cure53/DOMPurify",
-      "stargazerCount": 15559,
+      "stargazerCount": 15621,
       "description": "DOMPurify - a DOM-only, super-fast, uber-tolerant XSS sanitizer for HTML, MathML and SVG. DOMPurify works with a secure default, but offers a lot of configurability and hooks. Demo:",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-07-20T01:14:50Z"
@@ -17866,7 +17977,7 @@
     {
       "nameWithOwner": "darylldoyle/svg-sanitizer",
       "url": "https://github.com/darylldoyle/svg-sanitizer",
-      "stargazerCount": 514,
+      "stargazerCount": 515,
       "description": "A PHP SVG/XML Sanitizer",
       "primaryLanguage": "PHP",
       "starredAt": "2017-07-20T01:01:17Z"
@@ -17874,7 +17985,7 @@
     {
       "nameWithOwner": "torvalds/linux",
       "url": "https://github.com/torvalds/linux",
-      "stargazerCount": 198183,
+      "stargazerCount": 198863,
       "description": "Linux kernel source tree",
       "primaryLanguage": "C",
       "starredAt": "2017-07-19T04:56:43Z"
@@ -17890,7 +18001,7 @@
     {
       "nameWithOwner": "VulcanJS/Vulcan",
       "url": "https://github.com/VulcanJS/Vulcan",
-      "stargazerCount": 7952,
+      "stargazerCount": 7953,
       "description": "🌋 A toolkit to quickly build apps with React, GraphQL & Meteor",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-07-17T22:50:46Z"
@@ -17898,7 +18009,7 @@
     {
       "nameWithOwner": "Jack000/SVGnest",
       "url": "https://github.com/Jack000/SVGnest",
-      "stargazerCount": 2422,
+      "stargazerCount": 2423,
       "description": "An open source vector nesting tool",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-07-17T06:27:40Z"
@@ -17914,7 +18025,7 @@
     {
       "nameWithOwner": "emotion-js/emotion",
       "url": "https://github.com/emotion-js/emotion",
-      "stargazerCount": 17821,
+      "stargazerCount": 17826,
       "description": "👩‍🎤 CSS-in-JS library designed for high performance style composition",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-07-17T03:59:27Z"
@@ -17922,7 +18033,7 @@
     {
       "nameWithOwner": "w3c/IntersectionObserver",
       "url": "https://github.com/w3c/IntersectionObserver",
-      "stargazerCount": 3623,
+      "stargazerCount": 3621,
       "description": "Intersection Observer",
       "primaryLanguage": "Bikeshed",
       "starredAt": "2017-07-17T03:46:33Z"
@@ -17930,7 +18041,7 @@
     {
       "nameWithOwner": "howtographql/howtographql",
       "url": "https://github.com/howtographql/howtographql",
-      "stargazerCount": 8725,
+      "stargazerCount": 8730,
       "description": "The Fullstack Tutorial for GraphQL",
       "primaryLanguage": "TypeScript",
       "starredAt": "2017-07-17T01:44:26Z"
@@ -17954,7 +18065,7 @@
     {
       "nameWithOwner": "tonik/theme",
       "url": "https://github.com/tonik/theme",
-      "stargazerCount": 1329,
+      "stargazerCount": 1330,
       "description": "Tonik is a WordPress Starter Theme which aims to modernize, organize and enhance some aspects of WordPress theme development.",
       "primaryLanguage": "PHP",
       "starredAt": "2017-07-12T23:13:53Z"
@@ -17970,7 +18081,7 @@
     {
       "nameWithOwner": "jaredreich/pell",
       "url": "https://github.com/jaredreich/pell",
-      "stargazerCount": 12031,
+      "stargazerCount": 12036,
       "description": "📝 the simplest and smallest WYSIWYG text editor for web, with no dependencies",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-07-12T23:10:15Z"
@@ -17994,7 +18105,7 @@
     {
       "nameWithOwner": "gitpoint/git-point",
       "url": "https://github.com/gitpoint/git-point",
-      "stargazerCount": 4748,
+      "stargazerCount": 4750,
       "description": "GitHub in your pocket :iphone:",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-07-12T04:01:55Z"
@@ -18018,7 +18129,7 @@
     {
       "nameWithOwner": "lipp/login-with",
       "url": "https://github.com/lipp/login-with",
-      "stargazerCount": 2334,
+      "stargazerCount": 2333,
       "description": "Stateless login-with microservice for OAuth",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-07-10T23:59:59Z"
@@ -18042,7 +18153,7 @@
     {
       "nameWithOwner": "date-fns/date-fns",
       "url": "https://github.com/date-fns/date-fns",
-      "stargazerCount": 35962,
+      "stargazerCount": 35991,
       "description": "⏳ Modern JavaScript date utility library ⌛️",
       "primaryLanguage": "TypeScript",
       "starredAt": "2017-07-10T06:33:58Z"
@@ -18050,7 +18161,7 @@
     {
       "nameWithOwner": "vadimdemedes/ink",
       "url": "https://github.com/vadimdemedes/ink",
-      "stargazerCount": 30187,
+      "stargazerCount": 30347,
       "description": "🌈 React for interactive command-line apps",
       "primaryLanguage": "TypeScript",
       "starredAt": "2017-07-10T05:55:17Z"
@@ -18058,7 +18169,7 @@
     {
       "nameWithOwner": "nitin42/terminal-in-react",
       "url": "https://github.com/nitin42/terminal-in-react",
-      "stargazerCount": 2150,
+      "stargazerCount": 2151,
       "description": "👨‍💻  A component that renders a terminal",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-07-10T03:37:18Z"
@@ -18098,7 +18209,7 @@
     {
       "nameWithOwner": "stripe-archive/react-stripe-elements",
       "url": "https://github.com/stripe-archive/react-stripe-elements",
-      "stargazerCount": 3029,
+      "stargazerCount": 3031,
       "description": "Moved to stripe/react-stripe-js.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-07-08T22:26:06Z"
@@ -18130,7 +18241,7 @@
     {
       "nameWithOwner": "Eugeny/tabby",
       "url": "https://github.com/Eugeny/tabby",
-      "stargazerCount": 65061,
+      "stargazerCount": 65267,
       "description": "A terminal for a more modern age",
       "primaryLanguage": "TypeScript",
       "starredAt": "2017-07-05T23:33:05Z"
@@ -18146,7 +18257,7 @@
     {
       "nameWithOwner": "lelandrichardson/react-primitives",
       "url": "https://github.com/lelandrichardson/react-primitives",
-      "stargazerCount": 3076,
+      "stargazerCount": 3075,
       "description": "Primitive React Interfaces Across Targets",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-07-05T05:38:19Z"
@@ -18170,7 +18281,7 @@
     {
       "nameWithOwner": "ljharb/qs",
       "url": "https://github.com/ljharb/qs",
-      "stargazerCount": 8768,
+      "stargazerCount": 8770,
       "description": "A querystring parser and serializer with nesting support",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-07-03T21:23:25Z"
@@ -18178,7 +18289,7 @@
     {
       "nameWithOwner": "npm/npm",
       "url": "https://github.com/npm/npm",
-      "stargazerCount": 17567,
+      "stargazerCount": 17563,
       "description": "This repository is moving to: https://github.com/npm/cli",
       "primaryLanguage": null,
       "starredAt": "2017-07-03T08:55:37Z"
@@ -18186,7 +18297,7 @@
     {
       "nameWithOwner": "ekalinin/sitemap.js",
       "url": "https://github.com/ekalinin/sitemap.js",
-      "stargazerCount": 1619,
+      "stargazerCount": 1620,
       "description": "Sitemap-generating framework for node.js",
       "primaryLanguage": "TypeScript",
       "starredAt": "2017-07-03T07:05:46Z"
@@ -18250,7 +18361,7 @@
     {
       "nameWithOwner": "JakeChampion/fetch",
       "url": "https://github.com/JakeChampion/fetch",
-      "stargazerCount": 25930,
+      "stargazerCount": 25934,
       "description": "A window.fetch JavaScript polyfill.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-06-29T05:03:18Z"
@@ -18266,7 +18377,7 @@
     {
       "nameWithOwner": "tsherif/picogl.js",
       "url": "https://github.com/tsherif/picogl.js",
-      "stargazerCount": 796,
+      "stargazerCount": 797,
       "description": "A minimal WebGL 2 rendering library",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-06-29T04:59:03Z"
@@ -18290,7 +18401,7 @@
     {
       "nameWithOwner": "etherdelta/etherdelta.github.io",
       "url": "https://github.com/etherdelta/etherdelta.github.io",
-      "stargazerCount": 554,
+      "stargazerCount": 553,
       "description": "",
       "primaryLanguage": "HTML",
       "starredAt": "2017-06-29T01:28:27Z"
@@ -18306,7 +18417,7 @@
     {
       "nameWithOwner": "micku7zu/vanilla-tilt.js",
       "url": "https://github.com/micku7zu/vanilla-tilt.js",
-      "stargazerCount": 3974,
+      "stargazerCount": 3976,
       "description": "A smooth 3D tilt javascript library.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-06-27T05:36:01Z"
@@ -18338,7 +18449,7 @@
     {
       "nameWithOwner": "dabbott/react-express",
       "url": "https://github.com/dabbott/react-express",
-      "stargazerCount": 2602,
+      "stargazerCount": 2601,
       "description": "Learn React through interactive examples",
       "primaryLanguage": "TypeScript",
       "starredAt": "2017-06-23T04:10:13Z"
@@ -18362,7 +18473,7 @@
     {
       "nameWithOwner": "sindresorhus/cows",
       "url": "https://github.com/sindresorhus/cows",
-      "stargazerCount": 427,
+      "stargazerCount": 426,
       "description": ":cow: ASCII cows",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-06-23T01:54:30Z"
@@ -18402,7 +18513,7 @@
     {
       "nameWithOwner": "timarney/react-app-rewired",
       "url": "https://github.com/timarney/react-app-rewired",
-      "stargazerCount": 9879,
+      "stargazerCount": 9881,
       "description": "Override create-react-app webpack configs without ejecting",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-06-22T08:06:59Z"
@@ -18418,7 +18529,7 @@
     {
       "nameWithOwner": "bekatom/awesome-ethereum",
       "url": "https://github.com/bekatom/awesome-ethereum",
-      "stargazerCount": 903,
+      "stargazerCount": 904,
       "description": ":zap: Awesome Ethereum Resources",
       "primaryLanguage": null,
       "starredAt": "2017-06-22T02:33:01Z"
@@ -18426,7 +18537,7 @@
     {
       "nameWithOwner": "MetaMask/metamask-extension",
       "url": "https://github.com/MetaMask/metamask-extension",
-      "stargazerCount": 12682,
+      "stargazerCount": 12690,
       "description": ":globe_with_meridians: :electric_plug: The MetaMask browser extension enables browsing Ethereum blockchain enabled websites",
       "primaryLanguage": "TypeScript",
       "starredAt": "2017-06-21T04:49:44Z"
@@ -18442,7 +18553,7 @@
     {
       "nameWithOwner": "ethereumbook/ethereumbook",
       "url": "https://github.com/ethereumbook/ethereumbook",
-      "stargazerCount": 20667,
+      "stargazerCount": 20691,
       "description": "Mastering Ethereum, by Andreas M. Antonopoulos, Gavin Wood",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-06-18T00:11:50Z"
@@ -18458,7 +18569,7 @@
     {
       "nameWithOwner": "alexfernandez/loadtest",
       "url": "https://github.com/alexfernandez/loadtest",
-      "stargazerCount": 2618,
+      "stargazerCount": 2617,
       "description": "Runs a load test on the selected URL. Fast and easy to use. Can be integrated in your own workflow using the API.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-06-16T03:49:14Z"
@@ -18490,7 +18601,7 @@
     {
       "nameWithOwner": "directus/directus",
       "url": "https://github.com/directus/directus",
-      "stargazerCount": 31769,
+      "stargazerCount": 31858,
       "description": "The flexible backend for all your projects 🐰 Turn your DB into a headless CMS, admin panels, or apps with a custom UI, instant APIs, auth & more.",
       "primaryLanguage": "TypeScript",
       "starredAt": "2017-06-15T03:49:57Z"
@@ -18506,7 +18617,7 @@
     {
       "nameWithOwner": "robinmoisson/staticrypt",
       "url": "https://github.com/robinmoisson/staticrypt",
-      "stargazerCount": 7425,
+      "stargazerCount": 7433,
       "description": "Password protect a static HTML page, decrypted in-browser in JS with no dependency. No server logic needed.",
       "primaryLanguage": "HTML",
       "starredAt": "2017-06-14T22:29:28Z"
@@ -18514,7 +18625,7 @@
     {
       "nameWithOwner": "pouchdb/pouchdb",
       "url": "https://github.com/pouchdb/pouchdb",
-      "stargazerCount": 17338,
+      "stargazerCount": 17344,
       "description": ":kangaroo: - PouchDB is a pocket-sized database.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-06-14T05:47:18Z"
@@ -18522,7 +18633,7 @@
     {
       "nameWithOwner": "notwaldorf/tiny-care-terminal",
       "url": "https://github.com/notwaldorf/tiny-care-terminal",
-      "stargazerCount": 5974,
+      "stargazerCount": 5975,
       "description": "💖💻 A little dashboard that tries to take care of you when you're using your terminal.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-06-14T04:21:57Z"
@@ -18530,7 +18641,7 @@
     {
       "nameWithOwner": "gohugoio/hugo",
       "url": "https://github.com/gohugoio/hugo",
-      "stargazerCount": 82423,
+      "stargazerCount": 82611,
       "description": "The world’s fastest framework for building websites.",
       "primaryLanguage": "Go",
       "starredAt": "2017-06-12T05:18:56Z"
@@ -18538,7 +18649,7 @@
     {
       "nameWithOwner": "diegomura/react-log",
       "url": "https://github.com/diegomura/react-log",
-      "stargazerCount": 576,
+      "stargazerCount": 578,
       "description": "React for the Console",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-06-11T23:19:18Z"
@@ -18594,7 +18705,7 @@
     {
       "nameWithOwner": "openethereum/parity-ethereum",
       "url": "https://github.com/openethereum/parity-ethereum",
-      "stargazerCount": 6844,
+      "stargazerCount": 6845,
       "description": "The fast, light, and robust client for Ethereum-like networks.",
       "primaryLanguage": "Rust",
       "starredAt": "2017-06-08T02:07:50Z"
@@ -18602,7 +18713,7 @@
     {
       "nameWithOwner": "balena-io/etcher",
       "url": "https://github.com/balena-io/etcher",
-      "stargazerCount": 31731,
+      "stargazerCount": 31808,
       "description": "Flash OS images to SD cards & USB drives, safely and easily.",
       "primaryLanguage": "TypeScript",
       "starredAt": "2017-06-08T00:11:38Z"
@@ -18618,7 +18729,7 @@
     {
       "nameWithOwner": "evanpurkhiser/rEFInd-minimal",
       "url": "https://github.com/evanpurkhiser/rEFInd-minimal",
-      "stargazerCount": 2133,
+      "stargazerCount": 2138,
       "description": "A stunningly clean theme for the rEFInd UEFI boot manager.",
       "primaryLanguage": null,
       "starredAt": "2017-06-07T08:46:30Z"
@@ -18626,7 +18737,7 @@
     {
       "nameWithOwner": "sindresorhus/speed-test",
       "url": "https://github.com/sindresorhus/speed-test",
-      "stargazerCount": 3928,
+      "stargazerCount": 3929,
       "description": "Test your internet connection speed and ping using speedtest.net from the CLI",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-06-07T05:54:00Z"
@@ -18634,7 +18745,7 @@
     {
       "nameWithOwner": "sindresorhus/fast-cli",
       "url": "https://github.com/sindresorhus/fast-cli",
-      "stargazerCount": 2699,
+      "stargazerCount": 2705,
       "description": "Test your download and upload speed using fast.com",
       "primaryLanguage": "TypeScript",
       "starredAt": "2017-06-07T05:22:59Z"
@@ -18650,7 +18761,7 @@
     {
       "nameWithOwner": "css-doodle/css-doodle",
       "url": "https://github.com/css-doodle/css-doodle",
-      "stargazerCount": 5823,
+      "stargazerCount": 5826,
       "description": "A web component for visual art and creative coding with CSS",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-06-07T01:41:08Z"
@@ -18658,7 +18769,7 @@
     {
       "nameWithOwner": "sdmg15/Best-websites-a-programmer-should-visit",
       "url": "https://github.com/sdmg15/Best-websites-a-programmer-should-visit",
-      "stargazerCount": 72004,
+      "stargazerCount": 72286,
       "description": ":link: Some useful websites for programmers.",
       "primaryLanguage": null,
       "starredAt": "2017-06-07T01:35:13Z"
@@ -18674,7 +18785,7 @@
     {
       "nameWithOwner": "horst3180/arc-theme",
       "url": "https://github.com/horst3180/arc-theme",
-      "stargazerCount": 8271,
+      "stargazerCount": 8273,
       "description": "A flat theme with transparent elements",
       "primaryLanguage": "CSS",
       "starredAt": "2017-06-06T01:45:53Z"
@@ -18682,7 +18793,7 @@
     {
       "nameWithOwner": "Swordfish90/cool-retro-term",
       "url": "https://github.com/Swordfish90/cool-retro-term",
-      "stargazerCount": 23679,
+      "stargazerCount": 23751,
       "description": "A good looking terminal emulator which mimics the old cathode display...",
       "primaryLanguage": "QML",
       "starredAt": "2017-06-06T01:11:59Z"
@@ -18690,7 +18801,7 @@
     {
       "nameWithOwner": "webtorrent/webtorrent-cli",
       "url": "https://github.com/webtorrent/webtorrent-cli",
-      "stargazerCount": 1250,
+      "stargazerCount": 1255,
       "description": "WebTorrent, the streaming torrent client. For the command line.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-06-06T00:55:44Z"
@@ -18698,7 +18809,7 @@
     {
       "nameWithOwner": "askmike/gekko",
       "url": "https://github.com/askmike/gekko",
-      "stargazerCount": 10155,
+      "stargazerCount": 10159,
       "description": "A bitcoin trading bot written in node - https://gekko.wizb.it/",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-06-05T10:20:04Z"
@@ -18706,7 +18817,7 @@
     {
       "nameWithOwner": "Limeth/ethaddrgen",
       "url": "https://github.com/Limeth/ethaddrgen",
-      "stargazerCount": 180,
+      "stargazerCount": 178,
       "description": "Custom Ethereum vanity address generator made in Rust",
       "primaryLanguage": "Rust",
       "starredAt": "2017-06-05T00:53:10Z"
@@ -18714,7 +18825,7 @@
     {
       "nameWithOwner": "cm45t3r/candlestick",
       "url": "https://github.com/cm45t3r/candlestick",
-      "stargazerCount": 380,
+      "stargazerCount": 385,
       "description": "Candlestick patterns detection.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-06-05T00:19:06Z"
@@ -18722,7 +18833,7 @@
     {
       "nameWithOwner": "typicode/lowdb",
       "url": "https://github.com/typicode/lowdb",
-      "stargazerCount": 22179,
+      "stargazerCount": 22193,
       "description": "Simple and fast JSON database",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-06-04T09:44:14Z"
@@ -18738,7 +18849,7 @@
     {
       "nameWithOwner": "feathericons/feather",
       "url": "https://github.com/feathericons/feather",
-      "stargazerCount": 25559,
+      "stargazerCount": 25566,
       "description": "Simply beautiful open-source icons",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-06-02T23:00:38Z"
@@ -18746,7 +18857,7 @@
     {
       "nameWithOwner": "coinbase/coinbase-pro-node",
       "url": "https://github.com/coinbase/coinbase-pro-node",
-      "stargazerCount": 868,
+      "stargazerCount": 869,
       "description": "DEPRECATED — The official Node.js library for Coinbase Pro",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-06-02T12:29:40Z"
@@ -18762,7 +18873,7 @@
     {
       "nameWithOwner": "ipfs/js-ipfs",
       "url": "https://github.com/ipfs/js-ipfs",
-      "stargazerCount": 7428,
+      "stargazerCount": 7426,
       "description": "IPFS implementation in JavaScript",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-06-01T05:04:50Z"
@@ -18770,7 +18881,7 @@
     {
       "nameWithOwner": "sindresorhus/awesome-nodejs",
       "url": "https://github.com/sindresorhus/awesome-nodejs",
-      "stargazerCount": 61880,
+      "stargazerCount": 62012,
       "description": ":zap: Delightful Node.js packages and resources",
       "primaryLanguage": null,
       "starredAt": "2017-05-31T07:28:23Z"
@@ -18778,7 +18889,7 @@
     {
       "nameWithOwner": "anandanand84/technicalindicators",
       "url": "https://github.com/anandanand84/technicalindicators",
-      "stargazerCount": 2329,
+      "stargazerCount": 2337,
       "description": "A javascript technical indicators written in typescript with pattern recognition right in the browser",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-05-30T07:47:09Z"
@@ -18802,7 +18913,7 @@
     {
       "nameWithOwner": "thibmaek/awesome-raspberry-pi",
       "url": "https://github.com/thibmaek/awesome-raspberry-pi",
-      "stargazerCount": 14810,
+      "stargazerCount": 14855,
       "description": "📝 A curated list of awesome Raspberry Pi tools, projects, images and resources",
       "primaryLanguage": "Shell",
       "starredAt": "2017-05-29T12:36:15Z"
@@ -18826,7 +18937,7 @@
     {
       "nameWithOwner": "sindresorhus/query-string",
       "url": "https://github.com/sindresorhus/query-string",
-      "stargazerCount": 6869,
+      "stargazerCount": 6870,
       "description": "Parse and stringify URL query strings",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-05-28T06:33:21Z"
@@ -18834,7 +18945,7 @@
     {
       "nameWithOwner": "node-fetch/node-fetch",
       "url": "https://github.com/node-fetch/node-fetch",
-      "stargazerCount": 8841,
+      "stargazerCount": 8843,
       "description": "A light-weight module that brings the Fetch API to Node.js",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-05-28T05:51:10Z"
@@ -18866,15 +18977,15 @@
     {
       "nameWithOwner": "trailofbits/algo",
       "url": "https://github.com/trailofbits/algo",
-      "stargazerCount": 29562,
+      "stargazerCount": 29589,
       "description": "Set up a personal VPN in the cloud",
-      "primaryLanguage": "Jinja",
+      "primaryLanguage": "Python",
       "starredAt": "2017-05-26T10:40:12Z"
     },
     {
       "nameWithOwner": "Aloshi/EmulationStation",
       "url": "https://github.com/Aloshi/EmulationStation",
-      "stargazerCount": 2163,
+      "stargazerCount": 2164,
       "description": "A flexible emulator front-end supporting keyboardless navigation and custom system themes.",
       "primaryLanguage": "C++",
       "starredAt": "2017-05-25T04:15:15Z"
@@ -18882,7 +18993,7 @@
     {
       "nameWithOwner": "RetroPie/RetroPie-Setup",
       "url": "https://github.com/RetroPie/RetroPie-Setup",
-      "stargazerCount": 10229,
+      "stargazerCount": 10228,
       "description": "Shell script to set up a Raspberry Pi/Odroid/PC with RetroArch emulator and various cores",
       "primaryLanguage": "Shell",
       "starredAt": "2017-05-25T03:13:31Z"
@@ -18890,7 +19001,7 @@
     {
       "nameWithOwner": "Chaosthebot/Chaos",
       "url": "https://github.com/Chaosthebot/Chaos",
-      "stargazerCount": 2439,
+      "stargazerCount": 2438,
       "description": "A social coding experiment that updates its own code democratically.",
       "primaryLanguage": "Python",
       "starredAt": "2017-05-25T00:19:16Z"
@@ -18906,7 +19017,7 @@
     {
       "nameWithOwner": "prasmussen/gdrive",
       "url": "https://github.com/prasmussen/gdrive",
-      "stargazerCount": 8983,
+      "stargazerCount": 8984,
       "description": "Google Drive CLI Client",
       "primaryLanguage": "Go",
       "starredAt": "2017-05-23T23:40:39Z"
@@ -18914,7 +19025,7 @@
     {
       "nameWithOwner": "diegomura/react-pdf",
       "url": "https://github.com/diegomura/react-pdf",
-      "stargazerCount": 15867,
+      "stargazerCount": 15887,
       "description": "📄  Create PDF files using React",
       "primaryLanguage": "TypeScript",
       "starredAt": "2017-05-22T06:51:45Z"
@@ -18930,7 +19041,7 @@
     {
       "nameWithOwner": "GoogleChrome/workbox",
       "url": "https://github.com/GoogleChrome/workbox",
-      "stargazerCount": 12708,
+      "stargazerCount": 12713,
       "description": "📦 Workbox: JavaScript libraries for Progressive Web Apps",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-05-22T00:36:20Z"
@@ -18946,7 +19057,7 @@
     {
       "nameWithOwner": "jatchili/minimalist-ripple-client",
       "url": "https://github.com/jatchili/minimalist-ripple-client",
-      "stargazerCount": 144,
+      "stargazerCount": 145,
       "description": "minimalist ripple client",
       "primaryLanguage": "HTML",
       "starredAt": "2017-05-20T23:00:54Z"
@@ -18962,7 +19073,7 @@
     {
       "nameWithOwner": "tastejs/hacker-news-pwas",
       "url": "https://github.com/tastejs/hacker-news-pwas",
-      "stargazerCount": 2380,
+      "stargazerCount": 2381,
       "description": "HNPWA - Hacker News readers as Progressive Web Apps 📱",
       "primaryLanguage": "HTML",
       "starredAt": "2017-05-20T06:53:19Z"
@@ -18970,7 +19081,7 @@
     {
       "nameWithOwner": "shaka-project/shaka-player",
       "url": "https://github.com/shaka-project/shaka-player",
-      "stargazerCount": 7614,
+      "stargazerCount": 7630,
       "description": "JavaScript player library / DASH & HLS client / MSE-EME player",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-05-20T04:14:52Z"
@@ -19018,7 +19129,7 @@
     {
       "nameWithOwner": "trufflesuite/truffle",
       "url": "https://github.com/trufflesuite/truffle",
-      "stargazerCount": 13983,
+      "stargazerCount": 13981,
       "description": ":warning: The Truffle Suite is being sunset. For information on ongoing support, migration options and FAQs, visit the Consensys blog. Thank you for all the support over the years.",
       "primaryLanguage": "TypeScript",
       "starredAt": "2017-05-19T00:47:47Z"
@@ -19050,7 +19161,7 @@
     {
       "nameWithOwner": "babel/babelify",
       "url": "https://github.com/babel/babelify",
-      "stargazerCount": 1676,
+      "stargazerCount": 1677,
       "description": "Browserify transform for Babel",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-05-17T11:02:49Z"
@@ -19066,7 +19177,7 @@
     {
       "nameWithOwner": "zsh-users/zsh-autosuggestions",
       "url": "https://github.com/zsh-users/zsh-autosuggestions",
-      "stargazerCount": 33465,
+      "stargazerCount": 33540,
       "description": "Fish-like autosuggestions for zsh",
       "primaryLanguage": "Shell",
       "starredAt": "2017-05-17T10:42:19Z"
@@ -19074,7 +19185,7 @@
     {
       "nameWithOwner": "vigetlabs/blendid",
       "url": "https://github.com/vigetlabs/blendid",
-      "stargazerCount": 4947,
+      "stargazerCount": 4946,
       "description": "A delicious blend of gulp tasks combined into a configurable asset pipeline and static site builder",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-05-16T23:21:39Z"
@@ -19090,7 +19201,7 @@
     {
       "nameWithOwner": "vercel/styled-jsx",
       "url": "https://github.com/vercel/styled-jsx",
-      "stargazerCount": 7776,
+      "stargazerCount": 7779,
       "description": "Full CSS support for JSX without compromises",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-05-15T23:22:39Z"
@@ -19114,7 +19225,7 @@
     {
       "nameWithOwner": "blueimp/JavaScript-Load-Image",
       "url": "https://github.com/blueimp/JavaScript-Load-Image",
-      "stargazerCount": 4457,
+      "stargazerCount": 4460,
       "description": "Load images provided as File or Blob objects or via URL. Retrieve an optionally scaled, cropped or rotated HTML img or canvas element. Use methods to parse image metadata to extract IPTC and Exif tags as well as embedded thumbnail images, to overwrite the Exif Orientation value and to restore the complete image header after resizing.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-05-12T06:49:00Z"
@@ -19122,7 +19233,7 @@
     {
       "nameWithOwner": "eligrey/canvas-toBlob.js",
       "url": "https://github.com/eligrey/canvas-toBlob.js",
-      "stargazerCount": 676,
+      "stargazerCount": 677,
       "description": "A canvas.toBlob() implementation",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-05-12T06:08:40Z"
@@ -19178,7 +19289,7 @@
     {
       "nameWithOwner": "hughsk/glsl-noise",
       "url": "https://github.com/hughsk/glsl-noise",
-      "stargazerCount": 391,
+      "stargazerCount": 392,
       "description": "webgl-noise shaders ported to work with glslify",
       "primaryLanguage": "GLSL",
       "starredAt": "2017-05-11T11:48:05Z"
@@ -19210,7 +19321,7 @@
     {
       "nameWithOwner": "vercel/serve",
       "url": "https://github.com/vercel/serve",
-      "stargazerCount": 9674,
+      "stargazerCount": 9683,
       "description": "Static file serving and directory listing",
       "primaryLanguage": "TypeScript",
       "starredAt": "2017-05-11T11:18:42Z"
@@ -19226,7 +19337,7 @@
     {
       "nameWithOwner": "mattdesl/budo",
       "url": "https://github.com/mattdesl/budo",
-      "stargazerCount": 2172,
+      "stargazerCount": 2173,
       "description": ":clapper: a dev server for rapid prototyping",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-05-11T11:16:24Z"
@@ -19242,7 +19353,7 @@
     {
       "nameWithOwner": "Mamboleoo/InfiniteTubes",
       "url": "https://github.com/Mamboleoo/InfiniteTubes",
-      "stargazerCount": 423,
+      "stargazerCount": 424,
       "description": "A tunnel experiment in WebGL inspired by the effect seen on http://www.fornasetti.com/](Fornasetti.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-05-10T11:30:18Z"
@@ -19266,7 +19377,7 @@
     {
       "nameWithOwner": "mosch/react-avatar-editor",
       "url": "https://github.com/mosch/react-avatar-editor",
-      "stargazerCount": 2445,
+      "stargazerCount": 2450,
       "description": "Small avatar & profile picture component. Resize and crop uploaded images using a intuitive user interface.",
       "primaryLanguage": "TypeScript",
       "starredAt": "2017-05-10T01:27:08Z"
@@ -19274,7 +19385,7 @@
     {
       "nameWithOwner": "dominictobias/react-image-crop",
       "url": "https://github.com/dominictobias/react-image-crop",
-      "stargazerCount": 4001,
+      "stargazerCount": 4011,
       "description": "A responsive image cropping tool for React",
       "primaryLanguage": "TypeScript",
       "starredAt": "2017-05-10T01:27:03Z"
@@ -19306,7 +19417,7 @@
     {
       "nameWithOwner": "balajmarius/svg2jsx",
       "url": "https://github.com/balajmarius/svg2jsx",
-      "stargazerCount": 1891,
+      "stargazerCount": 1894,
       "description": "Transform SVG to valid JSX.",
       "primaryLanguage": "TypeScript",
       "starredAt": "2017-05-08T01:47:29Z"
@@ -19346,7 +19457,7 @@
     {
       "nameWithOwner": "Whitevinyl/tombola.js",
       "url": "https://github.com/Whitevinyl/tombola.js",
-      "stargazerCount": 75,
+      "stargazerCount": 76,
       "description": "Random/chance generation methods, geared towards procedural generation, generative art/music etc.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-05-07T20:42:04Z"
@@ -19362,7 +19473,7 @@
     {
       "nameWithOwner": "facebookarchive/prepack",
       "url": "https://github.com/facebookarchive/prepack",
-      "stargazerCount": 14185,
+      "stargazerCount": 14183,
       "description": "A JavaScript bundle optimizer.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-05-05T22:01:27Z"
@@ -19370,7 +19481,7 @@
     {
       "nameWithOwner": "bntzio/wipe-modules",
       "url": "https://github.com/bntzio/wipe-modules",
-      "stargazerCount": 352,
+      "stargazerCount": 353,
       "description": "🗑️ Easily remove the node_modules folder of non-active projects",
       "primaryLanguage": "Shell",
       "starredAt": "2017-05-05T21:32:22Z"
@@ -19378,7 +19489,7 @@
     {
       "nameWithOwner": "sjfricke/awesome-webgl",
       "url": "https://github.com/sjfricke/awesome-webgl",
-      "stargazerCount": 1405,
+      "stargazerCount": 1407,
       "description": "A curated list of awesome WebGL libraries, resources and much more",
       "primaryLanguage": null,
       "starredAt": "2017-05-05T06:45:38Z"
@@ -19394,7 +19505,7 @@
     {
       "nameWithOwner": "tholman/github-corners",
       "url": "https://github.com/tholman/github-corners",
-      "stargazerCount": 4971,
+      "stargazerCount": 4974,
       "description": "A fresher \"Fork me on GitHub\" callout.",
       "primaryLanguage": "HTML",
       "starredAt": "2017-05-05T01:25:53Z"
@@ -19402,7 +19513,7 @@
     {
       "nameWithOwner": "zenorocha/codecopy",
       "url": "https://github.com/zenorocha/codecopy",
-      "stargazerCount": 1062,
+      "stargazerCount": 1061,
       "description": "A browser extension that adds copy to clipboard buttons on every code block",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-05-05T01:24:21Z"
@@ -19418,7 +19529,7 @@
     {
       "nameWithOwner": "pojala/electrino",
       "url": "https://github.com/pojala/electrino",
-      "stargazerCount": 4396,
+      "stargazerCount": 4400,
       "description": "Desktop runtime for apps built on web technologies, using the system's own web browser engine",
       "primaryLanguage": "C#",
       "starredAt": "2017-05-05T01:09:16Z"
@@ -19458,7 +19569,7 @@
     {
       "nameWithOwner": "ykob/sketch-threejs",
       "url": "https://github.com/ykob/sketch-threejs",
-      "stargazerCount": 2467,
+      "stargazerCount": 2472,
       "description": "Interactive sketches made with three.js.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-05-04T05:57:38Z"
@@ -19466,7 +19577,7 @@
     {
       "nameWithOwner": "mapbox/togeojson",
       "url": "https://github.com/mapbox/togeojson",
-      "stargazerCount": 1294,
+      "stargazerCount": 1296,
       "description": "convert KML and GPX to GeoJSON, without the fuss",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-05-03T21:10:16Z"
@@ -19482,7 +19593,7 @@
     {
       "nameWithOwner": "contentful/contentful.js",
       "url": "https://github.com/contentful/contentful.js",
-      "stargazerCount": 1242,
+      "stargazerCount": 1243,
       "description": "JavaScript library for Contentful's Delivery API (node & browser)",
       "primaryLanguage": "TypeScript",
       "starredAt": "2017-05-02T06:22:22Z"
@@ -19506,7 +19617,7 @@
     {
       "nameWithOwner": "sindresorhus/meow",
       "url": "https://github.com/sindresorhus/meow",
-      "stargazerCount": 3622,
+      "stargazerCount": 3627,
       "description": "🐈 CLI app helper",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-04-21T01:22:02Z"
@@ -19522,7 +19633,7 @@
     {
       "nameWithOwner": "dollarshaveclub/stickybits",
       "url": "https://github.com/dollarshaveclub/stickybits",
-      "stargazerCount": 2186,
+      "stargazerCount": 2184,
       "description": "Stickybits is a lightweight alternative to `position: sticky` polyfills 🍬",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-04-20T00:55:32Z"
@@ -19538,7 +19649,7 @@
     {
       "nameWithOwner": "sghall/react-move",
       "url": "https://github.com/sghall/react-move",
-      "stargazerCount": 6585,
+      "stargazerCount": 6586,
       "description": "React Move | Beautiful, data-driven animations for React",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-04-19T22:47:35Z"
@@ -19554,7 +19665,7 @@
     {
       "nameWithOwner": "appbaseio/reactivesearch",
       "url": "https://github.com/appbaseio/reactivesearch",
-      "stargazerCount": 4910,
+      "stargazerCount": 4911,
       "description": "Search UI components for React and Vue",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-04-13T03:37:08Z"
@@ -19562,7 +19673,7 @@
     {
       "nameWithOwner": "ansman/validate.js",
       "url": "https://github.com/ansman/validate.js",
-      "stargazerCount": 2618,
+      "stargazerCount": 2619,
       "description": "A declarative validation library written javascript",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-04-12T23:58:09Z"
@@ -19570,7 +19681,7 @@
     {
       "nameWithOwner": "kbrsh/moon",
       "url": "https://github.com/kbrsh/moon",
-      "stargazerCount": 5984,
+      "stargazerCount": 5983,
       "description": "🌙 The minimal & fast library for functional user interfaces",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-04-10T00:37:46Z"
@@ -19578,7 +19689,7 @@
     {
       "nameWithOwner": "sweetalert2/sweetalert2",
       "url": "https://github.com/sweetalert2/sweetalert2",
-      "stargazerCount": 17766,
+      "stargazerCount": 17790,
       "description": "✨ A beautiful, responsive, highly customizable and accessible (WAI-ARIA) replacement for JavaScript's popup boxes. Zero dependencies. 🇺🇦🇪🇺",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-04-08T05:40:14Z"
@@ -19586,7 +19697,7 @@
     {
       "nameWithOwner": "preactjs/preact",
       "url": "https://github.com/preactjs/preact",
-      "stargazerCount": 37821,
+      "stargazerCount": 37843,
       "description": "⚛️ Fast 3kB React alternative with the same modern API. Components & Virtual DOM.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-04-08T05:35:24Z"
@@ -19594,7 +19705,7 @@
     {
       "nameWithOwner": "nadbm/react-datasheet",
       "url": "https://github.com/nadbm/react-datasheet",
-      "stargazerCount": 5438,
+      "stargazerCount": 5437,
       "description": "Excel-like data grid (table) component for React",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-04-08T05:24:25Z"
@@ -19602,7 +19713,7 @@
     {
       "nameWithOwner": "adamwdraper/Numeral-js",
       "url": "https://github.com/adamwdraper/Numeral-js",
-      "stargazerCount": 9728,
+      "stargazerCount": 9729,
       "description": "A javascript library for formatting and manipulating numbers.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-04-07T00:54:27Z"
@@ -19610,7 +19721,7 @@
     {
       "nameWithOwner": "piqnt/planck.js",
       "url": "https://github.com/piqnt/planck.js",
-      "stargazerCount": 5124,
+      "stargazerCount": 5128,
       "description": "2D JavaScript Physics Engine",
       "primaryLanguage": "TypeScript",
       "starredAt": "2017-04-06T23:53:23Z"
@@ -19618,7 +19729,7 @@
     {
       "nameWithOwner": "thomaspark/gridgarden",
       "url": "https://github.com/thomaspark/gridgarden",
-      "stargazerCount": 3305,
+      "stargazerCount": 3308,
       "description": "A game for learning CSS grid layout 🥕",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-04-06T23:13:23Z"
@@ -19650,7 +19761,7 @@
     {
       "nameWithOwner": "reactide/reactide",
       "url": "https://github.com/reactide/reactide",
-      "stargazerCount": 10527,
+      "stargazerCount": 10525,
       "description": "Reactide is the first dedicated IDE for React web application development.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-04-01T03:31:49Z"
@@ -19658,7 +19769,7 @@
     {
       "nameWithOwner": "decaporg/decap-cms",
       "url": "https://github.com/decaporg/decap-cms",
-      "stargazerCount": 18493,
+      "stargazerCount": 18510,
       "description": "A Git-based CMS for Static Site Generators",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-04-01T03:21:32Z"
@@ -19666,7 +19777,7 @@
     {
       "nameWithOwner": "mdo/github-buttons",
       "url": "https://github.com/mdo/github-buttons",
-      "stargazerCount": 2874,
+      "stargazerCount": 2876,
       "description": "Showcase the success of any GitHub repo or user with these simple, static buttons with dynamic counts.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-03-29T03:24:11Z"
@@ -19674,7 +19785,7 @@
     {
       "nameWithOwner": "styled-components/polished",
       "url": "https://github.com/styled-components/polished",
-      "stargazerCount": 7661,
+      "stargazerCount": 7660,
       "description": "A lightweight toolset for writing styles in JavaScript ✨",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-03-28T23:50:14Z"
@@ -19682,7 +19793,7 @@
     {
       "nameWithOwner": "buttercup/buttercup-desktop",
       "url": "https://github.com/buttercup/buttercup-desktop",
-      "stargazerCount": 4412,
+      "stargazerCount": 4415,
       "description": ":key: Cross-Platform Passwords & Secrets Vault",
       "primaryLanguage": "TypeScript",
       "starredAt": "2017-03-28T10:06:57Z"
@@ -19698,7 +19809,7 @@
     {
       "nameWithOwner": "jgthms/minireset.css",
       "url": "https://github.com/jgthms/minireset.css",
-      "stargazerCount": 2797,
+      "stargazerCount": 2803,
       "description": "A tiny modern CSS reset",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-03-24T11:50:17Z"
@@ -19706,7 +19817,7 @@
     {
       "nameWithOwner": "robbiebarrat/rapping-neural-network",
       "url": "https://github.com/robbiebarrat/rapping-neural-network",
-      "stargazerCount": 1053,
+      "stargazerCount": 1054,
       "description": "Rap song writing recurrent neural network trained on Kanye West's entire discography",
       "primaryLanguage": "Python",
       "starredAt": "2017-03-23T22:21:54Z"
@@ -19730,7 +19841,7 @@
     {
       "nameWithOwner": "nolimits4web/swiper",
       "url": "https://github.com/nolimits4web/swiper",
-      "stargazerCount": 41234,
+      "stargazerCount": 41270,
       "description": "Most modern mobile touch slider with hardware accelerated transitions",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-03-21T04:28:16Z"
@@ -19738,7 +19849,7 @@
     {
       "nameWithOwner": "dabanlee/blurify",
       "url": "https://github.com/dabanlee/blurify",
-      "stargazerCount": 693,
+      "stargazerCount": 694,
       "description": "blurify.js is a tiny(~2kb) library to blurred pictures, support graceful downgrade from `css` mode to `canvas` mode.",
       "primaryLanguage": "TypeScript",
       "starredAt": "2017-03-21T03:20:28Z"
@@ -19762,7 +19873,7 @@
     {
       "nameWithOwner": "jamiebuilds/react-loadable",
       "url": "https://github.com/jamiebuilds/react-loadable",
-      "stargazerCount": 16588,
+      "stargazerCount": 16587,
       "description": ":hourglass_flowing_sand: A higher order component for loading components with promises.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-03-14T01:06:47Z"
@@ -19770,7 +19881,7 @@
     {
       "nameWithOwner": "expo/create-react-native-app",
       "url": "https://github.com/expo/create-react-native-app",
-      "stargazerCount": 13277,
+      "stargazerCount": 13276,
       "description": "Create React Native apps that run on iOS, Android, and web",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-03-14T00:34:26Z"
@@ -19810,7 +19921,7 @@
     {
       "nameWithOwner": "wooorm/franc",
       "url": "https://github.com/wooorm/franc",
-      "stargazerCount": 4280,
+      "stargazerCount": 4287,
       "description": "Natural language detection",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-03-09T21:47:07Z"
@@ -19818,7 +19929,7 @@
     {
       "nameWithOwner": "atom/atom",
       "url": "https://github.com/atom/atom",
-      "stargazerCount": 60562,
+      "stargazerCount": 60565,
       "description": ":atom: The hackable text editor",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-03-09T21:40:41Z"
@@ -19826,7 +19937,7 @@
     {
       "nameWithOwner": "firebase/functions-samples",
       "url": "https://github.com/firebase/functions-samples",
-      "stargazerCount": 12177,
+      "stargazerCount": 12183,
       "description": "Collection of sample apps showcasing popular use cases using Cloud Functions for Firebase",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-03-09T20:43:02Z"
@@ -19834,7 +19945,7 @@
     {
       "nameWithOwner": "facebookarchive/react-360",
       "url": "https://github.com/facebookarchive/react-360",
-      "stargazerCount": 8737,
+      "stargazerCount": 8738,
       "description": "Create amazing 360 and VR content using React",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-03-09T05:35:16Z"
@@ -19866,7 +19977,7 @@
     {
       "nameWithOwner": "joshwcomeau/react-flip-move",
       "url": "https://github.com/joshwcomeau/react-flip-move",
-      "stargazerCount": 4125,
+      "stargazerCount": 4126,
       "description": "Effortless animation between DOM changes (eg. list reordering) using the FLIP technique.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-03-04T02:31:12Z"
@@ -19874,7 +19985,7 @@
     {
       "nameWithOwner": "edankwan/penis.js",
       "url": "https://github.com/edankwan/penis.js",
-      "stargazerCount": 1340,
+      "stargazerCount": 1341,
       "description": "",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-03-03T04:58:19Z"
@@ -19890,7 +20001,7 @@
     {
       "nameWithOwner": "microsoft/vscode",
       "url": "https://github.com/microsoft/vscode",
-      "stargazerCount": 174911,
+      "stargazerCount": 175267,
       "description": "Visual Studio Code",
       "primaryLanguage": "TypeScript",
       "starredAt": "2017-03-02T04:47:25Z"
@@ -19898,7 +20009,7 @@
     {
       "nameWithOwner": "jorgebucaran/hyperapp",
       "url": "https://github.com/jorgebucaran/hyperapp",
-      "stargazerCount": 19147,
+      "stargazerCount": 19150,
       "description": "1kB-ish JavaScript framework for building hypertext applications",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-03-01T10:30:38Z"
@@ -19906,7 +20017,7 @@
     {
       "nameWithOwner": "viatsko/awesome-vscode",
       "url": "https://github.com/viatsko/awesome-vscode",
-      "stargazerCount": 26984,
+      "stargazerCount": 27124,
       "description": "🎨 A curated list of delightful VS Code packages and resources.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-03-01T03:28:21Z"
@@ -19914,7 +20025,7 @@
     {
       "nameWithOwner": "alexjlockwood/ShapeShifter",
       "url": "https://github.com/alexjlockwood/ShapeShifter",
-      "stargazerCount": 4037,
+      "stargazerCount": 4036,
       "description": "SVG icon animation tool for Android, iOS, and the web",
       "primaryLanguage": "TypeScript",
       "starredAt": "2017-02-28T20:13:37Z"
@@ -19922,7 +20033,7 @@
     {
       "nameWithOwner": "BoostIO/BoostNote-App",
       "url": "https://github.com/BoostIO/BoostNote-App",
-      "stargazerCount": 3922,
+      "stargazerCount": 3928,
       "description": "Boost Note is a document driven project management tool that maximizes remote DevOps team velocity.",
       "primaryLanguage": "TypeScript",
       "starredAt": "2017-02-28T05:03:49Z"
@@ -19938,7 +20049,7 @@
     {
       "nameWithOwner": "zz85/space-radar",
       "url": "https://github.com/zz85/space-radar",
-      "stargazerCount": 1410,
+      "stargazerCount": 1411,
       "description": "Disk And Memory Space Visualization App built with Electron & d3.js",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-02-28T04:56:17Z"
@@ -19954,7 +20065,7 @@
     {
       "nameWithOwner": "slab/quill",
       "url": "https://github.com/slab/quill",
-      "stargazerCount": 45780,
+      "stargazerCount": 45838,
       "description": "Quill is a modern WYSIWYG editor built for compatibility and extensibility",
       "primaryLanguage": "TypeScript",
       "starredAt": "2017-02-28T04:14:58Z"
@@ -19978,7 +20089,7 @@
     {
       "nameWithOwner": "k4m4/movies-for-hackers",
       "url": "https://github.com/k4m4/movies-for-hackers",
-      "stargazerCount": 10917,
+      "stargazerCount": 10926,
       "description": "🎬 A curated list of movies every hacker & cyberpunk must watch.",
       "primaryLanguage": "Shell",
       "starredAt": "2017-02-26T23:57:49Z"
@@ -19994,7 +20105,7 @@
     {
       "nameWithOwner": "timarney/react-faq",
       "url": "https://github.com/timarney/react-faq",
-      "stargazerCount": 1810,
+      "stargazerCount": 1811,
       "description": "A collection of links to help answer your questions about React.js",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-02-25T02:04:18Z"
@@ -20002,7 +20113,7 @@
     {
       "nameWithOwner": "jaredhanson/passport",
       "url": "https://github.com/jaredhanson/passport",
-      "stargazerCount": 23371,
+      "stargazerCount": 23373,
       "description": "Simple, unobtrusive authentication for Node.js.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-02-24T11:26:37Z"
@@ -20010,7 +20121,7 @@
     {
       "nameWithOwner": "danvk/source-map-explorer",
       "url": "https://github.com/danvk/source-map-explorer",
-      "stargazerCount": 3892,
+      "stargazerCount": 3896,
       "description": "Analyze and debug space usage through source maps",
       "primaryLanguage": "TypeScript",
       "starredAt": "2017-02-24T11:16:41Z"
@@ -20018,7 +20129,7 @@
     {
       "nameWithOwner": "botpress/botpress",
       "url": "https://github.com/botpress/botpress",
-      "stargazerCount": 13970,
+      "stargazerCount": 13998,
       "description": "The open-source hub to build & deploy GPT/LLM Agents ⚡️",
       "primaryLanguage": "TypeScript",
       "starredAt": "2017-02-24T07:23:28Z"
@@ -20034,7 +20145,7 @@
     {
       "nameWithOwner": "acode/cli",
       "url": "https://github.com/acode/cli",
-      "stargazerCount": 3822,
+      "stargazerCount": 3823,
       "description": "Autocode CLI and standard library tooling",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-02-23T21:30:04Z"
@@ -20058,7 +20169,7 @@
     {
       "nameWithOwner": "developit/unfetch",
       "url": "https://github.com/developit/unfetch",
-      "stargazerCount": 5717,
+      "stargazerCount": 5718,
       "description": "🐕 Bare minimum 500b fetch polyfill.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-02-23T00:01:05Z"
@@ -20074,7 +20185,7 @@
     {
       "nameWithOwner": "jeromeetienne/AR.js",
       "url": "https://github.com/jeromeetienne/AR.js",
-      "stargazerCount": 15822,
+      "stargazerCount": 15825,
       "description": "Efficient Augmented Reality for the Web - 60fps on mobile!",
       "primaryLanguage": "HTML",
       "starredAt": "2017-02-22T22:39:21Z"
@@ -20090,7 +20201,7 @@
     {
       "nameWithOwner": "anaibol/awesome-serverless",
       "url": "https://github.com/anaibol/awesome-serverless",
-      "stargazerCount": 7528,
+      "stargazerCount": 7529,
       "description": ":cloud: A curated list of awesome services, solutions and resources for serverless / nobackend applications.",
       "primaryLanguage": null,
       "starredAt": "2017-02-22T02:14:42Z"
@@ -20098,7 +20209,7 @@
     {
       "nameWithOwner": "mfornos/awesome-microservices",
       "url": "https://github.com/mfornos/awesome-microservices",
-      "stargazerCount": 13774,
+      "stargazerCount": 13784,
       "description": "A curated list of Microservice Architecture related principles and technologies.",
       "primaryLanguage": null,
       "starredAt": "2017-02-22T02:12:45Z"
@@ -20114,7 +20225,7 @@
     {
       "nameWithOwner": "Open-Web-Analytics/Open-Web-Analytics",
       "url": "https://github.com/Open-Web-Analytics/Open-Web-Analytics",
-      "stargazerCount": 2582,
+      "stargazerCount": 2583,
       "description": "Official repository for Open Web Analytics which is an open source alternative to commercial tools such as Google Analytics. Stay in control of the data you collect about the use of your website or app.  Please consider sponsoring this project.",
       "primaryLanguage": "PHP",
       "starredAt": "2017-02-21T08:55:49Z"
@@ -20178,7 +20289,7 @@
     {
       "nameWithOwner": "styled-components/styled-components",
       "url": "https://github.com/styled-components/styled-components",
-      "stargazerCount": 40853,
+      "stargazerCount": 40857,
       "description": "Visual primitives for the component age. Use the best bits of ES6 and CSS to style your apps without stress 💅",
       "primaryLanguage": "TypeScript",
       "starredAt": "2017-02-19T04:36:11Z"
@@ -20194,7 +20305,7 @@
     {
       "nameWithOwner": "lynnandtonic/a-single-div",
       "url": "https://github.com/lynnandtonic/a-single-div",
-      "stargazerCount": 1787,
+      "stargazerCount": 1788,
       "description": "🎨 CSS drawings with only one HTML element.",
       "primaryLanguage": "Stylus",
       "starredAt": "2017-02-18T10:58:54Z"
@@ -20202,7 +20313,7 @@
     {
       "nameWithOwner": "herrbischoff/awesome-macos-command-line",
       "url": "https://github.com/herrbischoff/awesome-macos-command-line",
-      "stargazerCount": 29679,
+      "stargazerCount": 29689,
       "description": "Use your macOS terminal shell to do awesome things.",
       "primaryLanguage": null,
       "starredAt": "2017-02-17T05:59:49Z"
@@ -20210,7 +20321,7 @@
     {
       "nameWithOwner": "GitbookIO/gitbook",
       "url": "https://github.com/GitbookIO/gitbook",
-      "stargazerCount": 28137,
+      "stargazerCount": 28163,
       "description": "The open source frontend for GitBook doc sites",
       "primaryLanguage": "TypeScript",
       "starredAt": "2017-02-17T00:22:35Z"
@@ -20242,7 +20353,7 @@
     {
       "nameWithOwner": "SimbCo/httpster",
       "url": "https://github.com/SimbCo/httpster",
-      "stargazerCount": 338,
+      "stargazerCount": 339,
       "description": "Simple http server for quick loading of content",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-02-16T09:15:30Z"
@@ -20258,7 +20369,7 @@
     {
       "nameWithOwner": "terkelg/awesome-creative-coding",
       "url": "https://github.com/terkelg/awesome-creative-coding",
-      "stargazerCount": 13754,
+      "stargazerCount": 13791,
       "description": "Creative Coding: Generative Art, Data visualization, Interaction Design, Resources.",
       "primaryLanguage": "HTML",
       "starredAt": "2017-02-15T21:05:20Z"
@@ -20282,7 +20393,7 @@
     {
       "nameWithOwner": "ponzu-cms/ponzu",
       "url": "https://github.com/ponzu-cms/ponzu",
-      "stargazerCount": 5752,
+      "stargazerCount": 5753,
       "description": "Headless CMS with automatic JSON API. Featuring auto-HTTPS from Let's Encrypt, HTTP/2 Server Push, and flexible server framework written in Go.",
       "primaryLanguage": "Go",
       "starredAt": "2017-02-14T00:23:40Z"
@@ -20290,7 +20401,7 @@
     {
       "nameWithOwner": "brunch/brunch",
       "url": "https://github.com/brunch/brunch",
-      "stargazerCount": 6785,
+      "stargazerCount": 6783,
       "description": ":fork_and_knife: Web applications made easy. Since 2011.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-02-13T23:44:03Z"
@@ -20322,7 +20433,7 @@
     {
       "nameWithOwner": "motdotla/dotenv",
       "url": "https://github.com/motdotla/dotenv",
-      "stargazerCount": 19898,
+      "stargazerCount": 19921,
       "description": "Loads environment variables from .env for nodejs projects.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-02-11T03:49:04Z"
@@ -20338,7 +20449,7 @@
     {
       "nameWithOwner": "markedjs/marked",
       "url": "https://github.com/markedjs/marked",
-      "stargazerCount": 35189,
+      "stargazerCount": 35235,
       "description": "A markdown parser and compiler. Built for speed.",
       "primaryLanguage": "TypeScript",
       "starredAt": "2017-02-09T09:27:28Z"
@@ -20346,7 +20457,7 @@
     {
       "nameWithOwner": "airbnb/css",
       "url": "https://github.com/airbnb/css",
-      "stargazerCount": 6986,
+      "stargazerCount": 6988,
       "description": "A mostly reasonable approach to CSS and Sass.",
       "primaryLanguage": null,
       "starredAt": "2017-02-09T01:25:55Z"
@@ -20354,7 +20465,7 @@
     {
       "nameWithOwner": "airbnb/javascript",
       "url": "https://github.com/airbnb/javascript",
-      "stargazerCount": 147119,
+      "stargazerCount": 147216,
       "description": "JavaScript Style Guide",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-02-09T01:15:49Z"
@@ -20378,7 +20489,7 @@
     {
       "nameWithOwner": "CWSpear/hyperterm-visor",
       "url": "https://github.com/CWSpear/hyperterm-visor",
-      "stargazerCount": 165,
+      "stargazerCount": 164,
       "description": "Open your Hyper terminal from anywhere with a global hotkey.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-02-07T22:22:27Z"
@@ -20386,7 +20497,7 @@
     {
       "nameWithOwner": "caolan/async",
       "url": "https://github.com/caolan/async",
-      "stargazerCount": 28231,
+      "stargazerCount": 28228,
       "description": "Async utilities for node and the browser",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-02-06T20:45:36Z"
@@ -20394,7 +20505,7 @@
     {
       "nameWithOwner": "sparksuite/simplemde-markdown-editor",
       "url": "https://github.com/sparksuite/simplemde-markdown-editor",
-      "stargazerCount": 10074,
+      "stargazerCount": 10083,
       "description": "A simple, beautiful, and embeddable JavaScript Markdown editor. Delightful editing for beginners and experts alike. Features built-in autosaving and spell checking.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-02-05T20:35:43Z"
@@ -20410,7 +20521,7 @@
     {
       "nameWithOwner": "playcanvas/engine",
       "url": "https://github.com/playcanvas/engine",
-      "stargazerCount": 10492,
+      "stargazerCount": 10614,
       "description": "Powerful web graphics runtime built on WebGL, WebGPU, WebXR and glTF",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-02-02T09:04:46Z"
@@ -20418,7 +20529,7 @@
     {
       "nameWithOwner": "pubkey/rxdb",
       "url": "https://github.com/pubkey/rxdb",
-      "stargazerCount": 22513,
+      "stargazerCount": 22542,
       "description": "A fast, local first, reactive Database for JavaScript Applications https://rxdb.info/",
       "primaryLanguage": "TypeScript",
       "starredAt": "2017-02-01T21:38:52Z"
@@ -20426,7 +20537,7 @@
     {
       "nameWithOwner": "webpack/webpack",
       "url": "https://github.com/webpack/webpack",
-      "stargazerCount": 65450,
+      "stargazerCount": 65455,
       "description": "A bundler for javascript and friends. Packs many modules into a few bundled assets. Code Splitting allows for loading parts of the application on demand. Through \"loaders\", modules can be CommonJs, AMD, ES6 modules, CSS, Images, JSON, Coffeescript, LESS, ... and your custom stuff.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-02-01T01:06:40Z"
@@ -20434,7 +20545,7 @@
     {
       "nameWithOwner": "developit/mitt",
       "url": "https://github.com/developit/mitt",
-      "stargazerCount": 11435,
+      "stargazerCount": 11459,
       "description": "🥊 Tiny 200 byte functional event emitter / pubsub.",
       "primaryLanguage": "TypeScript",
       "starredAt": "2017-01-31T22:38:24Z"
@@ -20442,7 +20553,7 @@
     {
       "nameWithOwner": "Kinto/kinto",
       "url": "https://github.com/Kinto/kinto",
-      "stargazerCount": 4370,
+      "stargazerCount": 4367,
       "description": "A generic JSON document store with sharing and synchronisation capabilities.",
       "primaryLanguage": "Python",
       "starredAt": "2017-01-30T12:27:39Z"
@@ -20466,7 +20577,7 @@
     {
       "nameWithOwner": "n0shake/Public-APIs",
       "url": "https://github.com/n0shake/Public-APIs",
-      "stargazerCount": 22205,
+      "stargazerCount": 22238,
       "description": "📚 A public list of APIs from round the web.",
       "primaryLanguage": null,
       "starredAt": "2017-01-18T23:49:29Z"
@@ -20498,7 +20609,7 @@
     {
       "nameWithOwner": "web3/web3.js",
       "url": "https://github.com/web3/web3.js",
-      "stargazerCount": 19801,
+      "stargazerCount": 19814,
       "description": "Collection of comprehensive TypeScript libraries for Interaction with the Ethereum JSON RPC API and utility functions.",
       "primaryLanguage": "TypeScript",
       "starredAt": "2017-01-17T23:21:30Z"
@@ -20506,7 +20617,7 @@
     {
       "nameWithOwner": "JulietaUla/Montserrat",
       "url": "https://github.com/JulietaUla/Montserrat",
-      "stargazerCount": 1719,
+      "stargazerCount": 1723,
       "description": "",
       "primaryLanguage": "Python",
       "starredAt": "2017-01-16T07:01:59Z"
@@ -20514,7 +20625,7 @@
     {
       "nameWithOwner": "bitcoin/bitcoin",
       "url": "https://github.com/bitcoin/bitcoin",
-      "stargazerCount": 84716,
+      "stargazerCount": 84863,
       "description": "Bitcoin Core integration/staging tree",
       "primaryLanguage": "C++",
       "starredAt": "2017-01-13T06:57:28Z"
@@ -20522,7 +20633,7 @@
     {
       "nameWithOwner": "OutCast3k/coinbin",
       "url": "https://github.com/OutCast3k/coinbin",
-      "stargazerCount": 940,
+      "stargazerCount": 939,
       "description": "Javascript Bitcoin Wallet. Supports Multisig, Stealth, HD, SegWit, Bech32, Time Locked Addresses, RBF and more!",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-01-13T00:31:18Z"
@@ -20530,7 +20641,7 @@
     {
       "nameWithOwner": "luisvinicius167/ityped",
       "url": "https://github.com/luisvinicius167/ityped",
-      "stargazerCount": 2322,
+      "stargazerCount": 2321,
       "description": "Dead simple Javascript animated typing, with no dependencies.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-01-12T23:24:39Z"
@@ -20554,7 +20665,7 @@
     {
       "nameWithOwner": "firtoz/react-three-renderer",
       "url": "https://github.com/firtoz/react-three-renderer",
-      "stargazerCount": 1490,
+      "stargazerCount": 1489,
       "description": "Render into a three.js canvas using React.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-01-11T05:50:29Z"
@@ -20570,7 +20681,7 @@
     {
       "nameWithOwner": "alex3165/react-mapbox-gl",
       "url": "https://github.com/alex3165/react-mapbox-gl",
-      "stargazerCount": 1974,
+      "stargazerCount": 1977,
       "description": "A React binding of mapbox-gl-js",
       "primaryLanguage": "TypeScript",
       "starredAt": "2017-01-10T09:22:15Z"
@@ -20586,7 +20697,7 @@
     {
       "nameWithOwner": "FortAwesome/Font-Awesome",
       "url": "https://github.com/FortAwesome/Font-Awesome",
-      "stargazerCount": 75482,
+      "stargazerCount": 75531,
       "description": "The iconic SVG, font, and CSS toolkit",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-01-09T04:07:43Z"
@@ -20594,7 +20705,7 @@
     {
       "nameWithOwner": "ryanmcdermott/clean-code-javascript",
       "url": "https://github.com/ryanmcdermott/clean-code-javascript",
-      "stargazerCount": 93267,
+      "stargazerCount": 93296,
       "description": "Clean Code concepts adapted for JavaScript",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-01-08T22:39:51Z"
@@ -20602,7 +20713,7 @@
     {
       "nameWithOwner": "mapbox/mapbox-gl-js",
       "url": "https://github.com/mapbox/mapbox-gl-js",
-      "stargazerCount": 11746,
+      "stargazerCount": 11770,
       "description": "Interactive, thoroughly customizable maps in the browser, powered by vector tiles and WebGL",
       "primaryLanguage": "TypeScript",
       "starredAt": "2017-01-08T09:51:34Z"
@@ -20610,7 +20721,7 @@
     {
       "nameWithOwner": "gulpjs/gulp",
       "url": "https://github.com/gulpjs/gulp",
-      "stargazerCount": 33064,
+      "stargazerCount": 33061,
       "description": "A toolkit to automate & enhance your workflow",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-01-06T03:15:43Z"
@@ -20626,7 +20737,7 @@
     {
       "nameWithOwner": "bayleeadamoss/zazu",
       "url": "https://github.com/bayleeadamoss/zazu",
-      "stargazerCount": 2091,
+      "stargazerCount": 2090,
       "description": ":rocket: A fully extensible and open source launcher for hackers, creators and dabblers.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-01-05T03:32:25Z"
@@ -20634,7 +20745,7 @@
     {
       "nameWithOwner": "amilajack/eslint-plugin-compat",
       "url": "https://github.com/amilajack/eslint-plugin-compat",
-      "stargazerCount": 3131,
+      "stargazerCount": 3134,
       "description": "Check the browser compatibility of your code",
       "primaryLanguage": "TypeScript",
       "starredAt": "2017-01-05T01:45:59Z"
@@ -20666,7 +20777,7 @@
     {
       "nameWithOwner": "wesbos/JavaScript30",
       "url": "https://github.com/wesbos/JavaScript30",
-      "stargazerCount": 28602,
+      "stargazerCount": 28628,
       "description": "30 Day Vanilla JS Challenge",
       "primaryLanguage": "HTML",
       "starredAt": "2017-01-03T07:56:41Z"
@@ -20674,7 +20785,7 @@
     {
       "nameWithOwner": "docsifyjs/docsify",
       "url": "https://github.com/docsifyjs/docsify",
-      "stargazerCount": 30064,
+      "stargazerCount": 30153,
       "description": "🃏 A magical documentation site generator.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-01-02T22:19:04Z"
@@ -20690,7 +20801,7 @@
     {
       "nameWithOwner": "255kb/stack-on-a-budget",
       "url": "https://github.com/255kb/stack-on-a-budget",
-      "stargazerCount": 12259,
+      "stargazerCount": 12269,
       "description": "A collection of services with great free tiers for developers on a budget. Sponsored by Mockoon, the best mock API tool. https://mockoon.com",
       "primaryLanguage": null,
       "starredAt": "2016-12-19T04:57:53Z"
@@ -20706,7 +20817,7 @@
     {
       "nameWithOwner": "Unity-Technologies/EditorXR",
       "url": "https://github.com/Unity-Technologies/EditorXR",
-      "stargazerCount": 937,
+      "stargazerCount": 938,
       "description": "Author XR in XR",
       "primaryLanguage": "C#",
       "starredAt": "2016-12-16T06:14:01Z"
@@ -20722,7 +20833,7 @@
     {
       "nameWithOwner": "panzerdp/voca",
       "url": "https://github.com/panzerdp/voca",
-      "stargazerCount": 3616,
+      "stargazerCount": 3617,
       "description": "The ultimate JavaScript string library",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-12-15T23:28:02Z"
@@ -20730,7 +20841,7 @@
     {
       "nameWithOwner": "wulkano/Kap",
       "url": "https://github.com/wulkano/Kap",
-      "stargazerCount": 18729,
+      "stargazerCount": 18743,
       "description": "An open-source screen recorder built with web technology",
       "primaryLanguage": "TypeScript",
       "starredAt": "2016-12-13T01:23:46Z"
@@ -20738,7 +20849,7 @@
     {
       "nameWithOwner": "nikolaeu/numi",
       "url": "https://github.com/nikolaeu/numi",
-      "stargazerCount": 6066,
+      "stargazerCount": 6091,
       "description": "Beautiful calculator app for macOS, Linux & Windows",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-12-12T09:01:05Z"
@@ -20754,7 +20865,7 @@
     {
       "nameWithOwner": "TanStack/form",
       "url": "https://github.com/TanStack/form",
-      "stargazerCount": 5639,
+      "stargazerCount": 5669,
       "description": "🤖 Headless, performant, and type-safe form state management for TS/JS, React, Vue, Angular, Solid, and Lit.",
       "primaryLanguage": "TypeScript",
       "starredAt": "2016-12-11T09:48:54Z"
@@ -20762,7 +20873,7 @@
     {
       "nameWithOwner": "LibreVR/Revive",
       "url": "https://github.com/LibreVR/Revive",
-      "stargazerCount": 3681,
+      "stargazerCount": 3680,
       "description": "Play Oculus-exclusive games on the HTC Vive or Valve Index, scroll down for downloads and installation instructions.",
       "primaryLanguage": "C++",
       "starredAt": "2016-12-06T11:23:29Z"
@@ -20770,7 +20881,7 @@
     {
       "nameWithOwner": "720kb/ndm",
       "url": "https://github.com/720kb/ndm",
-      "stargazerCount": 2122,
+      "stargazerCount": 2124,
       "description": ":computer: npm desktop manager https://720kb.github.io/ndm",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-12-06T10:44:34Z"
@@ -20802,7 +20913,7 @@
     {
       "nameWithOwner": "mscdex/ssh2",
       "url": "https://github.com/mscdex/ssh2",
-      "stargazerCount": 5667,
+      "stargazerCount": 5669,
       "description": "SSH2 client and server modules written in pure JavaScript for node.js",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-12-06T02:48:36Z"
@@ -20818,7 +20929,7 @@
     {
       "nameWithOwner": "kingdido999/zooming",
       "url": "https://github.com/kingdido999/zooming",
-      "stargazerCount": 1610,
+      "stargazerCount": 1612,
       "description": "🔍 Image zoom that makes sense.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-12-05T09:27:27Z"
@@ -20826,7 +20937,7 @@
     {
       "nameWithOwner": "sindresorhus/configstore",
       "url": "https://github.com/sindresorhus/configstore",
-      "stargazerCount": 877,
+      "stargazerCount": 878,
       "description": "Easily load and persist config without having to think about where and how",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-12-05T06:12:30Z"
@@ -20850,7 +20961,7 @@
     {
       "nameWithOwner": "space10-community/conversational-form",
       "url": "https://github.com/space10-community/conversational-form",
-      "stargazerCount": 3817,
+      "stargazerCount": 3819,
       "description": "Turning web forms into conversations",
       "primaryLanguage": "HTML",
       "starredAt": "2016-11-30T23:50:45Z"
@@ -20858,7 +20969,7 @@
     {
       "nameWithOwner": "allinurl/goaccess",
       "url": "https://github.com/allinurl/goaccess",
-      "stargazerCount": 19554,
+      "stargazerCount": 19600,
       "description": "GoAccess is a real-time web log analyzer and interactive viewer that runs in a terminal in *nix systems or through your browser.",
       "primaryLanguage": "C",
       "starredAt": "2016-11-30T05:48:54Z"
@@ -20866,7 +20977,7 @@
     {
       "nameWithOwner": "AriaMinaei/pretty-error",
       "url": "https://github.com/AriaMinaei/pretty-error",
-      "stargazerCount": 1519,
+      "stargazerCount": 1520,
       "description": "See node.js errors with less clutter",
       "primaryLanguage": "CoffeeScript",
       "starredAt": "2016-11-30T04:31:29Z"
@@ -20890,7 +21001,7 @@
     {
       "nameWithOwner": "keijiro/Skinner",
       "url": "https://github.com/keijiro/Skinner",
-      "stargazerCount": 3472,
+      "stargazerCount": 3478,
       "description": "Special Effects with Skinned Mesh in Unity",
       "primaryLanguage": "C#",
       "starredAt": "2016-11-27T03:21:47Z"
@@ -20898,7 +21009,7 @@
     {
       "nameWithOwner": "prerender/prerender",
       "url": "https://github.com/prerender/prerender",
-      "stargazerCount": 6519,
+      "stargazerCount": 6522,
       "description": "Node server that uses Headless Chrome to render a javascript-rendered page as HTML. To be used in conjunction with prerender middleware.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-11-27T03:01:41Z"
@@ -20906,7 +21017,7 @@
     {
       "nameWithOwner": "ohmyzsh/ohmyzsh",
       "url": "https://github.com/ohmyzsh/ohmyzsh",
-      "stargazerCount": 180197,
+      "stargazerCount": 180424,
       "description": "🙃   A delightful community-driven (with 2,400+ contributors) framework for managing your zsh configuration. Includes 300+ optional plugins (rails, git, macOS, hub, docker, homebrew, node, php, python, etc), 140+ themes to spice up your morning, and an auto-update tool that makes it easy to keep up with the latest updates from the community.",
       "primaryLanguage": "Shell",
       "starredAt": "2016-11-25T09:31:48Z"
@@ -20922,7 +21033,7 @@
     {
       "nameWithOwner": "zsh-users/zsh-syntax-highlighting",
       "url": "https://github.com/zsh-users/zsh-syntax-highlighting",
-      "stargazerCount": 21430,
+      "stargazerCount": 21474,
       "description": "Fish shell like syntax highlighting for Zsh.",
       "primaryLanguage": "Shell",
       "starredAt": "2016-11-25T09:05:35Z"
@@ -20930,7 +21041,7 @@
     {
       "nameWithOwner": "sindresorhus/pure",
       "url": "https://github.com/sindresorhus/pure",
-      "stargazerCount": 13707,
+      "stargazerCount": 13721,
       "description": "Pretty, minimal and fast ZSH prompt",
       "primaryLanguage": "Shell",
       "starredAt": "2016-11-25T09:03:09Z"
@@ -20946,7 +21057,7 @@
     {
       "nameWithOwner": "bnb/awesome-hyper",
       "url": "https://github.com/bnb/awesome-hyper",
-      "stargazerCount": 10855,
+      "stargazerCount": 10857,
       "description": "🖥 Delightful Hyper plugins, themes, and resources",
       "primaryLanguage": null,
       "starredAt": "2016-11-25T05:57:36Z"
@@ -20962,7 +21073,7 @@
     {
       "nameWithOwner": "SBoudrias/Inquirer.js",
       "url": "https://github.com/SBoudrias/Inquirer.js",
-      "stargazerCount": 20997,
+      "stargazerCount": 21015,
       "description": "A collection of common interactive command line user interfaces.",
       "primaryLanguage": "TypeScript",
       "starredAt": "2016-11-25T04:33:45Z"
@@ -20994,7 +21105,7 @@
     {
       "nameWithOwner": "localForage/localForage",
       "url": "https://github.com/localForage/localForage",
-      "stargazerCount": 25496,
+      "stargazerCount": 25512,
       "description": "💾 Offline storage, improved. Wraps IndexedDB, WebSQL, or localStorage using a simple but powerful API.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-11-22T09:10:58Z"
@@ -21010,7 +21121,7 @@
     {
       "nameWithOwner": "chalk/chalk",
       "url": "https://github.com/chalk/chalk",
-      "stargazerCount": 22540,
+      "stargazerCount": 22555,
       "description": "🖍 Terminal string styling done right",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-11-21T23:56:57Z"
@@ -21026,7 +21137,7 @@
     {
       "nameWithOwner": "hemanth/awesome-pwa",
       "url": "https://github.com/hemanth/awesome-pwa",
-      "stargazerCount": 4701,
+      "stargazerCount": 4709,
       "description": "Awesome list of progressive web apps!",
       "primaryLanguage": null,
       "starredAt": "2016-11-21T07:16:20Z"
@@ -21042,7 +21153,7 @@
     {
       "nameWithOwner": "krisk/Fuse",
       "url": "https://github.com/krisk/Fuse",
-      "stargazerCount": 19353,
+      "stargazerCount": 19403,
       "description": "Lightweight fuzzy-search, in JavaScript",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-11-18T09:05:38Z"
@@ -21058,7 +21169,7 @@
     {
       "nameWithOwner": "palantir/blueprint",
       "url": "https://github.com/palantir/blueprint",
-      "stargazerCount": 21160,
+      "stargazerCount": 21172,
       "description": "A React-based UI toolkit for the web",
       "primaryLanguage": "TypeScript",
       "starredAt": "2016-11-16T23:53:34Z"
@@ -21122,7 +21233,7 @@
     {
       "nameWithOwner": "lesspass/lesspass",
       "url": "https://github.com/lesspass/lesspass",
-      "stargazerCount": 5878,
+      "stargazerCount": 5886,
       "description": ":key: stateless open source password manager",
       "primaryLanguage": "TypeScript",
       "starredAt": "2016-11-15T01:37:08Z"
@@ -21130,7 +21241,7 @@
     {
       "nameWithOwner": "sindresorhus/pageres",
       "url": "https://github.com/sindresorhus/pageres",
-      "stargazerCount": 9727,
+      "stargazerCount": 9729,
       "description": "Capture website screenshots",
       "primaryLanguage": "TypeScript",
       "starredAt": "2016-11-15T00:38:11Z"
@@ -21170,7 +21281,7 @@
     {
       "nameWithOwner": "GetStream/Winds",
       "url": "https://github.com/GetStream/Winds",
-      "stargazerCount": 9072,
+      "stargazerCount": 9077,
       "description": "A Beautiful Open Source RSS & Podcast App Powered by Getstream.io",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-11-13T22:40:21Z"
@@ -21178,7 +21289,7 @@
     {
       "nameWithOwner": "peers/peerjs",
       "url": "https://github.com/peers/peerjs",
-      "stargazerCount": 12945,
+      "stargazerCount": 12960,
       "description": "Simple peer-to-peer with WebRTC.",
       "primaryLanguage": "TypeScript",
       "starredAt": "2016-11-11T08:03:05Z"
@@ -21186,7 +21297,7 @@
     {
       "nameWithOwner": "microsoft/WSL",
       "url": "https://github.com/microsoft/WSL",
-      "stargazerCount": 29324,
+      "stargazerCount": 29437,
       "description": "Windows Subsystem for Linux",
       "primaryLanguage": "C++",
       "starredAt": "2016-11-11T05:28:06Z"
@@ -21194,7 +21305,7 @@
     {
       "nameWithOwner": "webtorrent/webtorrent",
       "url": "https://github.com/webtorrent/webtorrent",
-      "stargazerCount": 30295,
+      "stargazerCount": 30314,
       "description": "⚡️ Streaming torrent client for the web",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-11-10T09:24:27Z"
@@ -21202,7 +21313,7 @@
     {
       "nameWithOwner": "WhitestormJS/whs.js",
       "url": "https://github.com/WhitestormJS/whs.js",
-      "stargazerCount": 6232,
+      "stargazerCount": 6230,
       "description": ":rocket: 🌪 Super-fast 3D framework for Web Applications 🥇 & Games 🎮. Based on Three.js",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-11-09T23:03:56Z"
@@ -21218,7 +21329,7 @@
     {
       "nameWithOwner": "keijiro/Klak",
       "url": "https://github.com/keijiro/Klak",
-      "stargazerCount": 1970,
+      "stargazerCount": 1973,
       "description": "Creative coding library for Unity",
       "primaryLanguage": "C#",
       "starredAt": "2016-11-08T05:21:07Z"
@@ -21266,7 +21377,7 @@
     {
       "nameWithOwner": "dokku/dokku",
       "url": "https://github.com/dokku/dokku",
-      "stargazerCount": 30884,
+      "stargazerCount": 30928,
       "description": "A docker-powered PaaS that helps you build and manage the lifecycle of applications",
       "primaryLanguage": "Shell",
       "starredAt": "2016-10-30T03:35:21Z"
@@ -21274,7 +21385,7 @@
     {
       "nameWithOwner": "dollarshaveclub/shave",
       "url": "https://github.com/dollarshaveclub/shave",
-      "stargazerCount": 2105,
+      "stargazerCount": 2104,
       "description": "💈 Shave is a 0 dep JS plugin that truncates text to fit within an element based on a set max-height  ✁",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-10-27T03:57:33Z"
@@ -21282,7 +21393,7 @@
     {
       "nameWithOwner": "leereilly/games",
       "url": "https://github.com/leereilly/games",
-      "stargazerCount": 23657,
+      "stargazerCount": 23685,
       "description": ":video_game: A list of popular/awesome video games, add-ons, maps, etc. hosted on GitHub. Any genre. Any platform. Any engine.",
       "primaryLanguage": null,
       "starredAt": "2016-10-27T03:56:43Z"
@@ -21290,7 +21401,7 @@
     {
       "nameWithOwner": "faisalman/ua-parser-js",
       "url": "https://github.com/faisalman/ua-parser-js",
-      "stargazerCount": 9765,
+      "stargazerCount": 9775,
       "description": "\"Unmask Your Traffic\" - UAParser.js: The Essential Web Development Tool for User-Agent Detection",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-10-27T00:54:31Z"
@@ -21298,7 +21409,7 @@
     {
       "nameWithOwner": "vercel/next.js",
       "url": "https://github.com/vercel/next.js",
-      "stargazerCount": 133379,
+      "stargazerCount": 133583,
       "description": "The React Framework",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-10-26T12:20:00Z"
@@ -21322,7 +21433,7 @@
     {
       "nameWithOwner": "maxwellito/vivus",
       "url": "https://github.com/maxwellito/vivus",
-      "stargazerCount": 15387,
+      "stargazerCount": 15385,
       "description": "JavaScript library to make drawing animation on SVG",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-10-18T08:44:19Z"
@@ -21330,7 +21441,7 @@
     {
       "nameWithOwner": "eligrey/FileSaver.js",
       "url": "https://github.com/eligrey/FileSaver.js",
-      "stargazerCount": 21910,
+      "stargazerCount": 21922,
       "description": "An HTML5 saveAs() FileSaver implementation",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-10-17T01:14:28Z"
@@ -21338,7 +21449,7 @@
     {
       "nameWithOwner": "animate-css/animate.css",
       "url": "https://github.com/animate-css/animate.css",
-      "stargazerCount": 81980,
+      "stargazerCount": 82007,
       "description": "🍿 A cross-browser library of CSS animations. As easy to use as an easy thing.",
       "primaryLanguage": "CSS",
       "starredAt": "2016-10-17T00:06:52Z"
@@ -21354,7 +21465,7 @@
     {
       "nameWithOwner": "mikelovesrobots/mmmm",
       "url": "https://github.com/mikelovesrobots/mmmm",
-      "stargazerCount": 822,
+      "stargazerCount": 823,
       "description": "",
       "primaryLanguage": null,
       "starredAt": "2016-10-15T08:51:43Z"
@@ -21386,7 +21497,7 @@
     {
       "nameWithOwner": "request/request",
       "url": "https://github.com/request/request",
-      "stargazerCount": 25644,
+      "stargazerCount": 25639,
       "description": "🏊🏾 Simplified HTTP request client.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-10-13T06:39:48Z"
@@ -21394,7 +21505,7 @@
     {
       "nameWithOwner": "yarnpkg/yarn",
       "url": "https://github.com/yarnpkg/yarn",
-      "stargazerCount": 41546,
+      "stargazerCount": 41547,
       "description": "The 1.x line is frozen - features and bugfixes now happen on https://github.com/yarnpkg/berry",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-10-13T05:35:00Z"
@@ -21402,7 +21513,7 @@
     {
       "nameWithOwner": "BenjaminVanRyseghem/numbro",
       "url": "https://github.com/BenjaminVanRyseghem/numbro",
-      "stargazerCount": 1127,
+      "stargazerCount": 1128,
       "description": "A JS library for number formatting",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-10-13T00:05:37Z"
@@ -21410,7 +21521,7 @@
     {
       "nameWithOwner": "WickyNilliams/headroom.js",
       "url": "https://github.com/WickyNilliams/headroom.js",
-      "stargazerCount": 10857,
+      "stargazerCount": 10858,
       "description": "Give your pages some headroom. Hide your header until you need it",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-10-11T02:00:08Z"
@@ -21466,7 +21577,7 @@
     {
       "nameWithOwner": "googlevr/gvr-unity-sdk",
       "url": "https://github.com/googlevr/gvr-unity-sdk",
-      "stargazerCount": 2716,
+      "stargazerCount": 2717,
       "description": "Google VR SDK for Unity",
       "primaryLanguage": "C#",
       "starredAt": "2016-10-03T23:36:52Z"
@@ -21474,7 +21585,7 @@
     {
       "nameWithOwner": "mapbox/maki",
       "url": "https://github.com/mapbox/maki",
-      "stargazerCount": 1537,
+      "stargazerCount": 1538,
       "description": "A POI Icon Set",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-10-03T04:50:07Z"
@@ -21498,7 +21609,7 @@
     {
       "nameWithOwner": "gilbarbara/react-inlinesvg",
       "url": "https://github.com/gilbarbara/react-inlinesvg",
-      "stargazerCount": 1299,
+      "stargazerCount": 1300,
       "description": "An SVG loader component for ReactJS",
       "primaryLanguage": "TypeScript",
       "starredAt": "2016-09-30T01:22:30Z"
@@ -21546,7 +21657,7 @@
     {
       "nameWithOwner": "apostrophecms/apostrophe",
       "url": "https://github.com/apostrophecms/apostrophe",
-      "stargazerCount": 4465,
+      "stargazerCount": 4473,
       "description": "A full-featured, open-source content management framework built with Node.js that empowers organizations by combining in-context editing and headless architecture in a full-stack JS environment.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-09-28T23:16:09Z"
@@ -21586,7 +21697,7 @@
     {
       "nameWithOwner": "taye/interact.js",
       "url": "https://github.com/taye/interact.js",
-      "stargazerCount": 12691,
+      "stargazerCount": 12702,
       "description": "JavaScript drag and drop, resizing and multi-touch gestures with inertia and snapping for modern browsers (and also IE9+)",
       "primaryLanguage": "TypeScript",
       "starredAt": "2016-09-28T05:43:33Z"
@@ -21610,7 +21721,7 @@
     {
       "nameWithOwner": "MoOx/phenomic",
       "url": "https://github.com/MoOx/phenomic",
-      "stargazerCount": 3197,
+      "stargazerCount": 3196,
       "description": "DEPRECATED. Please use Next.js instead.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-09-27T00:36:41Z"
@@ -21634,7 +21745,7 @@
     {
       "nameWithOwner": "TryGhost/Ghost",
       "url": "https://github.com/TryGhost/Ghost",
-      "stargazerCount": 49964,
+      "stargazerCount": 50075,
       "description": "Independent technology for modern publishing, memberships, subscriptions and newsletters.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-09-24T01:04:48Z"
@@ -21642,7 +21753,7 @@
     {
       "nameWithOwner": "FormidableLabs/react-music",
       "url": "https://github.com/FormidableLabs/react-music",
-      "stargazerCount": 2728,
+      "stargazerCount": 2729,
       "description": "Make beats with React!",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-09-23T07:53:10Z"
@@ -21650,7 +21761,7 @@
     {
       "nameWithOwner": "bigbite/macy.js",
       "url": "https://github.com/bigbite/macy.js",
-      "stargazerCount": 1326,
+      "stargazerCount": 1327,
       "description": "",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-09-22T23:13:59Z"
@@ -21658,7 +21769,7 @@
     {
       "nameWithOwner": "liabru/matter-js",
       "url": "https://github.com/liabru/matter-js",
-      "stargazerCount": 17565,
+      "stargazerCount": 17598,
       "description": "a 2D rigid body physics engine for the web ▲● ■",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-09-22T21:02:25Z"
@@ -21690,7 +21801,7 @@
     {
       "nameWithOwner": "desandro/masonry",
       "url": "https://github.com/desandro/masonry",
-      "stargazerCount": 16599,
+      "stargazerCount": 16608,
       "description": ":love_hotel: Cascading grid layout plugin",
       "primaryLanguage": "HTML",
       "starredAt": "2016-09-20T11:33:43Z"
@@ -21706,7 +21817,7 @@
     {
       "nameWithOwner": "Rush/Font-Awesome-SVG-PNG",
       "url": "https://github.com/Rush/Font-Awesome-SVG-PNG",
-      "stargazerCount": 3223,
+      "stargazerCount": 3222,
       "description": "Font Awesome split to individual SVG and PNG files of different sizes along with Node.JS based generator",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-09-19T12:21:52Z"
@@ -21738,7 +21849,7 @@
     {
       "nameWithOwner": "shoutem/ui",
       "url": "https://github.com/shoutem/ui",
-      "stargazerCount": 4943,
+      "stargazerCount": 4944,
       "description": "Customizable set of components for React Native applications",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-09-18T01:04:49Z"
@@ -21762,7 +21873,7 @@
     {
       "nameWithOwner": "olivernn/lunr.js",
       "url": "https://github.com/olivernn/lunr.js",
-      "stargazerCount": 9095,
+      "stargazerCount": 9101,
       "description": "A bit like Solr, but much smaller and not as bright",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-09-17T13:22:40Z"
@@ -21786,7 +21897,7 @@
     {
       "nameWithOwner": "helpers/handlebars-helpers",
       "url": "https://github.com/helpers/handlebars-helpers",
-      "stargazerCount": 2228,
+      "stargazerCount": 2229,
       "description": "188 handlebars helpers in ~20 categories. Can be used with Assemble, Ghost, YUI, express.js etc.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-09-17T05:24:07Z"
@@ -21818,7 +21929,7 @@
     {
       "nameWithOwner": "benweet/stackedit",
       "url": "https://github.com/benweet/stackedit",
-      "stargazerCount": 22363,
+      "stargazerCount": 22389,
       "description": "In-browser Markdown editor",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-09-16T14:03:49Z"
@@ -21922,7 +22033,7 @@
     {
       "nameWithOwner": "hparra/gulp-rename",
       "url": "https://github.com/hparra/gulp-rename",
-      "stargazerCount": 692,
+      "stargazerCount": 691,
       "description": "Rename files easily",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-09-15T00:49:32Z"
@@ -21930,7 +22041,7 @@
     {
       "nameWithOwner": "EvandroLG/pageAccelerator",
       "url": "https://github.com/EvandroLG/pageAccelerator",
-      "stargazerCount": 1203,
+      "stargazerCount": 1204,
       "description": "A very light solution to load web pages faster",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-09-14T22:28:54Z"
@@ -21954,7 +22065,7 @@
     {
       "nameWithOwner": "Ableton/link",
       "url": "https://github.com/Ableton/link",
-      "stargazerCount": 1178,
+      "stargazerCount": 1179,
       "description": "Ableton Link",
       "primaryLanguage": "C++",
       "starredAt": "2016-09-14T22:00:51Z"
@@ -21962,7 +22073,7 @@
     {
       "nameWithOwner": "sindresorhus/gulp-ruby-sass",
       "url": "https://github.com/sindresorhus/gulp-ruby-sass",
-      "stargazerCount": 461,
+      "stargazerCount": 462,
       "description": "Compile Sass to CSS with Ruby Sass",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-09-13T23:44:33Z"
@@ -22034,7 +22145,7 @@
     {
       "nameWithOwner": "c-frame/aframe-extras",
       "url": "https://github.com/c-frame/aframe-extras",
-      "stargazerCount": 994,
+      "stargazerCount": 995,
       "description": "Add-ons and helpers for A-Frame VR.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-09-10T13:15:59Z"
@@ -22042,7 +22153,7 @@
     {
       "nameWithOwner": "react-native-elements/react-native-elements",
       "url": "https://github.com/react-native-elements/react-native-elements",
-      "stargazerCount": 25502,
+      "stargazerCount": 25514,
       "description": "Cross-Platform React Native UI Toolkit",
       "primaryLanguage": "MDX",
       "starredAt": "2016-09-10T08:40:47Z"
@@ -22058,7 +22169,7 @@
     {
       "nameWithOwner": "wix/react-native-navigation",
       "url": "https://github.com/wix/react-native-navigation",
-      "stargazerCount": 13113,
+      "stargazerCount": 13117,
       "description": "A complete native navigation solution for React Native",
       "primaryLanguage": "MDX",
       "starredAt": "2016-09-10T07:14:31Z"
@@ -22066,7 +22177,7 @@
     {
       "nameWithOwner": "supermedium/superframe",
       "url": "https://github.com/supermedium/superframe",
-      "stargazerCount": 1397,
+      "stargazerCount": 1399,
       "description": ":package: A super collection of A-Frame components.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-09-09T12:16:21Z"
@@ -22082,7 +22193,7 @@
     {
       "nameWithOwner": "julianshapiro/velocity",
       "url": "https://github.com/julianshapiro/velocity",
-      "stargazerCount": 17294,
+      "stargazerCount": 17292,
       "description": "Accelerated JavaScript animation.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-09-09T04:04:07Z"
@@ -22098,7 +22209,7 @@
     {
       "nameWithOwner": "pixijs/pixijs",
       "url": "https://github.com/pixijs/pixijs",
-      "stargazerCount": 45439,
+      "stargazerCount": 45475,
       "description": "The HTML5 Creation Engine: Create beautiful digital content with the fastest, most flexible 2D WebGL renderer.",
       "primaryLanguage": "TypeScript",
       "starredAt": "2016-09-09T03:33:17Z"
@@ -22106,7 +22217,7 @@
     {
       "nameWithOwner": "Homebrew/brew",
       "url": "https://github.com/Homebrew/brew",
-      "stargazerCount": 44326,
+      "stargazerCount": 44427,
       "description": "🍺 The missing package manager for macOS (or Linux)",
       "primaryLanguage": "Ruby",
       "starredAt": "2016-09-08T01:50:30Z"
@@ -22122,7 +22233,7 @@
     {
       "nameWithOwner": "sarcadass/granim.js",
       "url": "https://github.com/sarcadass/granim.js",
-      "stargazerCount": 5312,
+      "stargazerCount": 5314,
       "description": "Create fluid and interactive gradient animations with this small javascript library.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-09-08T01:01:05Z"
@@ -22138,7 +22249,7 @@
     {
       "nameWithOwner": "eslint/eslint",
       "url": "https://github.com/eslint/eslint",
-      "stargazerCount": 26121,
+      "stargazerCount": 26150,
       "description": "Find and fix problems in your JavaScript code.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-09-06T00:45:17Z"
@@ -22146,7 +22257,7 @@
     {
       "nameWithOwner": "mrdoob/stats.js",
       "url": "https://github.com/mrdoob/stats.js",
-      "stargazerCount": 8931,
+      "stargazerCount": 8937,
       "description": "JavaScript Performance Monitor",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-08-29T02:31:59Z"
@@ -22154,7 +22265,7 @@
     {
       "nameWithOwner": "camwiegert/in-view",
       "url": "https://github.com/camwiegert/in-view",
-      "stargazerCount": 4634,
+      "stargazerCount": 4633,
       "description": "Get notified when a DOM element enters or exits the viewport. :eyes:",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-08-28T22:21:40Z"
@@ -22162,7 +22273,7 @@
     {
       "nameWithOwner": "google/deepdream",
       "url": "https://github.com/google/deepdream",
-      "stargazerCount": 13251,
+      "stargazerCount": 13248,
       "description": "",
       "primaryLanguage": null,
       "starredAt": "2016-08-25T05:39:46Z"
@@ -22170,7 +22281,7 @@
     {
       "nameWithOwner": "jaywcjlove/awesome-mac",
       "url": "https://github.com/jaywcjlove/awesome-mac",
-      "stargazerCount": 85257,
+      "stargazerCount": 85557,
       "description": " Now we have become very big, Different from the original idea. Collect premium software in various categories.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-08-25T00:44:49Z"
@@ -22194,7 +22305,7 @@
     {
       "nameWithOwner": "postcss/autoprefixer",
       "url": "https://github.com/postcss/autoprefixer",
-      "stargazerCount": 22088,
+      "stargazerCount": 22099,
       "description": " Parse CSS and add vendor prefixes to rules by Can I Use",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-08-23T01:15:13Z"
@@ -22202,7 +22313,7 @@
     {
       "nameWithOwner": "yargs/yargs",
       "url": "https://github.com/yargs/yargs",
-      "stargazerCount": 11319,
+      "stargazerCount": 11325,
       "description": " yargs the modern, pirate-themed successor to optimist.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-08-18T23:17:17Z"
@@ -22226,7 +22337,7 @@
     {
       "nameWithOwner": "eduardoboucas/staticman",
       "url": "https://github.com/eduardoboucas/staticman",
-      "stargazerCount": 2450,
+      "stargazerCount": 2453,
       "description": "💪  User-generated content for Git-powered websites",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-08-17T23:00:12Z"
@@ -22258,7 +22369,7 @@
     {
       "nameWithOwner": "FormidableLabs/webpack-dashboard",
       "url": "https://github.com/FormidableLabs/webpack-dashboard",
-      "stargazerCount": 13976,
+      "stargazerCount": 13980,
       "description": "A CLI dashboard for webpack dev server",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-08-16T11:45:20Z"
@@ -22282,7 +22393,7 @@
     {
       "nameWithOwner": "shime/play-sound",
       "url": "https://github.com/shime/play-sound",
-      "stargazerCount": 219,
+      "stargazerCount": 220,
       "description": "Play sounds by shelling out to one of the available audio players.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-08-15T03:06:54Z"
@@ -22290,7 +22401,7 @@
     {
       "nameWithOwner": "usablica/kissui.scrollanim",
       "url": "https://github.com/usablica/kissui.scrollanim",
-      "stargazerCount": 1424,
+      "stargazerCount": 1423,
       "description": "CSS3 scroll animation library",
       "primaryLanguage": "CSS",
       "starredAt": "2016-08-14T22:12:41Z"
@@ -22330,7 +22441,7 @@
     {
       "nameWithOwner": "jdf/processing.py",
       "url": "https://github.com/jdf/processing.py",
-      "stargazerCount": 1646,
+      "stargazerCount": 1647,
       "description": "Write Processing sketches in Python",
       "primaryLanguage": "Python",
       "starredAt": "2016-08-09T14:14:54Z"
@@ -22346,7 +22457,7 @@
     {
       "nameWithOwner": "danielmiessler/SecLists",
       "url": "https://github.com/danielmiessler/SecLists",
-      "stargazerCount": 64377,
+      "stargazerCount": 64612,
       "description": "SecLists is the security tester's companion. It's a collection of multiple types of lists used during security assessments, collected in one place. List types include usernames, passwords, URLs, sensitive data patterns, fuzzing payloads, web shells, and many more.",
       "primaryLanguage": "PHP",
       "starredAt": "2016-08-09T06:16:27Z"
@@ -22354,7 +22465,7 @@
     {
       "nameWithOwner": "FallibleInc/security-guide-for-developers",
       "url": "https://github.com/FallibleInc/security-guide-for-developers",
-      "stargazerCount": 20989,
+      "stargazerCount": 20996,
       "description": "Security Guide for Developers",
       "primaryLanguage": null,
       "starredAt": "2016-08-08T11:02:41Z"
@@ -22370,7 +22481,7 @@
     {
       "nameWithOwner": "sindresorhus/guides",
       "url": "https://github.com/sindresorhus/guides",
-      "stargazerCount": 2496,
+      "stargazerCount": 2497,
       "description": "A collection of succinct guides - Public Domain",
       "primaryLanguage": null,
       "starredAt": "2016-08-07T09:05:33Z"
@@ -22378,7 +22489,7 @@
     {
       "nameWithOwner": "aframevr/aframe-inspector",
       "url": "https://github.com/aframevr/aframe-inspector",
-      "stargazerCount": 673,
+      "stargazerCount": 676,
       "description": ":mag: Visual inspector tool for A-Frame. Hit *<ctrl> + <alt> + i* on any A-Frame scene.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-08-02T20:43:58Z"
@@ -22386,7 +22497,7 @@
     {
       "nameWithOwner": "isaacs/node-glob",
       "url": "https://github.com/isaacs/node-glob",
-      "stargazerCount": 8629,
+      "stargazerCount": 8638,
       "description": "glob functionality for node.js",
       "primaryLanguage": "TypeScript",
       "starredAt": "2016-08-02T01:35:07Z"
@@ -22394,7 +22505,7 @@
     {
       "nameWithOwner": "sachinchoolur/lightgallery.js",
       "url": "https://github.com/sachinchoolur/lightgallery.js",
-      "stargazerCount": 5328,
+      "stargazerCount": 5329,
       "description": "Full featured JavaScript image & video gallery. No dependencies",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-08-01T23:07:38Z"
@@ -22434,7 +22545,7 @@
     {
       "nameWithOwner": "facebook/create-react-app",
       "url": "https://github.com/facebook/create-react-app",
-      "stargazerCount": 103371,
+      "stargazerCount": 103401,
       "description": "Set up a modern web app by running one command.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-07-23T06:28:31Z"
@@ -22442,7 +22553,7 @@
     {
       "nameWithOwner": "willianjusten/awesome-audio-visualization",
       "url": "https://github.com/willianjusten/awesome-audio-visualization",
-      "stargazerCount": 4795,
+      "stargazerCount": 4799,
       "description": "A curated list about Audio Visualization.",
       "primaryLanguage": "Shell",
       "starredAt": "2016-07-21T02:00:50Z"
@@ -22458,7 +22569,7 @@
     {
       "nameWithOwner": "rauchg/wifi-password",
       "url": "https://github.com/rauchg/wifi-password",
-      "stargazerCount": 4501,
+      "stargazerCount": 4504,
       "description": "Get the password of the wifi you're on (bash)",
       "primaryLanguage": "Shell",
       "starredAt": "2016-07-18T23:17:10Z"
@@ -22466,7 +22577,7 @@
     {
       "nameWithOwner": "rgcr/m-cli",
       "url": "https://github.com/rgcr/m-cli",
-      "stargazerCount": 9761,
+      "stargazerCount": 9766,
       "description": " Swiss Army Knife for macOS ",
       "primaryLanguage": "Shell",
       "starredAt": "2016-07-18T02:58:43Z"
@@ -22474,7 +22585,7 @@
     {
       "nameWithOwner": "vercel/hyper",
       "url": "https://github.com/vercel/hyper",
-      "stargazerCount": 44101,
+      "stargazerCount": 44130,
       "description": "A terminal built on web technologies",
       "primaryLanguage": "TypeScript",
       "starredAt": "2016-07-17T23:08:47Z"
@@ -22522,7 +22633,7 @@
     {
       "nameWithOwner": "juliangarnier/anime",
       "url": "https://github.com/juliangarnier/anime",
-      "stargazerCount": 62485,
+      "stargazerCount": 62689,
       "description": "JavaScript animation engine",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-06-27T23:52:25Z"
@@ -22530,7 +22641,7 @@
     {
       "nameWithOwner": "SamVerschueren/listr",
       "url": "https://github.com/SamVerschueren/listr",
-      "stargazerCount": 3291,
+      "stargazerCount": 3290,
       "description": "Terminal task list",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-06-27T06:40:03Z"
@@ -22570,7 +22681,7 @@
     {
       "nameWithOwner": "CodingTrain/website-archive",
       "url": "https://github.com/CodingTrain/website-archive",
-      "stargazerCount": 5735,
+      "stargazerCount": 5733,
       "description": "Archive of the Coding Train website (first version)",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-06-19T04:01:08Z"
@@ -22578,7 +22689,7 @@
     {
       "nameWithOwner": "nygardk/react-share",
       "url": "https://github.com/nygardk/react-share",
-      "stargazerCount": 2733,
+      "stargazerCount": 2732,
       "description": "Social media share buttons and share counts for React",
       "primaryLanguage": "TypeScript",
       "starredAt": "2016-06-18T00:23:44Z"
@@ -22586,7 +22697,7 @@
     {
       "nameWithOwner": "mrdoob/three.js",
       "url": "https://github.com/mrdoob/three.js",
-      "stargazerCount": 107764,
+      "stargazerCount": 107921,
       "description": "JavaScript 3D Library.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-06-17T10:56:50Z"
@@ -22602,7 +22713,7 @@
     {
       "nameWithOwner": "stackgl/shader-school",
       "url": "https://github.com/stackgl/shader-school",
-      "stargazerCount": 4369,
+      "stargazerCount": 4371,
       "description": ":mortar_board: A workshopper for GLSL shaders and graphics programming",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-06-15T23:21:47Z"
@@ -22626,7 +22737,7 @@
     {
       "nameWithOwner": "michalsnik/aos",
       "url": "https://github.com/michalsnik/aos",
-      "stargazerCount": 27742,
+      "stargazerCount": 27758,
       "description": "Animate on scroll library",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-06-14T02:40:55Z"
@@ -22634,7 +22745,7 @@
     {
       "nameWithOwner": "mov37/is.js",
       "url": "https://github.com/mov37/is.js",
-      "stargazerCount": 972,
+      "stargazerCount": 971,
       "description": "Minimalistic predicate library.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-06-13T01:07:03Z"
@@ -22642,7 +22753,7 @@
     {
       "nameWithOwner": "sahat/megaboilerplate",
       "url": "https://github.com/sahat/megaboilerplate",
-      "stargazerCount": 3824,
+      "stargazerCount": 3823,
       "description": "Handcrafted starter projects, optimized for simplicity and ease of use.",
       "primaryLanguage": "CSS",
       "starredAt": "2016-06-13T01:06:10Z"
@@ -22650,7 +22761,7 @@
     {
       "nameWithOwner": "infernojs/inferno",
       "url": "https://github.com/infernojs/inferno",
-      "stargazerCount": 16288,
+      "stargazerCount": 16293,
       "description": ":fire: An extremely fast, React-like JavaScript library for building modern user interfaces",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-06-13T01:04:29Z"
@@ -22738,7 +22849,7 @@
     {
       "nameWithOwner": "mmckegg/loop-drop-app",
       "url": "https://github.com/mmckegg/loop-drop-app",
-      "stargazerCount": 827,
+      "stargazerCount": 828,
       "description": "[unmaintained] MIDI looper, modular synth and sampler app built using Web Audio and Web MIDI APIs",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-06-08T22:36:34Z"
@@ -22754,7 +22865,7 @@
     {
       "nameWithOwner": "fabricjs/fabric.js",
       "url": "https://github.com/fabricjs/fabric.js",
-      "stargazerCount": 30244,
+      "stargazerCount": 30275,
       "description": "Javascript Canvas Library, SVG-to-Canvas (& canvas-to-SVG) Parser",
       "primaryLanguage": "TypeScript",
       "starredAt": "2016-06-08T08:12:28Z"
@@ -22770,7 +22881,7 @@
     {
       "nameWithOwner": "barbajs/barba",
       "url": "https://github.com/barbajs/barba",
-      "stargazerCount": 12369,
+      "stargazerCount": 12544,
       "description": "Create badass, fluid and smooth transitions between your website’s pages",
       "primaryLanguage": "TypeScript",
       "starredAt": "2016-06-08T03:19:22Z"
@@ -22786,7 +22897,7 @@
     {
       "nameWithOwner": "mudcube/MIDI.js",
       "url": "https://github.com/mudcube/MIDI.js",
-      "stargazerCount": 3878,
+      "stargazerCount": 3881,
       "description": ":musical_keyboard: Making life easy to create a MIDI-app on the web. Includes a library to program synesthesia into your app for memory recognition or for creating trippy effects. Convert soundfonts for Guitar, Bass, Drums, ect. into code that can be read by the browser. Supports multiple simultaneous instruments and perfect timing.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-06-06T23:22:06Z"
@@ -22794,7 +22905,7 @@
     {
       "nameWithOwner": "djipco/webmidi",
       "url": "https://github.com/djipco/webmidi",
-      "stargazerCount": 1634,
+      "stargazerCount": 1638,
       "description": "Tame the Web MIDI API. Send and receive MIDI messages with ease. Control instruments with user-friendly functions (playNote, sendPitchBend, etc.). React to MIDI input with simple event listeners (noteon, pitchbend, controlchange, etc.).",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-06-06T23:17:02Z"
@@ -22826,7 +22937,7 @@
     {
       "nameWithOwner": "impress/impress.js",
       "url": "https://github.com/impress/impress.js",
-      "stargazerCount": 37995,
+      "stargazerCount": 38001,
       "description": "It's a presentation framework based on the power of CSS3 transforms and transitions in modern browsers and inspired by the idea behind prezi.com.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-06-06T22:24:58Z"
@@ -22834,7 +22945,7 @@
     {
       "nameWithOwner": "serkanyersen/ifvisible.js",
       "url": "https://github.com/serkanyersen/ifvisible.js",
-      "stargazerCount": 1948,
+      "stargazerCount": 1949,
       "description": "Crossbrowser & lightweight way to check if user is looking at the page or interacting with it.",
       "primaryLanguage": "TypeScript",
       "starredAt": "2016-06-06T22:22:40Z"
@@ -22842,7 +22953,7 @@
     {
       "nameWithOwner": "ritz078/embed-js",
       "url": "https://github.com/ritz078/embed-js",
-      "stargazerCount": 1268,
+      "stargazerCount": 1267,
       "description": "🌻  A lightweight plugin to embed emojis, media, maps, tweets, code and more. ✨",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-06-06T22:18:46Z"
@@ -22850,7 +22961,7 @@
     {
       "nameWithOwner": "dixonandmoe/rellax",
       "url": "https://github.com/dixonandmoe/rellax",
-      "stargazerCount": 7143,
+      "stargazerCount": 7145,
       "description": "Lightweight, vanilla javascript parallax library",
       "primaryLanguage": "HTML",
       "starredAt": "2016-06-06T22:17:03Z"
@@ -22858,7 +22969,7 @@
     {
       "nameWithOwner": "asvd/microlight",
       "url": "https://github.com/asvd/microlight",
-      "stargazerCount": 1486,
+      "stargazerCount": 1487,
       "description": "highlights code in any programming language",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-06-05T23:02:20Z"
@@ -22874,7 +22985,7 @@
     {
       "nameWithOwner": "googlecreativelab/anypixel",
       "url": "https://github.com/googlecreativelab/anypixel",
-      "stargazerCount": 6446,
+      "stargazerCount": 6448,
       "description": "A web-friendly way for anyone to build unusual displays",
       "primaryLanguage": "C",
       "starredAt": "2016-06-03T11:12:37Z"
@@ -22882,7 +22993,7 @@
     {
       "nameWithOwner": "CodeByZach/pace",
       "url": "https://github.com/CodeByZach/pace",
-      "stargazerCount": 15670,
+      "stargazerCount": 15668,
       "description": "Automatically add a progress bar to your site.",
       "primaryLanguage": "CSS",
       "starredAt": "2016-06-02T13:22:33Z"
@@ -22890,7 +23001,7 @@
     {
       "nameWithOwner": "wpscanteam/wpscan",
       "url": "https://github.com/wpscanteam/wpscan",
-      "stargazerCount": 9110,
+      "stargazerCount": 9120,
       "description": "WPScan WordPress security scanner. Written for security professionals and blog maintainers to test the security of their WordPress websites. Contact us via contact@wpscan.com",
       "primaryLanguage": "Ruby",
       "starredAt": "2016-05-31T06:04:15Z"
@@ -22914,7 +23025,7 @@
     {
       "nameWithOwner": "Tonejs/Tone.js",
       "url": "https://github.com/Tonejs/Tone.js",
-      "stargazerCount": 14108,
+      "stargazerCount": 14126,
       "description": "A Web Audio framework for making interactive music in the browser.",
       "primaryLanguage": "TypeScript",
       "starredAt": "2016-05-28T11:30:55Z"
@@ -22922,7 +23033,7 @@
     {
       "nameWithOwner": "processing/p5.js-sound",
       "url": "https://github.com/processing/p5.js-sound",
-      "stargazerCount": 894,
+      "stargazerCount": 891,
       "description": "p5.sound brings the Processing approach to Web Audio and p5.js. Demos:",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-05-28T11:23:12Z"
@@ -22938,7 +23049,7 @@
     {
       "nameWithOwner": "processing-js/processing-js",
       "url": "https://github.com/processing-js/processing-js",
-      "stargazerCount": 3091,
+      "stargazerCount": 3092,
       "description": "A port of the Processing visualization language to JavaScript.",
       "primaryLanguage": "Processing",
       "starredAt": "2016-05-27T08:24:23Z"
@@ -22962,7 +23073,7 @@
     {
       "nameWithOwner": "processing/p5.js",
       "url": "https://github.com/processing/p5.js",
-      "stargazerCount": 22796,
+      "stargazerCount": 22842,
       "description": "p5.js is a client-side JS platform that empowers artists, designers, students, and anyone to learn to code and express themselves creatively on the web. It is based on the core principles of Processing. http://twitter.com/p5xjs —",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-05-26T11:20:42Z"
@@ -22978,7 +23089,7 @@
     {
       "nameWithOwner": "anandthakker/doiuse",
       "url": "https://github.com/anandthakker/doiuse",
-      "stargazerCount": 1282,
+      "stargazerCount": 1284,
       "description": ":bomb: Lint CSS for browser support against caniuse database.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-05-25T00:45:03Z"
@@ -22986,7 +23097,7 @@
     {
       "nameWithOwner": "react-boilerplate/react-boilerplate",
       "url": "https://github.com/react-boilerplate/react-boilerplate",
-      "stargazerCount": 29529,
+      "stargazerCount": 29533,
       "description": "🔥 A highly scalable, offline-first foundation with the best developer experience and a focus on performance and best practices.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-05-23T22:23:25Z"
@@ -22994,7 +23105,7 @@
     {
       "nameWithOwner": "railsware/upterm",
       "url": "https://github.com/railsware/upterm",
-      "stargazerCount": 19178,
+      "stargazerCount": 19175,
       "description": "A terminal emulator for the 21st century.",
       "primaryLanguage": "TypeScript",
       "starredAt": "2016-05-23T22:21:02Z"
@@ -23026,7 +23137,7 @@
     {
       "nameWithOwner": "sampotts/plyr",
       "url": "https://github.com/sampotts/plyr",
-      "stargazerCount": 28944,
+      "stargazerCount": 29004,
       "description": "A simple HTML5, YouTube and Vimeo player",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-05-16T09:42:31Z"
@@ -23042,7 +23153,7 @@
     {
       "nameWithOwner": "donnemartin/gitsome",
       "url": "https://github.com/donnemartin/gitsome",
-      "stargazerCount": 7633,
+      "stargazerCount": 7636,
       "description": "A supercharged Git/GitHub command line interface (CLI).  An official integration for GitHub and GitHub Enterprise: https://github.com/works-with/category/desktop-tools",
       "primaryLanguage": "Python",
       "starredAt": "2016-05-10T02:47:44Z"
@@ -23050,7 +23161,7 @@
     {
       "nameWithOwner": "laravel/valet",
       "url": "https://github.com/laravel/valet",
-      "stargazerCount": 2567,
+      "stargazerCount": 2568,
       "description": "A more enjoyable local development experience for Mac.",
       "primaryLanguage": "PHP",
       "starredAt": "2016-05-10T01:58:08Z"
@@ -23058,7 +23169,7 @@
     {
       "nameWithOwner": "sobolevn/git-secret",
       "url": "https://github.com/sobolevn/git-secret",
-      "stargazerCount": 3873,
+      "stargazerCount": 3875,
       "description": ":busts_in_silhouette: A bash-tool to store your private data inside a git repository.",
       "primaryLanguage": "Shell",
       "starredAt": "2016-05-10T01:53:26Z"
@@ -23066,7 +23177,7 @@
     {
       "nameWithOwner": "matomo-org/matomo",
       "url": "https://github.com/matomo-org/matomo",
-      "stargazerCount": 20700,
+      "stargazerCount": 20725,
       "description": "Empowering People Ethically 🚀 — Matomo is hiring! Join us → https://matomo.org/jobs Matomo is the leading open-source alternative to Google Analytics, giving you complete control and built-in privacy. Easily collect, visualise, and analyse data from websites & apps. Star us on GitHub ⭐️  – Pull Requests welcome! ",
       "primaryLanguage": "PHP",
       "starredAt": "2016-05-10T01:50:56Z"
@@ -23074,7 +23185,7 @@
     {
       "nameWithOwner": "mapbox/mapbox-sdk-js",
       "url": "https://github.com/mapbox/mapbox-sdk-js",
-      "stargazerCount": 747,
+      "stargazerCount": 752,
       "description": "A JavaScript client to Mapbox services, supporting Node, browsers, and React Native",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-05-08T12:11:31Z"
@@ -23090,7 +23201,7 @@
     {
       "nameWithOwner": "react-native-linear-gradient/react-native-linear-gradient",
       "url": "https://github.com/react-native-linear-gradient/react-native-linear-gradient",
-      "stargazerCount": 4935,
+      "stargazerCount": 4934,
       "description": "A <LinearGradient /> component for react-native",
       "primaryLanguage": "Java",
       "starredAt": "2016-05-06T05:40:55Z"
@@ -23098,7 +23209,7 @@
     {
       "nameWithOwner": "h5bp/server-configs-apache",
       "url": "https://github.com/h5bp/server-configs-apache",
-      "stargazerCount": 3244,
+      "stargazerCount": 3243,
       "description": "Apache HTTP server boilerplate configs",
       "primaryLanguage": "Shell",
       "starredAt": "2016-05-06T04:38:24Z"
@@ -23114,7 +23225,7 @@
     {
       "nameWithOwner": "WordPress/application-passwords",
       "url": "https://github.com/WordPress/application-passwords",
-      "stargazerCount": 184,
+      "stargazerCount": 186,
       "description": "",
       "primaryLanguage": "PHP",
       "starredAt": "2016-05-04T10:56:08Z"
@@ -23122,7 +23233,7 @@
     {
       "nameWithOwner": "zyedidia/micro",
       "url": "https://github.com/zyedidia/micro",
-      "stargazerCount": 26565,
+      "stargazerCount": 26613,
       "description": "A modern and intuitive terminal-based text editor",
       "primaryLanguage": "Go",
       "starredAt": "2016-05-04T03:01:37Z"
@@ -23130,7 +23241,7 @@
     {
       "nameWithOwner": "sanathp/statusok",
       "url": "https://github.com/sanathp/statusok",
-      "stargazerCount": 1629,
+      "stargazerCount": 1628,
       "description": "Monitor your Website and APIs from your Computer. Get Notified through Slack, E-mail when your server is down or response time is more than expected. ",
       "primaryLanguage": "Go",
       "starredAt": "2016-05-04T02:31:42Z"
@@ -23154,7 +23265,7 @@
     {
       "nameWithOwner": "kristoferjoseph/flexboxgrid",
       "url": "https://github.com/kristoferjoseph/flexboxgrid",
-      "stargazerCount": 9373,
+      "stargazerCount": 9371,
       "description": "Grid based on CSS3 flexbox",
       "primaryLanguage": "HTML",
       "starredAt": "2016-05-04T01:12:20Z"
@@ -23162,7 +23273,7 @@
     {
       "nameWithOwner": "typicode/husky",
       "url": "https://github.com/typicode/husky",
-      "stargazerCount": 33854,
+      "stargazerCount": 33908,
       "description": "Git hooks made easy 🐶 woof!",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-05-03T05:50:38Z"
@@ -23170,7 +23281,7 @@
     {
       "nameWithOwner": "typicode/json-server",
       "url": "https://github.com/typicode/json-server",
-      "stargazerCount": 74655,
+      "stargazerCount": 74700,
       "description": "Get a full fake REST API with zero coding in less than 30 seconds (seriously)",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-05-03T05:49:40Z"
@@ -23178,7 +23289,7 @@
     {
       "nameWithOwner": "kciter/react-barcode",
       "url": "https://github.com/kciter/react-barcode",
-      "stargazerCount": 430,
+      "stargazerCount": 431,
       "description": "A <Barcode/> component for use with React.",
       "primaryLanguage": "Makefile",
       "starredAt": "2016-04-29T11:07:11Z"
@@ -23186,7 +23297,7 @@
     {
       "nameWithOwner": "dompdf/dompdf",
       "url": "https://github.com/dompdf/dompdf",
-      "stargazerCount": 10868,
+      "stargazerCount": 10871,
       "description": "HTML to PDF converter for PHP",
       "primaryLanguage": "PHP",
       "starredAt": "2016-04-29T05:57:35Z"
@@ -23194,7 +23305,7 @@
     {
       "nameWithOwner": "electron/electron",
       "url": "https://github.com/electron/electron",
-      "stargazerCount": 117584,
+      "stargazerCount": 117711,
       "description": ":electron: Build cross-platform desktop apps with JavaScript, HTML, and CSS",
       "primaryLanguage": "C++",
       "starredAt": "2016-04-29T05:18:35Z"
@@ -23202,7 +23313,7 @@
     {
       "nameWithOwner": "standard/standard",
       "url": "https://github.com/standard/standard",
-      "stargazerCount": 29331,
+      "stargazerCount": 29338,
       "description": "🌟 JavaScript Style Guide, with linter & automatic code fixer",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-04-29T03:18:58Z"
@@ -23210,7 +23321,7 @@
     {
       "nameWithOwner": "freeCodeCamp/freeCodeCamp",
       "url": "https://github.com/freeCodeCamp/freeCodeCamp",
-      "stargazerCount": 424144,
+      "stargazerCount": 424969,
       "description": "freeCodeCamp.org's open-source codebase and curriculum. Learn math, programming, and computer science for free.",
       "primaryLanguage": "TypeScript",
       "starredAt": "2016-04-28T08:57:17Z"
@@ -23218,7 +23329,7 @@
     {
       "nameWithOwner": "vuejs/vue",
       "url": "https://github.com/vuejs/vue",
-      "stargazerCount": 209176,
+      "stargazerCount": 209219,
       "description": "This is the repo for Vue 2. For Vue 3, go to https://github.com/vuejs/core",
       "primaryLanguage": "TypeScript",
       "starredAt": "2016-04-28T00:15:33Z"
@@ -23226,7 +23337,7 @@
     {
       "nameWithOwner": "rserota/wad",
       "url": "https://github.com/rserota/wad",
-      "stargazerCount": 1929,
+      "stargazerCount": 1930,
       "description": "Web Audio DAW.  Use the Web Audio API for dynamic sound synthesis.  It's like jQuery for your ears. ",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-04-27T22:19:14Z"
@@ -23234,7 +23345,7 @@
     {
       "nameWithOwner": "bpampuch/pdfmake",
       "url": "https://github.com/bpampuch/pdfmake",
-      "stargazerCount": 12029,
+      "stargazerCount": 12037,
       "description": "Client/server side PDF printing in pure JavaScript",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-04-27T22:15:05Z"
@@ -23242,7 +23353,7 @@
     {
       "nameWithOwner": "Leonidas-from-XIV/node-xml2js",
       "url": "https://github.com/Leonidas-from-XIV/node-xml2js",
-      "stargazerCount": 4957,
+      "stargazerCount": 4958,
       "description": "XML to JavaScript object converter.",
       "primaryLanguage": "CoffeeScript",
       "starredAt": "2016-04-26T21:59:02Z"
@@ -23250,7 +23361,7 @@
     {
       "nameWithOwner": "HubSpot/youmightnotneedjquery",
       "url": "https://github.com/HubSpot/youmightnotneedjquery",
-      "stargazerCount": 14211,
+      "stargazerCount": 14213,
       "description": "",
       "primaryLanguage": "Astro",
       "starredAt": "2016-04-26T11:19:46Z"
@@ -23258,7 +23369,7 @@
     {
       "nameWithOwner": "michael-lazar/rtv",
       "url": "https://github.com/michael-lazar/rtv",
-      "stargazerCount": 4652,
+      "stargazerCount": 4651,
       "description": "Browse Reddit from your terminal",
       "primaryLanguage": "Python",
       "starredAt": "2016-04-26T06:06:15Z"
@@ -23266,7 +23377,7 @@
     {
       "nameWithOwner": "reactjs/react-router-redux",
       "url": "https://github.com/reactjs/react-router-redux",
-      "stargazerCount": 7785,
+      "stargazerCount": 7783,
       "description": "Ruthlessly simple bindings to keep react-router and redux in sync",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-04-26T05:39:03Z"
@@ -23274,7 +23385,7 @@
     {
       "nameWithOwner": "realm/realm-js",
       "url": "https://github.com/realm/realm-js",
-      "stargazerCount": 5925,
+      "stargazerCount": 5930,
       "description": " Realm is a mobile database: an alternative to SQLite & key-value stores",
       "primaryLanguage": "TypeScript",
       "starredAt": "2016-04-25T11:43:34Z"
@@ -23282,7 +23393,7 @@
     {
       "nameWithOwner": "sindresorhus/ora",
       "url": "https://github.com/sindresorhus/ora",
-      "stargazerCount": 9387,
+      "stargazerCount": 9400,
       "description": "Elegant terminal spinner",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-04-25T10:15:56Z"
@@ -23290,7 +23401,7 @@
     {
       "nameWithOwner": "shastajs/shasta",
       "url": "https://github.com/shastajs/shasta",
-      "stargazerCount": 511,
+      "stargazerCount": 512,
       "description": "Dead simple + opinionated toolkit for building redux/react applications",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-04-25T08:49:56Z"
@@ -23298,7 +23409,7 @@
     {
       "nameWithOwner": "chartjs/Chart.js",
       "url": "https://github.com/chartjs/Chart.js",
-      "stargazerCount": 66261,
+      "stargazerCount": 66315,
       "description": "Simple HTML5 Charts using the <canvas> tag",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-04-25T00:48:44Z"
@@ -23306,7 +23417,7 @@
     {
       "nameWithOwner": "billorcutt/i_dropped_my_phone_the_screen_cracked",
       "url": "https://github.com/billorcutt/i_dropped_my_phone_the_screen_cracked",
-      "stargazerCount": 463,
+      "stargazerCount": 464,
       "description": "web audio, cracked.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-04-24T11:50:32Z"
@@ -23322,7 +23433,7 @@
     {
       "nameWithOwner": "kriasoft/react-starter-kit",
       "url": "https://github.com/kriasoft/react-starter-kit",
-      "stargazerCount": 22985,
+      "stargazerCount": 23017,
       "description": "Modern React starter kit with Bun, TypeScript, Tailwind CSS, tRPC, and Cloudflare Workers. Production-ready monorepo for building fast web apps.",
       "primaryLanguage": "TypeScript",
       "starredAt": "2016-04-22T07:24:54Z"
@@ -23330,7 +23441,7 @@
     {
       "nameWithOwner": "mrmrs/colors",
       "url": "https://github.com/mrmrs/colors",
-      "stargazerCount": 9341,
+      "stargazerCount": 9342,
       "description": "Smarter defaults for colors on the web.",
       "primaryLanguage": "CSS",
       "starredAt": "2016-04-22T05:27:06Z"
@@ -23338,7 +23449,7 @@
     {
       "nameWithOwner": "joshbuchea/HEAD",
       "url": "https://github.com/joshbuchea/HEAD",
-      "stargazerCount": 30191,
+      "stargazerCount": 30200,
       "description": "A simple guide to HTML <head> elements",
       "primaryLanguage": null,
       "starredAt": "2016-04-22T04:41:35Z"
@@ -23354,7 +23465,7 @@
     {
       "nameWithOwner": "elrumordelaluz/csshake",
       "url": "https://github.com/elrumordelaluz/csshake",
-      "stargazerCount": 4881,
+      "stargazerCount": 4882,
       "description": "CSS classes to move your DOM!",
       "primaryLanguage": "SCSS",
       "starredAt": "2016-04-21T01:07:13Z"
@@ -23378,7 +23489,7 @@
     {
       "nameWithOwner": "hapijs/hapi",
       "url": "https://github.com/hapijs/hapi",
-      "stargazerCount": 14707,
+      "stargazerCount": 14714,
       "description": "The Simple, Secure Framework Developers Trust",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-04-20T10:21:47Z"
@@ -23386,7 +23497,7 @@
     {
       "nameWithOwner": "koajs/koa",
       "url": "https://github.com/koajs/koa",
-      "stargazerCount": 35582,
+      "stargazerCount": 35578,
       "description": "Expressive middleware for node.js using ES2017 async functions",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-04-20T10:20:29Z"
@@ -23410,7 +23521,7 @@
     {
       "nameWithOwner": "minbrowser/min",
       "url": "https://github.com/minbrowser/min",
-      "stargazerCount": 8540,
+      "stargazerCount": 8565,
       "description": "A fast, minimal browser that protects your privacy",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-04-20T04:56:28Z"
@@ -23434,7 +23545,7 @@
     {
       "nameWithOwner": "dleitee/strman",
       "url": "https://github.com/dleitee/strman",
-      "stargazerCount": 2008,
+      "stargazerCount": 2007,
       "description": "🏗A Javascript string manipulation library.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-04-19T08:27:42Z"
@@ -23450,7 +23561,7 @@
     {
       "nameWithOwner": "petehunt/webpack-howto",
       "url": "https://github.com/petehunt/webpack-howto",
-      "stargazerCount": 10067,
+      "stargazerCount": 10065,
       "description": "",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-04-17T11:20:45Z"
@@ -23458,7 +23569,7 @@
     {
       "nameWithOwner": "petehunt/react-howto",
       "url": "https://github.com/petehunt/react-howto",
-      "stargazerCount": 11594,
+      "stargazerCount": 11593,
       "description": "Your guide to the (sometimes overwhelming!) React ecosystem.",
       "primaryLanguage": null,
       "starredAt": "2016-04-17T11:18:52Z"
@@ -23474,7 +23585,7 @@
     {
       "nameWithOwner": "hjson/hjson",
       "url": "https://github.com/hjson/hjson",
-      "stargazerCount": 2740,
+      "stargazerCount": 2742,
       "description": "Hjson, a user interface for JSON",
       "primaryLanguage": "HTML",
       "starredAt": "2016-04-16T06:18:19Z"
@@ -23482,7 +23593,7 @@
     {
       "nameWithOwner": "parse-community/parse-dashboard",
       "url": "https://github.com/parse-community/parse-dashboard",
-      "stargazerCount": 3766,
+      "stargazerCount": 3774,
       "description": "A dashboard for managing Parse Server",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-04-16T03:40:07Z"
@@ -23490,7 +23601,7 @@
     {
       "nameWithOwner": "parse-community/parse-server",
       "url": "https://github.com/parse-community/parse-server",
-      "stargazerCount": 21236,
+      "stargazerCount": 21245,
       "description": "Parse Server for Node.js / Express",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-04-16T03:39:08Z"
@@ -23498,7 +23609,7 @@
     {
       "nameWithOwner": "rt2zz/redux-persist",
       "url": "https://github.com/rt2zz/redux-persist",
-      "stargazerCount": 13010,
+      "stargazerCount": 13007,
       "description": "persist and rehydrate a redux store",
       "primaryLanguage": "TypeScript",
       "starredAt": "2016-04-16T03:18:05Z"
@@ -23506,7 +23617,7 @@
     {
       "nameWithOwner": "markerikson/react-redux-links",
       "url": "https://github.com/markerikson/react-redux-links",
-      "stargazerCount": 22626,
+      "stargazerCount": 22621,
       "description": "Curated tutorial and resource links I've collected on React, Redux, ES6, and more",
       "primaryLanguage": null,
       "starredAt": "2016-04-15T23:11:35Z"
@@ -23514,7 +23625,7 @@
     {
       "nameWithOwner": "jemise111/react-native-swipe-list-view",
       "url": "https://github.com/jemise111/react-native-swipe-list-view",
-      "stargazerCount": 2803,
+      "stargazerCount": 2806,
       "description": "A React Native ListView component with rows that swipe open and closed",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-04-15T22:08:04Z"
@@ -23522,7 +23633,7 @@
     {
       "nameWithOwner": "alda-lang/alda",
       "url": "https://github.com/alda-lang/alda",
-      "stargazerCount": 5769,
+      "stargazerCount": 5771,
       "description": "A music programming language for musicians. :notes:",
       "primaryLanguage": "Go",
       "starredAt": "2016-04-15T09:10:42Z"
@@ -23562,7 +23673,7 @@
     {
       "nameWithOwner": "pagekit/pagekit",
       "url": "https://github.com/pagekit/pagekit",
-      "stargazerCount": 5507,
+      "stargazerCount": 5508,
       "description": "Pagekit CMS",
       "primaryLanguage": "PHP",
       "starredAt": "2016-04-14T23:31:29Z"
@@ -23570,7 +23681,7 @@
     {
       "nameWithOwner": "remix-run/react-router",
       "url": "https://github.com/remix-run/react-router",
-      "stargazerCount": 55241,
+      "stargazerCount": 55287,
       "description": "Declarative routing for React",
       "primaryLanguage": "TypeScript",
       "starredAt": "2016-04-14T01:38:59Z"
@@ -23578,7 +23689,7 @@
     {
       "nameWithOwner": "fbsamples/f8app",
       "url": "https://github.com/fbsamples/f8app",
-      "stargazerCount": 13959,
+      "stargazerCount": 13958,
       "description": "Source code of the official F8 app of 2017, powered by React Native and other Facebook open source projects.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-04-13T21:35:45Z"
@@ -23594,7 +23705,7 @@
     {
       "nameWithOwner": "microsoft/react-native-windows",
       "url": "https://github.com/microsoft/react-native-windows",
-      "stargazerCount": 16915,
+      "stargazerCount": 16930,
       "description": "A framework for building native Windows apps with React.",
       "primaryLanguage": "C++",
       "starredAt": "2016-04-13T20:40:39Z"
@@ -23602,7 +23713,7 @@
     {
       "nameWithOwner": "searchkit/searchkit",
       "url": "https://github.com/searchkit/searchkit",
-      "stargazerCount": 4826,
+      "stargazerCount": 4827,
       "description": "React + Vue Search UI for Elasticsearch & Opensearch. Compatible with Algolia's Instantsearch and Autocomplete components.",
       "primaryLanguage": "TypeScript",
       "starredAt": "2016-04-13T07:36:45Z"
@@ -23610,7 +23721,7 @@
     {
       "nameWithOwner": "nkbt/react-copy-to-clipboard",
       "url": "https://github.com/nkbt/react-copy-to-clipboard",
-      "stargazerCount": 2362,
+      "stargazerCount": 2364,
       "description": "Copy-to-clipboard React component",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-04-13T04:03:50Z"
@@ -23618,7 +23729,7 @@
     {
       "nameWithOwner": "react-icons/react-icons",
       "url": "https://github.com/react-icons/react-icons",
-      "stargazerCount": 12217,
+      "stargazerCount": 12229,
       "description": "svg react icons of popular icon packs",
       "primaryLanguage": "TypeScript",
       "starredAt": "2016-04-13T04:03:07Z"
@@ -23626,7 +23737,7 @@
     {
       "nameWithOwner": "astralapp/astral",
       "url": "https://github.com/astralapp/astral",
-      "stargazerCount": 3365,
+      "stargazerCount": 3370,
       "description": "Organize Your GitHub Stars With Ease",
       "primaryLanguage": "PHP",
       "starredAt": "2016-04-12T06:40:11Z"
@@ -23642,7 +23753,7 @@
     {
       "nameWithOwner": "PrismJS/prism",
       "url": "https://github.com/PrismJS/prism",
-      "stargazerCount": 12707,
+      "stargazerCount": 12721,
       "description": "Lightweight, robust, elegant syntax highlighting.",
       "primaryLanguage": "TypeScript",
       "starredAt": "2016-04-12T03:54:54Z"
@@ -23666,7 +23777,7 @@
     {
       "nameWithOwner": "sindresorhus/awesome",
       "url": "https://github.com/sindresorhus/awesome",
-      "stargazerCount": 384882,
+      "stargazerCount": 388446,
       "description": "😎 Awesome lists about all kinds of interesting topics",
       "primaryLanguage": null,
       "starredAt": "2016-04-11T00:49:12Z"
@@ -23674,7 +23785,7 @@
     {
       "nameWithOwner": "philipwalton/flexbugs",
       "url": "https://github.com/philipwalton/flexbugs",
-      "stargazerCount": 13606,
+      "stargazerCount": 13604,
       "description": "A community-curated list of flexbox issues and cross-browser workarounds for them.",
       "primaryLanguage": null,
       "starredAt": "2016-04-11T00:02:51Z"
@@ -23682,7 +23793,7 @@
     {
       "nameWithOwner": "enaqx/awesome-react",
       "url": "https://github.com/enaqx/awesome-react",
-      "stargazerCount": 69055,
+      "stargazerCount": 69192,
       "description": "A collection of awesome things regarding React ecosystem",
       "primaryLanguage": null,
       "starredAt": "2016-04-10T21:21:13Z"
@@ -23714,7 +23825,7 @@
     {
       "nameWithOwner": "react-dropzone/react-dropzone",
       "url": "https://github.com/react-dropzone/react-dropzone",
-      "stargazerCount": 10854,
+      "stargazerCount": 10865,
       "description": "Simple HTML5 drag-drop zone with React.js.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-04-07T23:28:24Z"
@@ -23722,7 +23833,7 @@
     {
       "nameWithOwner": "versionpress/versionpress",
       "url": "https://github.com/versionpress/versionpress",
-      "stargazerCount": 2597,
+      "stargazerCount": 2599,
       "description": "Git-based version control for WordPress. Whoa!",
       "primaryLanguage": "PHP",
       "starredAt": "2016-04-06T23:13:02Z"
@@ -23730,7 +23841,7 @@
     {
       "nameWithOwner": "floating-ui/floating-ui",
       "url": "https://github.com/floating-ui/floating-ui",
-      "stargazerCount": 31446,
+      "stargazerCount": 31470,
       "description": "A JavaScript library to position floating elements and create interactions for them.",
       "primaryLanguage": "TypeScript",
       "starredAt": "2016-04-06T22:55:00Z"
@@ -23738,7 +23849,7 @@
     {
       "nameWithOwner": "typicode/hotel",
       "url": "https://github.com/typicode/hotel",
-      "stargazerCount": 9991,
+      "stargazerCount": 9990,
       "description": "🏩 A simple process manager for developers. Start apps from your browser and access them using local domains",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-04-06T04:52:53Z"
@@ -23762,7 +23873,7 @@
     {
       "nameWithOwner": "kosmetism/react-soundplayer",
       "url": "https://github.com/kosmetism/react-soundplayer",
-      "stargazerCount": 1460,
+      "stargazerCount": 1459,
       "description": "📻 Create custom web audio players with React",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-04-04T02:57:04Z"
@@ -23770,7 +23881,7 @@
     {
       "nameWithOwner": "storybookjs/storybook",
       "url": "https://github.com/storybookjs/storybook",
-      "stargazerCount": 87301,
+      "stargazerCount": 87398,
       "description": "Storybook is the industry standard workshop for building, documenting, and testing UI components in isolation",
       "primaryLanguage": "TypeScript",
       "starredAt": "2016-04-04T01:02:02Z"
@@ -23778,7 +23889,7 @@
     {
       "nameWithOwner": "howdyai/botkit",
       "url": "https://github.com/howdyai/botkit",
-      "stargazerCount": 11563,
+      "stargazerCount": 11561,
       "description": "Botkit is an open source developer tool for building chat bots, apps and custom integrations for major messaging platforms.",
       "primaryLanguage": "TypeScript",
       "starredAt": "2016-04-01T04:32:42Z"
@@ -23794,7 +23905,7 @@
     {
       "nameWithOwner": "visgl/react-map-gl",
       "url": "https://github.com/visgl/react-map-gl",
-      "stargazerCount": 8178,
+      "stargazerCount": 8191,
       "description": "React friendly API wrapper around MapboxGL JS",
       "primaryLanguage": "TypeScript",
       "starredAt": "2016-04-01T03:12:14Z"
@@ -23802,7 +23913,7 @@
     {
       "nameWithOwner": "jamiebuilds/spectacle-code-slide",
       "url": "https://github.com/jamiebuilds/spectacle-code-slide",
-      "stargazerCount": 4156,
+      "stargazerCount": 4157,
       "description": ":metal: Present code with style",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-04-01T03:08:33Z"
@@ -23826,7 +23937,7 @@
     {
       "nameWithOwner": "public-apis/public-apis",
       "url": "https://github.com/public-apis/public-apis",
-      "stargazerCount": 357633,
+      "stargazerCount": 358760,
       "description": "A collective list of free APIs",
       "primaryLanguage": "Python",
       "starredAt": "2016-03-29T05:59:35Z"
@@ -23834,7 +23945,7 @@
     {
       "nameWithOwner": "katspaugh/wavesurfer.js",
       "url": "https://github.com/katspaugh/wavesurfer.js",
-      "stargazerCount": 9509,
+      "stargazerCount": 9554,
       "description": "Audio waveform player",
       "primaryLanguage": "TypeScript",
       "starredAt": "2016-03-29T04:45:44Z"
@@ -23866,7 +23977,7 @@
     {
       "nameWithOwner": "pronamic/advanced-custom-fields-pro",
       "url": "https://github.com/pronamic/advanced-custom-fields-pro",
-      "stargazerCount": 1302,
+      "stargazerCount": 1303,
       "description": "Advanced Custom Fields Pro, Git-ified. Automatically synced via GitHub Actions! This repository is just a mirror of the Advanced Custom Fields Pro plugin. Please do not send pull requests and issues.",
       "primaryLanguage": "PHP",
       "starredAt": "2016-03-24T03:16:49Z"
@@ -23874,7 +23985,7 @@
     {
       "nameWithOwner": "scottjehl/picturefill",
       "url": "https://github.com/scottjehl/picturefill",
-      "stargazerCount": 9849,
+      "stargazerCount": 9848,
       "description": "A responsive image polyfill for <picture>, srcset, sizes, and more",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-03-23T04:08:01Z"
@@ -23882,7 +23993,7 @@
     {
       "nameWithOwner": "gulp-sourcemaps/gulp-sourcemaps",
       "url": "https://github.com/gulp-sourcemaps/gulp-sourcemaps",
-      "stargazerCount": 1102,
+      "stargazerCount": 1101,
       "description": "Sourcemap support for gulpjs.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-03-23T01:40:45Z"
@@ -23890,7 +24001,7 @@
     {
       "nameWithOwner": "babel/gulp-babel",
       "url": "https://github.com/babel/gulp-babel",
-      "stargazerCount": 1316,
+      "stargazerCount": 1317,
       "description": "Gulp plugin for Babel",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-03-23T01:17:39Z"
@@ -23898,7 +24009,7 @@
     {
       "nameWithOwner": "necolas/normalize.css",
       "url": "https://github.com/necolas/normalize.css",
-      "stargazerCount": 53311,
+      "stargazerCount": 53333,
       "description": "A modern alternative to CSS resets",
       "primaryLanguage": "CSS",
       "starredAt": "2016-03-21T02:36:02Z"
@@ -23930,7 +24041,7 @@
     {
       "nameWithOwner": "negomi/react-burger-menu",
       "url": "https://github.com/negomi/react-burger-menu",
-      "stargazerCount": 5100,
+      "stargazerCount": 5099,
       "description": ":hamburger: An off-canvas sidebar component with a collection of effects and styles using CSS transitions and SVG path animations",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-03-11T04:05:05Z"
@@ -23946,7 +24057,7 @@
     {
       "nameWithOwner": "Varying-Vagrant-Vagrants/VVV",
       "url": "https://github.com/Varying-Vagrant-Vagrants/VVV",
-      "stargazerCount": 4541,
+      "stargazerCount": 4540,
       "description": "An open source Vagrant configuration for developing with WordPress",
       "primaryLanguage": "Shell",
       "starredAt": "2016-03-09T06:28:10Z"
@@ -23962,7 +24073,7 @@
     {
       "nameWithOwner": "Pikaday/Pikaday",
       "url": "https://github.com/Pikaday/Pikaday",
-      "stargazerCount": 8073,
+      "stargazerCount": 8075,
       "description": "A refreshing JavaScript Datepicker — lightweight, no dependencies, modular CSS",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-03-08T00:20:17Z"
@@ -24002,7 +24113,7 @@
     {
       "nameWithOwner": "jonsuh/hamburgers",
       "url": "https://github.com/jonsuh/hamburgers",
-      "stargazerCount": 7093,
+      "stargazerCount": 7092,
       "description": "Tasty CSS-animated Hamburgers",
       "primaryLanguage": "SCSS",
       "starredAt": "2016-03-04T22:33:20Z"
@@ -24010,7 +24121,7 @@
     {
       "nameWithOwner": "certbot/certbot",
       "url": "https://github.com/certbot/certbot",
-      "stargazerCount": 32347,
+      "stargazerCount": 32361,
       "description": "Certbot is EFF's tool to obtain certs from Let's Encrypt and (optionally) auto-enable HTTPS on your server.  It can also act as a client for any other CA that uses the ACME protocol.",
       "primaryLanguage": "Python",
       "starredAt": "2016-03-03T01:49:29Z"
@@ -24018,7 +24129,7 @@
     {
       "nameWithOwner": "cubiq/iscroll",
       "url": "https://github.com/cubiq/iscroll",
-      "stargazerCount": 12856,
+      "stargazerCount": 12855,
       "description": "Smooth scrolling for the web",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-03-03T00:16:30Z"
@@ -24026,7 +24137,7 @@
     {
       "nameWithOwner": "naomiaro/waveform-playlist",
       "url": "https://github.com/naomiaro/waveform-playlist",
-      "stargazerCount": 1530,
+      "stargazerCount": 1537,
       "description": "Multitrack Web Audio editor and player with canvas waveform preview. Set cues, fades and shift multiple tracks in time. Record audio tracks or provide audio annotations. Export your mix to AudioBuffer or WAV! Add effects from Tone.js. Project inspired by Audacity.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-02-29T08:35:25Z"
@@ -24050,7 +24161,7 @@
     {
       "nameWithOwner": "react-native-image-picker/react-native-image-picker",
       "url": "https://github.com/react-native-image-picker/react-native-image-picker",
-      "stargazerCount": 8569,
+      "stargazerCount": 8574,
       "description": ":sunrise_over_mountains: A React Native module that allows you to use native UI to select media from the device library or directly from the camera.",
       "primaryLanguage": "Java",
       "starredAt": "2016-02-29T00:46:11Z"
@@ -24066,7 +24177,7 @@
     {
       "nameWithOwner": "lovell/sharp",
       "url": "https://github.com/lovell/sharp",
-      "stargazerCount": 30868,
+      "stargazerCount": 30911,
       "description": "High performance Node.js image processing, the fastest module to resize JPEG, PNG, WebP, AVIF and TIFF images. Uses the libvips library.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-02-26T11:12:52Z"
@@ -24074,7 +24185,7 @@
     {
       "nameWithOwner": "mahnunchik/gulp-responsive",
       "url": "https://github.com/mahnunchik/gulp-responsive",
-      "stargazerCount": 499,
+      "stargazerCount": 500,
       "description": "gulp-responsive generates images at different sizes",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-02-26T11:12:50Z"
@@ -24098,7 +24209,7 @@
     {
       "nameWithOwner": "metafizzy/packery",
       "url": "https://github.com/metafizzy/packery",
-      "stargazerCount": 4220,
+      "stargazerCount": 4221,
       "description": ":bento: Gapless, draggable grid layouts",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-02-25T23:17:01Z"
@@ -24106,7 +24217,7 @@
     {
       "nameWithOwner": "dthree/vorpal",
       "url": "https://github.com/dthree/vorpal",
-      "stargazerCount": 5640,
+      "stargazerCount": 5641,
       "description": "Node's framework for interactive CLIs",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-02-25T23:15:31Z"
@@ -24114,7 +24225,7 @@
     {
       "nameWithOwner": "MoOx/postcss-cssnext",
       "url": "https://github.com/MoOx/postcss-cssnext",
-      "stargazerCount": 5289,
+      "stargazerCount": 5288,
       "description": "`postcss-cssnext` has been deprecated in favor of `postcss-preset-env`.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-02-25T02:48:55Z"
@@ -24122,7 +24233,7 @@
     {
       "nameWithOwner": "google/material-design-lite",
       "url": "https://github.com/google/material-design-lite",
-      "stargazerCount": 32276,
+      "stargazerCount": 32268,
       "description": "Material Design Components in HTML/CSS/JS",
       "primaryLanguage": "HTML",
       "starredAt": "2016-02-24T23:25:14Z"
@@ -24130,7 +24241,7 @@
     {
       "nameWithOwner": "kriasoft/react-firebase-starter",
       "url": "https://github.com/kriasoft/react-firebase-starter",
-      "stargazerCount": 4520,
+      "stargazerCount": 4518,
       "description": "Boilerplate (seed) project for creating web apps with React.js, GraphQL.js and Relay",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-02-24T12:44:42Z"
@@ -24146,7 +24257,7 @@
     {
       "nameWithOwner": "tastejs/awesome-app-ideas",
       "url": "https://github.com/tastejs/awesome-app-ideas",
-      "stargazerCount": 5479,
+      "stargazerCount": 5480,
       "description": "List of awesome app ideas",
       "primaryLanguage": null,
       "starredAt": "2016-02-24T10:34:08Z"
@@ -24162,7 +24273,7 @@
     {
       "nameWithOwner": "gre/gl-react",
       "url": "https://github.com/gre/gl-react",
-      "stargazerCount": 2965,
+      "stargazerCount": 2967,
       "description": "gl-react – React library to write and compose WebGL shaders",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-02-24T08:02:23Z"
@@ -24186,7 +24297,7 @@
     {
       "nameWithOwner": "AllThingsSmitty/css-protips",
       "url": "https://github.com/AllThingsSmitty/css-protips",
-      "stargazerCount": 29285,
+      "stargazerCount": 29314,
       "description": "⚡️ A collection of tips to help take your CSS skills pro 🦾",
       "primaryLanguage": null,
       "starredAt": "2016-02-23T23:11:11Z"
@@ -24194,7 +24305,7 @@
     {
       "nameWithOwner": "codrops/Animocons",
       "url": "https://github.com/codrops/Animocons",
-      "stargazerCount": 1548,
+      "stargazerCount": 1547,
       "description": "Animated icons powered by the motion graphics library mo.js by Oleg Solomka. Inspiration comes from the Dribbble shot [\"Like Animation\"](https://dribbble.com/shots/2527200-Like-Animation) by Daryl Ginn.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-02-23T23:09:22Z"
@@ -24218,7 +24329,7 @@
     {
       "nameWithOwner": "moroshko/react-autosuggest",
       "url": "https://github.com/moroshko/react-autosuggest",
-      "stargazerCount": 5964,
+      "stargazerCount": 5963,
       "description": "WAI-ARIA compliant React autosuggest component",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-02-23T09:35:58Z"
@@ -24234,7 +24345,7 @@
     {
       "nameWithOwner": "remarkjs/react-markdown",
       "url": "https://github.com/remarkjs/react-markdown",
-      "stargazerCount": 14689,
+      "stargazerCount": 14736,
       "description": "Markdown component for React",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-02-23T08:53:11Z"
@@ -24242,7 +24353,7 @@
     {
       "nameWithOwner": "nfl/react-helmet",
       "url": "https://github.com/nfl/react-helmet",
-      "stargazerCount": 17481,
+      "stargazerCount": 17484,
       "description": "A document head manager for React",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-02-23T06:20:17Z"
@@ -24258,7 +24369,7 @@
     {
       "nameWithOwner": "jaredpalmer/razzle",
       "url": "https://github.com/jaredpalmer/razzle",
-      "stargazerCount": 11092,
+      "stargazerCount": 11090,
       "description": "✨ Create server-rendered universal JavaScript applications with no configuration",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-02-23T06:09:48Z"
@@ -24274,7 +24385,7 @@
     {
       "nameWithOwner": "Dogfalo/materialize",
       "url": "https://github.com/Dogfalo/materialize",
-      "stargazerCount": 38954,
+      "stargazerCount": 38958,
       "description": "Materialize, a CSS Framework based on Material Design",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-02-23T04:33:33Z"
@@ -24282,7 +24393,7 @@
     {
       "nameWithOwner": "facebookarchive/draft-js",
       "url": "https://github.com/facebookarchive/draft-js",
-      "stargazerCount": 22668,
+      "stargazerCount": 22666,
       "description": "A React framework for building text editors.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-02-23T02:46:53Z"
@@ -24306,7 +24417,7 @@
     {
       "nameWithOwner": "nodejs/node",
       "url": "https://github.com/nodejs/node",
-      "stargazerCount": 112328,
+      "stargazerCount": 112494,
       "description": "Node.js JavaScript runtime ✨🐢🚀✨",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-02-22T21:02:26Z"
@@ -24346,7 +24457,7 @@
     {
       "nameWithOwner": "reduxjs/redux-devtools",
       "url": "https://github.com/reduxjs/redux-devtools",
-      "stargazerCount": 14223,
+      "stargazerCount": 14235,
       "description": "DevTools for Redux with hot reloading, action replay, and customizable UI",
       "primaryLanguage": "TypeScript",
       "starredAt": "2016-02-21T21:34:52Z"
@@ -24354,7 +24465,7 @@
     {
       "nameWithOwner": "formatjs/formatjs",
       "url": "https://github.com/formatjs/formatjs",
-      "stargazerCount": 14538,
+      "stargazerCount": 14552,
       "description": "The monorepo home to all of the FormatJS related libraries, most notably react-intl.",
       "primaryLanguage": "TypeScript",
       "starredAt": "2016-02-21T13:43:45Z"
@@ -24370,7 +24481,7 @@
     {
       "nameWithOwner": "reactjs/react-router-tutorial",
       "url": "https://github.com/reactjs/react-router-tutorial",
-      "stargazerCount": 5511,
+      "stargazerCount": 5512,
       "description": "",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-02-20T12:29:23Z"
@@ -24386,7 +24497,7 @@
     {
       "nameWithOwner": "PaulLeCam/react-leaflet",
       "url": "https://github.com/PaulLeCam/react-leaflet",
-      "stargazerCount": 5417,
+      "stargazerCount": 5428,
       "description": "React components for Leaflet maps",
       "primaryLanguage": "TypeScript",
       "starredAt": "2016-02-20T02:09:00Z"
@@ -24394,7 +24505,7 @@
     {
       "nameWithOwner": "tomchentw/react-google-maps",
       "url": "https://github.com/tomchentw/react-google-maps",
-      "stargazerCount": 4627,
+      "stargazerCount": 4628,
       "description": "React.js Google Maps integration component",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-02-20T01:05:12Z"
@@ -24410,7 +24521,7 @@
     {
       "nameWithOwner": "axios/axios",
       "url": "https://github.com/axios/axios",
-      "stargazerCount": 107279,
+      "stargazerCount": 107342,
       "description": "Promise based HTTP client for the browser and node.js",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-02-19T12:58:33Z"
@@ -24434,7 +24545,7 @@
     {
       "nameWithOwner": "metafizzy/flickity",
       "url": "https://github.com/metafizzy/flickity",
-      "stargazerCount": 7582,
+      "stargazerCount": 7580,
       "description": ":leaves: Touch, responsive, flickable carousels",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-02-19T10:32:12Z"
@@ -24442,7 +24553,7 @@
     {
       "nameWithOwner": "desandro/classie",
       "url": "https://github.com/desandro/classie",
-      "stargazerCount": 864,
+      "stargazerCount": 863,
       "description": ":tophat: class helper functions",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-02-19T10:19:56Z"
@@ -24450,7 +24561,7 @@
     {
       "nameWithOwner": "desandro/imagesloaded",
       "url": "https://github.com/desandro/imagesloaded",
-      "stargazerCount": 8884,
+      "stargazerCount": 8886,
       "description": ":camera: JavaScript is all like \"You images done yet or what?\"",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-02-19T10:19:54Z"
@@ -24474,7 +24585,7 @@
     {
       "nameWithOwner": "FormidableLabs/spectacle",
       "url": "https://github.com/FormidableLabs/spectacle",
-      "stargazerCount": 9969,
+      "stargazerCount": 9973,
       "description": "A React-based library for creating sleek presentations using JSX syntax that gives you the ability to live demo your code.",
       "primaryLanguage": "TypeScript",
       "starredAt": "2016-02-19T09:44:45Z"
@@ -24482,7 +24593,7 @@
     {
       "nameWithOwner": "reduxjs/react-redux",
       "url": "https://github.com/reduxjs/react-redux",
-      "stargazerCount": 23489,
+      "stargazerCount": 23493,
       "description": "Official React bindings for Redux",
       "primaryLanguage": "TypeScript",
       "starredAt": "2016-02-19T09:43:27Z"
@@ -24490,7 +24601,7 @@
     {
       "nameWithOwner": "rstacruz/nprogress",
       "url": "https://github.com/rstacruz/nprogress",
-      "stargazerCount": 26352,
+      "stargazerCount": 26348,
       "description": "For slim progress bars like on YouTube, Medium, etc",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-02-19T09:37:27Z"
@@ -24498,7 +24609,7 @@
     {
       "nameWithOwner": "facebook/react",
       "url": "https://github.com/facebook/react",
-      "stargazerCount": 237546,
+      "stargazerCount": 237816,
       "description": "The library for web and native user interfaces.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-02-19T09:35:36Z"
@@ -24506,7 +24617,7 @@
     {
       "nameWithOwner": "mui/material-ui",
       "url": "https://github.com/mui/material-ui",
-      "stargazerCount": 96202,
+      "stargazerCount": 96281,
       "description": "Material UI: Comprehensive React component library that implements Google's Material Design. Free forever.",
       "primaryLanguage": "TypeScript",
       "starredAt": "2016-02-19T09:33:02Z"
@@ -24522,7 +24633,7 @@
     {
       "nameWithOwner": "chenglou/react-motion",
       "url": "https://github.com/chenglou/react-motion",
-      "stargazerCount": 21776,
+      "stargazerCount": 21765,
       "description": "A spring that solves your animation problems.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-02-19T09:26:31Z"
@@ -24546,7 +24657,7 @@
     {
       "nameWithOwner": "JedWatson/classnames",
       "url": "https://github.com/JedWatson/classnames",
-      "stargazerCount": 17767,
+      "stargazerCount": 17772,
       "description": "A simple javascript utility for conditionally joining classNames together",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-02-19T09:18:05Z"
@@ -24554,7 +24665,7 @@
     {
       "nameWithOwner": "css-modules/css-modules",
       "url": "https://github.com/css-modules/css-modules",
-      "stargazerCount": 17899,
+      "stargazerCount": 17904,
       "description": "Documentation about css-modules",
       "primaryLanguage": null,
       "starredAt": "2016-02-19T09:17:59Z"
@@ -24562,7 +24673,7 @@
     {
       "nameWithOwner": "JedWatson/react-select",
       "url": "https://github.com/JedWatson/react-select",
-      "stargazerCount": 27986,
+      "stargazerCount": 27987,
       "description": "The Select Component for React.js",
       "primaryLanguage": "TypeScript",
       "starredAt": "2016-02-19T09:14:54Z"
@@ -24570,7 +24681,7 @@
     {
       "nameWithOwner": "sindresorhus/gulp-autoprefixer",
       "url": "https://github.com/sindresorhus/gulp-autoprefixer",
-      "stargazerCount": 690,
+      "stargazerCount": 689,
       "description": "Prefix CSS",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-02-19T06:49:52Z"
@@ -24578,7 +24689,7 @@
     {
       "nameWithOwner": "BrowserSync/browser-sync",
       "url": "https://github.com/BrowserSync/browser-sync",
-      "stargazerCount": 12253,
+      "stargazerCount": 12256,
       "description": "Keep multiple browsers & devices in sync when building websites. https://browsersync.io",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-02-19T04:00:18Z"
@@ -24586,7 +24697,7 @@
     {
       "nameWithOwner": "floatdrop/gulp-plumber",
       "url": "https://github.com/floatdrop/gulp-plumber",
-      "stargazerCount": 803,
+      "stargazerCount": 802,
       "description": "Fixing Node pipes",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-02-19T03:53:41Z"
@@ -24610,7 +24721,7 @@
     {
       "nameWithOwner": "sass/node-sass",
       "url": "https://github.com/sass/node-sass",
-      "stargazerCount": 8496,
+      "stargazerCount": 8497,
       "description": ":rainbow: Node.js bindings to libsass",
       "primaryLanguage": "C++",
       "starredAt": "2016-02-19T02:06:13Z"
@@ -24618,7 +24729,7 @@
     {
       "nameWithOwner": "lipis/flag-icons",
       "url": "https://github.com/lipis/flag-icons",
-      "stargazerCount": 11424,
+      "stargazerCount": 11453,
       "description": ":flags: A curated collection of all country flags in SVG — plus the CSS for easier integration",
       "primaryLanguage": "HTML",
       "starredAt": "2016-02-19T00:35:23Z"
@@ -24626,7 +24737,7 @@
     {
       "nameWithOwner": "Hashnode/mern-starter",
       "url": "https://github.com/Hashnode/mern-starter",
-      "stargazerCount": 5165,
+      "stargazerCount": 5164,
       "description": "⛔️ DEPRECATED - Boilerplate for getting started with MERN stack",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-02-18T23:43:33Z"
@@ -24634,7 +24745,7 @@
     {
       "nameWithOwner": "callmecavs/bricks.js",
       "url": "https://github.com/callmecavs/bricks.js",
-      "stargazerCount": 4682,
+      "stargazerCount": 4683,
       "description": "A blazing fast masonry layout generator for fixed width elements.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-02-18T13:52:56Z"
@@ -24666,7 +24777,7 @@
     {
       "nameWithOwner": "lelandrichardson/react-native-parallax-view",
       "url": "https://github.com/lelandrichardson/react-native-parallax-view",
-      "stargazerCount": 1291,
+      "stargazerCount": 1292,
       "description": "Parallax view for vertical scrollview/listviews with a header image and header content",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-02-16T08:10:19Z"
@@ -24690,7 +24801,7 @@
     {
       "nameWithOwner": "leecade/react-native-swiper",
       "url": "https://github.com/leecade/react-native-swiper",
-      "stargazerCount": 10474,
+      "stargazerCount": 10476,
       "description": "The best Swiper component for React Native.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-02-15T03:02:59Z"
@@ -24722,7 +24833,7 @@
     {
       "nameWithOwner": "oblador/react-native-animatable",
       "url": "https://github.com/oblador/react-native-animatable",
-      "stargazerCount": 9925,
+      "stargazerCount": 9932,
       "description": "Standard set of easy to use animations and declarative transitions for React Native",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-02-13T00:45:55Z"
@@ -24730,7 +24841,7 @@
     {
       "nameWithOwner": "oblador/react-native-vector-icons",
       "url": "https://github.com/oblador/react-native-vector-icons",
-      "stargazerCount": 17678,
+      "stargazerCount": 17687,
       "description": "Customizable Icons for React Native with support for image source and full styling.",
       "primaryLanguage": "TypeScript",
       "starredAt": "2016-02-12T06:35:43Z"
@@ -24754,7 +24865,7 @@
     {
       "nameWithOwner": "inorganik/countUp.js",
       "url": "https://github.com/inorganik/countUp.js",
-      "stargazerCount": 8133,
+      "stargazerCount": 8137,
       "description": "Animates a numerical value by counting to it",
       "primaryLanguage": "TypeScript",
       "starredAt": "2016-02-11T22:48:46Z"
@@ -24762,7 +24873,7 @@
     {
       "nameWithOwner": "bramstein/fontfaceobserver",
       "url": "https://github.com/bramstein/fontfaceobserver",
-      "stargazerCount": 4321,
+      "stargazerCount": 4325,
       "description": "Webfont loading. Simple, small, and efficient.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-02-11T07:23:11Z"
@@ -24778,7 +24889,7 @@
     {
       "nameWithOwner": "tholman/cursor-effects",
       "url": "https://github.com/tholman/cursor-effects",
-      "stargazerCount": 3650,
+      "stargazerCount": 3661,
       "description": "Old-school cursor effects for your browser built with modern JavaScript",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-02-09T07:14:12Z"
@@ -24794,7 +24905,7 @@
     {
       "nameWithOwner": "airesvsg/acf-to-rest-api",
       "url": "https://github.com/airesvsg/acf-to-rest-api",
-      "stargazerCount": 1342,
+      "stargazerCount": 1343,
       "description": "Exposes Advanced Custom Fields Endpoints in the WordPress REST API",
       "primaryLanguage": "PHP",
       "starredAt": "2016-02-08T12:33:46Z"
@@ -24802,7 +24913,7 @@
     {
       "nameWithOwner": "times/acf-to-wp-api",
       "url": "https://github.com/times/acf-to-wp-api",
-      "stargazerCount": 204,
+      "stargazerCount": 203,
       "description": "Puts all ACF fields from posts, pages, custom post types, attachments and taxonomy terms, into the WP-API output under the 'acf' key",
       "primaryLanguage": "PHP",
       "starredAt": "2016-02-08T12:32:07Z"
@@ -24810,7 +24921,7 @@
     {
       "nameWithOwner": "jgthms/bulma",
       "url": "https://github.com/jgthms/bulma",
-      "stargazerCount": 49850,
+      "stargazerCount": 49864,
       "description": "Modern CSS framework based on Flexbox",
       "primaryLanguage": "CSS",
       "starredAt": "2016-02-08T03:14:36Z"
@@ -24834,7 +24945,7 @@
     {
       "nameWithOwner": "happypoulp/redux-tutorial",
       "url": "https://github.com/happypoulp/redux-tutorial",
-      "stargazerCount": 3752,
+      "stargazerCount": 3751,
       "description": "Learn how to use redux step by step",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-02-05T08:54:35Z"
@@ -24850,7 +24961,7 @@
     {
       "nameWithOwner": "nitaliano/react-native-mapbox-gl",
       "url": "https://github.com/nitaliano/react-native-mapbox-gl",
-      "stargazerCount": 2171,
+      "stargazerCount": 2172,
       "description": "A Mapbox GL react native module for creating custom maps",
       "primaryLanguage": "Java",
       "starredAt": "2016-02-04T06:00:26Z"
@@ -24858,7 +24969,7 @@
     {
       "nameWithOwner": "prose/prose",
       "url": "https://github.com/prose/prose",
-      "stargazerCount": 4769,
+      "stargazerCount": 4771,
       "description": "A Content Editor for GitHub.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-02-02T03:31:51Z"
@@ -24866,7 +24977,7 @@
     {
       "nameWithOwner": "keijiro/NoiseBall",
       "url": "https://github.com/keijiro/NoiseBall",
-      "stargazerCount": 297,
+      "stargazerCount": 298,
       "description": "Mesh deforming shader example (Unity)",
       "primaryLanguage": "C#",
       "starredAt": "2016-01-25T10:57:25Z"
@@ -24874,7 +24985,7 @@
     {
       "nameWithOwner": "keijiro/KvantSpray",
       "url": "https://github.com/keijiro/KvantSpray",
-      "stargazerCount": 1211,
+      "stargazerCount": 1212,
       "description": "Object instancing/particle animation system for Unity",
       "primaryLanguage": "C#",
       "starredAt": "2016-01-25T10:53:38Z"
@@ -24898,7 +25009,7 @@
     {
       "nameWithOwner": "keijiro/KinoBloom",
       "url": "https://github.com/keijiro/KinoBloom",
-      "stargazerCount": 998,
+      "stargazerCount": 1001,
       "description": "Bloom effect for Unity",
       "primaryLanguage": "C#",
       "starredAt": "2016-01-25T10:47:37Z"
@@ -24906,7 +25017,7 @@
     {
       "nameWithOwner": "react-native-maps/react-native-maps",
       "url": "https://github.com/react-native-maps/react-native-maps",
-      "stargazerCount": 15577,
+      "stargazerCount": 15591,
       "description": "React Native Mapview component for iOS + Android",
       "primaryLanguage": "TypeScript",
       "starredAt": "2016-01-24T06:10:34Z"
@@ -24954,7 +25065,7 @@
     {
       "nameWithOwner": "jashkenas/underscore",
       "url": "https://github.com/jashkenas/underscore",
-      "stargazerCount": 27389,
+      "stargazerCount": 27382,
       "description": "JavaScript's utility _ belt",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-01-08T06:29:27Z"
@@ -24962,7 +25073,7 @@
     {
       "nameWithOwner": "mojs/mojs",
       "url": "https://github.com/mojs/mojs",
-      "stargazerCount": 18632,
+      "stargazerCount": 18638,
       "description": "The motion graphics toolbelt for the web",
       "primaryLanguage": "CoffeeScript",
       "starredAt": "2016-01-08T01:09:38Z"
@@ -24978,7 +25089,7 @@
     {
       "nameWithOwner": "milligram/milligram",
       "url": "https://github.com/milligram/milligram",
-      "stargazerCount": 10238,
+      "stargazerCount": 10240,
       "description": "A minimalist CSS framework.",
       "primaryLanguage": "HTML",
       "starredAt": "2016-01-05T23:05:05Z"
@@ -24986,7 +25097,7 @@
     {
       "nameWithOwner": "KittyGiraudel/SJSJ",
       "url": "https://github.com/KittyGiraudel/SJSJ",
-      "stargazerCount": 2269,
+      "stargazerCount": 2268,
       "description": "Simplified JavaScript Jargon",
       "primaryLanguage": "HTML",
       "starredAt": "2015-12-23T22:54:45Z"
@@ -25002,7 +25113,7 @@
     {
       "nameWithOwner": "jlmakes/scrollreveal",
       "url": "https://github.com/jlmakes/scrollreveal",
-      "stargazerCount": 22519,
+      "stargazerCount": 22517,
       "description": "Animate elements as they scroll into view.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2015-12-20T01:52:10Z"
@@ -25010,7 +25121,7 @@
     {
       "nameWithOwner": "aframevr/aframe",
       "url": "https://github.com/aframevr/aframe",
-      "stargazerCount": 17269,
+      "stargazerCount": 17282,
       "description": ":a: Web framework for building virtual reality experiences.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2015-12-17T23:35:26Z"
@@ -25026,7 +25137,7 @@
     {
       "nameWithOwner": "VincentGarreau/particles.js",
       "url": "https://github.com/VincentGarreau/particles.js",
-      "stargazerCount": 29828,
+      "stargazerCount": 29852,
       "description": "A lightweight JavaScript library for creating particles",
       "primaryLanguage": "JavaScript",
       "starredAt": "2015-12-14T00:46:31Z"
@@ -25050,7 +25161,7 @@
     {
       "nameWithOwner": "babel/babel",
       "url": "https://github.com/babel/babel",
-      "stargazerCount": 43665,
+      "stargazerCount": 43666,
       "description": "🐠 Babel is a compiler for writing next generation JavaScript.",
       "primaryLanguage": "TypeScript",
       "starredAt": "2015-12-03T09:43:29Z"
@@ -25058,7 +25169,7 @@
     {
       "nameWithOwner": "GetmeUK/ContentTools",
       "url": "https://github.com/GetmeUK/ContentTools",
-      "stargazerCount": 3988,
+      "stargazerCount": 3989,
       "description": "A JS library for building WYSIWYG editors for HTML content.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2015-12-01T22:21:57Z"
@@ -25066,7 +25177,7 @@
     {
       "nameWithOwner": "Theodeus/tuna",
       "url": "https://github.com/Theodeus/tuna",
-      "stargazerCount": 1781,
+      "stargazerCount": 1782,
       "description": "An audio effects library for the Web Audio API.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2015-12-01T02:42:35Z"
@@ -25074,7 +25185,7 @@
     {
       "nameWithOwner": "callmecavs/jump.js",
       "url": "https://github.com/callmecavs/jump.js",
-      "stargazerCount": 3451,
+      "stargazerCount": 3452,
       "description": "A modern smooth scrolling library.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2015-11-30T23:58:52Z"
@@ -25090,7 +25201,7 @@
     {
       "nameWithOwner": "keystonejs/keystone-classic",
       "url": "https://github.com/keystonejs/keystone-classic",
-      "stargazerCount": 14585,
+      "stargazerCount": 14583,
       "description": "Node.js CMS and web app framework",
       "primaryLanguage": "JavaScript",
       "starredAt": "2015-11-25T03:13:54Z"
@@ -25154,7 +25265,7 @@
     {
       "nameWithOwner": "owenthereal/hacker-menu",
       "url": "https://github.com/owenthereal/hacker-menu",
-      "stargazerCount": 1004,
+      "stargazerCount": 1005,
       "description": "Hacker News Delivered to Desktop :dancers:",
       "primaryLanguage": "JavaScript",
       "starredAt": "2015-10-30T02:31:34Z"
@@ -25170,7 +25281,7 @@
     {
       "nameWithOwner": "sindresorhus/awesome-electron",
       "url": "https://github.com/sindresorhus/awesome-electron",
-      "stargazerCount": 26542,
+      "stargazerCount": 26560,
       "description": "Useful resources for creating apps with Electron",
       "primaryLanguage": null,
       "starredAt": "2015-10-29T20:56:16Z"
@@ -25186,7 +25297,7 @@
     {
       "nameWithOwner": "awesomedata/awesome-public-datasets",
       "url": "https://github.com/awesomedata/awesome-public-datasets",
-      "stargazerCount": 63858,
+      "stargazerCount": 63960,
       "description": "A topic-centric list of HQ open datasets.",
       "primaryLanguage": null,
       "starredAt": "2015-10-29T10:53:02Z"
@@ -25194,7 +25305,7 @@
     {
       "nameWithOwner": "Polymer/polymer",
       "url": "https://github.com/Polymer/polymer",
-      "stargazerCount": 22062,
+      "stargazerCount": 22059,
       "description": "Our original Web Component library.",
       "primaryLanguage": "HTML",
       "starredAt": "2015-10-29T10:34:15Z"
@@ -25218,7 +25329,7 @@
     {
       "nameWithOwner": "max-mapper/menubar",
       "url": "https://github.com/max-mapper/menubar",
-      "stargazerCount": 6736,
+      "stargazerCount": 6737,
       "description": "➖ high level way to create menubar desktop applications with electron",
       "primaryLanguage": "TypeScript",
       "starredAt": "2015-10-28T11:39:34Z"
@@ -25250,7 +25361,7 @@
     {
       "nameWithOwner": "metalsmith/metalsmith",
       "url": "https://github.com/metalsmith/metalsmith",
-      "stargazerCount": 7851,
+      "stargazerCount": 7852,
       "description": "An extremely simple, pluggable static site generator for Node.js",
       "primaryLanguage": "JavaScript",
       "starredAt": "2015-10-05T01:46:52Z"
@@ -25258,7 +25369,7 @@
     {
       "nameWithOwner": "expressjs/express",
       "url": "https://github.com/expressjs/express",
-      "stargazerCount": 67405,
+      "stargazerCount": 67457,
       "description": "Fast, unopinionated, minimalist web framework for node.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2015-10-03T11:27:13Z"
@@ -25306,7 +25417,7 @@
     {
       "nameWithOwner": "getify/You-Dont-Know-JS",
       "url": "https://github.com/getify/You-Dont-Know-JS",
-      "stargazerCount": 182772,
+      "stargazerCount": 182845,
       "description": "A book series (2 published editions) on the JS language.",
       "primaryLanguage": null,
       "starredAt": "2015-09-20T08:42:49Z"
@@ -25314,7 +25425,7 @@
     {
       "nameWithOwner": "dhg/Skeleton",
       "url": "https://github.com/dhg/Skeleton",
-      "stargazerCount": 19347,
+      "stargazerCount": 19354,
       "description": "Skeleton: A Dead Simple, Responsive Boilerplate for Mobile-Friendly Development",
       "primaryLanguage": "CSS",
       "starredAt": "2015-09-11T05:17:59Z"
@@ -25322,7 +25433,7 @@
     {
       "nameWithOwner": "dimsemenov/PhotoSwipe",
       "url": "https://github.com/dimsemenov/PhotoSwipe",
-      "stargazerCount": 24768,
+      "stargazerCount": 24786,
       "description": "JavaScript image gallery for mobile and desktop, modular, framework independent",
       "primaryLanguage": "JavaScript",
       "starredAt": "2015-08-19T04:15:35Z"

--- a/src/data/github-stars.json
+++ b/src/data/github-stars.json
@@ -59,7 +59,8 @@
     "Zig": "#ec915c"
   },
   "totalCount": 3178,
-  "fetchedAt": "2025-08-03T11:41:11.733Z",
+  "fetchedAt": "2025-08-03T11:51:39.729Z",
+  "cacheTimestamp": 1754221899729,
   "perPage": 100,
   "stars": [
     {
@@ -105,7 +106,7 @@
     {
       "nameWithOwner": "roboflow/supervision",
       "url": "https://github.com/roboflow/supervision",
-      "stargazerCount": 32958,
+      "stargazerCount": 32959,
       "description": "We write your reusable computer vision tools. 💜",
       "primaryLanguage": "Python",
       "starredAt": "2025-07-31T06:41:48Z"
@@ -129,7 +130,7 @@
     {
       "nameWithOwner": "musistudio/claude-code-router",
       "url": "https://github.com/musistudio/claude-code-router",
-      "stargazerCount": 9628,
+      "stargazerCount": 9630,
       "description": "Use Claude Code as the foundation for coding infrastructure, allowing you to decide how to interact with the model while enjoying updates from Anthropic.",
       "primaryLanguage": "TypeScript",
       "starredAt": "2025-07-29T10:46:07Z"
@@ -137,7 +138,7 @@
     {
       "nameWithOwner": "hesreallyhim/awesome-claude-code",
       "url": "https://github.com/hesreallyhim/awesome-claude-code",
-      "stargazerCount": 8385,
+      "stargazerCount": 8386,
       "description": "A curated list of awesome commands, files, and workflows for Claude Code",
       "primaryLanguage": "Python",
       "starredAt": "2025-07-28T22:20:47Z"
@@ -185,7 +186,7 @@
     {
       "nameWithOwner": "github/github-mcp-server",
       "url": "https://github.com/github/github-mcp-server",
-      "stargazerCount": 19986,
+      "stargazerCount": 19987,
       "description": "GitHub's official MCP Server",
       "primaryLanguage": "Go",
       "starredAt": "2025-07-23T23:52:04Z"
@@ -209,7 +210,7 @@
     {
       "nameWithOwner": "getAsterisk/claudia",
       "url": "https://github.com/getAsterisk/claudia",
-      "stargazerCount": 10541,
+      "stargazerCount": 10542,
       "description": "A powerful GUI app and Toolkit for Claude Code - Create custom agents, manage interactive Claude Code sessions, run secure background agents, and more.",
       "primaryLanguage": "TypeScript",
       "starredAt": "2025-07-21T01:48:14Z"
@@ -233,7 +234,7 @@
     {
       "nameWithOwner": "smtg-ai/claude-squad",
       "url": "https://github.com/smtg-ai/claude-squad",
-      "stargazerCount": 3888,
+      "stargazerCount": 3889,
       "description": "Manage multiple AI terminal agents like Claude Code, Aider, Codex, OpenCode, and Amp.",
       "primaryLanguage": "Go",
       "starredAt": "2025-07-19T23:00:17Z"
@@ -305,7 +306,7 @@
     {
       "nameWithOwner": "upstash/context7",
       "url": "https://github.com/upstash/context7",
-      "stargazerCount": 23733,
+      "stargazerCount": 23734,
       "description": "Context7 MCP Server -- Up-to-date code documentation for LLMs and AI code editors",
       "primaryLanguage": "JavaScript",
       "starredAt": "2025-07-17T22:19:15Z"
@@ -481,7 +482,7 @@
     {
       "nameWithOwner": "reflex-dev/reflex",
       "url": "https://github.com/reflex-dev/reflex",
-      "stargazerCount": 23892,
+      "stargazerCount": 23896,
       "description": "🕸️ Web apps in pure Python 🐍",
       "primaryLanguage": "Python",
       "starredAt": "2025-05-24T03:43:04Z"
@@ -569,7 +570,7 @@
     {
       "nameWithOwner": "openai/codex",
       "url": "https://github.com/openai/codex",
-      "stargazerCount": 31713,
+      "stargazerCount": 31714,
       "description": "Lightweight coding agent that runs in your terminal",
       "primaryLanguage": "Rust",
       "starredAt": "2025-04-17T09:39:47Z"
@@ -585,7 +586,7 @@
     {
       "nameWithOwner": "codecrafters-io/build-your-own-x",
       "url": "https://github.com/codecrafters-io/build-your-own-x",
-      "stargazerCount": 406512,
+      "stargazerCount": 406514,
       "description": "Master programming by recreating your favorite technologies from scratch.",
       "primaryLanguage": "Markdown",
       "starredAt": "2025-04-14T09:59:19Z"
@@ -649,7 +650,7 @@
     {
       "nameWithOwner": "suitenumerique/docs",
       "url": "https://github.com/suitenumerique/docs",
-      "stargazerCount": 13113,
+      "stargazerCount": 13114,
       "description": "A collaborative note taking, wiki and documentation platform that scales. Built with Django and React. ",
       "primaryLanguage": "Python",
       "starredAt": "2025-03-23T08:30:11Z"
@@ -665,7 +666,7 @@
     {
       "nameWithOwner": "LadybirdBrowser/ladybird",
       "url": "https://github.com/LadybirdBrowser/ladybird",
-      "stargazerCount": 46156,
+      "stargazerCount": 46157,
       "description": "Truly independent web browser",
       "primaryLanguage": "C++",
       "starredAt": "2025-02-28T03:14:02Z"
@@ -689,7 +690,7 @@
     {
       "nameWithOwner": "anthropics/claude-code",
       "url": "https://github.com/anthropics/claude-code",
-      "stargazerCount": 27613,
+      "stargazerCount": 27617,
       "description": "Claude Code is an agentic coding tool that lives in your terminal, understands your codebase, and helps you code faster by executing routine tasks, explaining complex code, and handling git workflows - all through natural language commands.",
       "primaryLanguage": "PowerShell",
       "starredAt": "2025-02-26T09:08:54Z"
@@ -737,7 +738,7 @@
     {
       "nameWithOwner": "zed-industries/zed",
       "url": "https://github.com/zed-industries/zed",
-      "stargazerCount": 63314,
+      "stargazerCount": 63315,
       "description": "Code at the speed of thought – Zed is a high-performance, multiplayer code editor from the creators of Atom and Tree-sitter.",
       "primaryLanguage": "Rust",
       "starredAt": "2025-02-16T10:55:38Z"
@@ -777,7 +778,7 @@
     {
       "nameWithOwner": "slidevjs/slidev",
       "url": "https://github.com/slidevjs/slidev",
-      "stargazerCount": 39191,
+      "stargazerCount": 39190,
       "description": "Presentation Slides for Developers",
       "primaryLanguage": "TypeScript",
       "starredAt": "2025-02-12T19:48:54Z"
@@ -817,7 +818,7 @@
     {
       "nameWithOwner": "huggingface/smolagents",
       "url": "https://github.com/huggingface/smolagents",
-      "stargazerCount": 21771,
+      "stargazerCount": 21772,
       "description": "🤗 smolagents: a barebones library for agents that think in code.",
       "primaryLanguage": "Python",
       "starredAt": "2025-02-07T13:04:09Z"
@@ -865,7 +866,7 @@
     {
       "nameWithOwner": "punkpeye/awesome-mcp-servers",
       "url": "https://github.com/punkpeye/awesome-mcp-servers",
-      "stargazerCount": 64464,
+      "stargazerCount": 64465,
       "description": "A collection of MCP servers.",
       "primaryLanguage": null,
       "starredAt": "2025-02-05T20:04:10Z"
@@ -945,7 +946,7 @@
     {
       "nameWithOwner": "block/goose",
       "url": "https://github.com/block/goose",
-      "stargazerCount": 18010,
+      "stargazerCount": 18011,
       "description": "an open source, extensible AI agent that goes beyond code suggestions - install, execute, edit, and test with any LLM",
       "primaryLanguage": "Rust",
       "starredAt": "2025-01-30T19:02:12Z"
@@ -1001,7 +1002,7 @@
     {
       "nameWithOwner": "modelcontextprotocol/servers",
       "url": "https://github.com/modelcontextprotocol/servers",
-      "stargazerCount": 62641,
+      "stargazerCount": 62642,
       "description": "Model Context Protocol Servers",
       "primaryLanguage": "TypeScript",
       "starredAt": "2025-01-26T03:25:50Z"
@@ -1057,7 +1058,7 @@
     {
       "nameWithOwner": "anthropics/anthropic-cookbook",
       "url": "https://github.com/anthropics/anthropic-cookbook",
-      "stargazerCount": 18678,
+      "stargazerCount": 18679,
       "description": "A collection of notebooks/recipes showcasing some fun and effective ways of using Claude.",
       "primaryLanguage": "Jupyter Notebook",
       "starredAt": "2025-01-24T21:22:08Z"
@@ -1465,7 +1466,7 @@
     {
       "nameWithOwner": "ItzCrazyKns/Perplexica",
       "url": "https://github.com/ItzCrazyKns/Perplexica",
-      "stargazerCount": 23339,
+      "stargazerCount": 23338,
       "description": "Perplexica is an AI-powered search engine. It is an Open source alternative to Perplexity AI",
       "primaryLanguage": "TypeScript",
       "starredAt": "2024-05-24T06:07:13Z"
@@ -1553,7 +1554,7 @@
     {
       "nameWithOwner": "awesome-selfhosted/awesome-selfhosted",
       "url": "https://github.com/awesome-selfhosted/awesome-selfhosted",
-      "stargazerCount": 239943,
+      "stargazerCount": 239945,
       "description": "A list of Free Software network services and web applications which can be hosted on your own servers",
       "primaryLanguage": null,
       "starredAt": "2024-03-21T02:12:32Z"
@@ -2665,7 +2666,7 @@
     {
       "nameWithOwner": "f/awesome-chatgpt-prompts",
       "url": "https://github.com/f/awesome-chatgpt-prompts",
-      "stargazerCount": 131886,
+      "stargazerCount": 131887,
       "description": "This repo includes ChatGPT prompt curation to use ChatGPT and other LLM tools better.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2023-01-25T11:06:27Z"
@@ -2713,7 +2714,7 @@
     {
       "nameWithOwner": "hotwired/turbo",
       "url": "https://github.com/hotwired/turbo",
-      "stargazerCount": 7077,
+      "stargazerCount": 7078,
       "description": "The speed of a single-page web application without having to write any JavaScript",
       "primaryLanguage": "JavaScript",
       "starredAt": "2022-11-02T12:44:39Z"
@@ -3049,7 +3050,7 @@
     {
       "nameWithOwner": "AUTOMATIC1111/stable-diffusion-webui",
       "url": "https://github.com/AUTOMATIC1111/stable-diffusion-webui",
-      "stargazerCount": 155154,
+      "stargazerCount": 155155,
       "description": "Stable Diffusion web UI",
       "primaryLanguage": "Python",
       "starredAt": "2022-09-15T09:41:35Z"
@@ -3465,7 +3466,7 @@
     {
       "nameWithOwner": "tldraw/tldraw",
       "url": "https://github.com/tldraw/tldraw",
-      "stargazerCount": 41121,
+      "stargazerCount": 41122,
       "description": "very good whiteboard SDK / infinite canvas SDK",
       "primaryLanguage": "TypeScript",
       "starredAt": "2021-12-18T05:14:11Z"
@@ -4641,7 +4642,7 @@
     {
       "nameWithOwner": "caddyserver/caddy",
       "url": "https://github.com/caddyserver/caddy",
-      "stargazerCount": 65919,
+      "stargazerCount": 65920,
       "description": "Fast and extensible multi-platform HTTP/1-2-3 web server with automatic HTTPS",
       "primaryLanguage": "Go",
       "starredAt": "2021-03-03T10:20:45Z"
@@ -4929,7 +4930,7 @@
     {
       "nameWithOwner": "excalidraw/excalidraw",
       "url": "https://github.com/excalidraw/excalidraw",
-      "stargazerCount": 104753,
+      "stargazerCount": 104754,
       "description": "Virtual whiteboard for sketching hand-drawn like diagrams",
       "primaryLanguage": "TypeScript",
       "starredAt": "2021-02-12T09:45:54Z"
@@ -5665,7 +5666,7 @@
     {
       "nameWithOwner": "rclone/rclone",
       "url": "https://github.com/rclone/rclone",
-      "stargazerCount": 51784,
+      "stargazerCount": 51785,
       "description": "\"rsync for cloud storage\" - Google Drive, S3, Dropbox, Backblaze B2, One Drive, Swift, Hubic, Wasabi, Google Cloud Storage, Azure Blob, Azure Files, Yandex Files",
       "primaryLanguage": "Go",
       "starredAt": "2020-10-19T01:36:41Z"
@@ -6417,7 +6418,7 @@
     {
       "nameWithOwner": "supabase/supabase",
       "url": "https://github.com/supabase/supabase",
-      "stargazerCount": 86481,
+      "stargazerCount": 86482,
       "description": "The Postgres development platform. Supabase gives you a dedicated Postgres database to build your web, mobile, and AI applications.",
       "primaryLanguage": "TypeScript",
       "starredAt": "2020-06-02T19:33:37Z"
@@ -7857,7 +7858,7 @@
     {
       "nameWithOwner": "ripienaar/free-for-dev",
       "url": "https://github.com/ripienaar/free-for-dev",
-      "stargazerCount": 108426,
+      "stargazerCount": 108427,
       "description": "A list of SaaS, PaaS and IaaS offerings that have free tiers of interest to devops and infradev",
       "primaryLanguage": "HTML",
       "starredAt": "2019-10-28T02:19:57Z"
@@ -8097,7 +8098,7 @@
     {
       "nameWithOwner": "firefly-iii/firefly-iii",
       "url": "https://github.com/firefly-iii/firefly-iii",
-      "stargazerCount": 19957,
+      "stargazerCount": 19958,
       "description": "Firefly III: a personal finances manager",
       "primaryLanguage": "PHP",
       "starredAt": "2019-10-03T03:17:03Z"
@@ -9065,7 +9066,7 @@
     {
       "nameWithOwner": "kubernetes/kubernetes",
       "url": "https://github.com/kubernetes/kubernetes",
-      "stargazerCount": 116654,
+      "stargazerCount": 116655,
       "description": "Production-Grade Container Scheduling and Management",
       "primaryLanguage": "Go",
       "starredAt": "2019-07-16T23:11:17Z"
@@ -10849,7 +10850,7 @@
     {
       "nameWithOwner": "trimstray/the-book-of-secret-knowledge",
       "url": "https://github.com/trimstray/the-book-of-secret-knowledge",
-      "stargazerCount": 180820,
+      "stargazerCount": 180821,
       "description": "A collection of inspiring lists, manuals, cheatsheets, blogs, hacks, one-liners, cli/web tools and more.",
       "primaryLanguage": null,
       "starredAt": "2019-02-25T03:03:10Z"
@@ -11729,7 +11730,7 @@
     {
       "nameWithOwner": "sharkdp/bat",
       "url": "https://github.com/sharkdp/bat",
-      "stargazerCount": 53720,
+      "stargazerCount": 53721,
       "description": "A cat(1) clone with wings.",
       "primaryLanguage": "Rust",
       "starredAt": "2019-01-08T01:25:43Z"
@@ -11913,7 +11914,7 @@
     {
       "nameWithOwner": "developit/htm",
       "url": "https://github.com/developit/htm",
-      "stargazerCount": 8910,
+      "stargazerCount": 8911,
       "description": "Hyperscript Tagged Markup: JSX alternative using standard tagged templates, with compiler support.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2018-12-13T10:36:21Z"
@@ -12865,7 +12866,7 @@
     {
       "nameWithOwner": "browsh-org/browsh",
       "url": "https://github.com/browsh-org/browsh",
-      "stargazerCount": 17709,
+      "stargazerCount": 17708,
       "description": "A fully-modern text-based browser, rendering to TTY and browsers",
       "primaryLanguage": "JavaScript",
       "starredAt": "2018-07-12T22:43:30Z"
@@ -12977,7 +12978,7 @@
     {
       "nameWithOwner": "justadudewhohacks/face-api.js",
       "url": "https://github.com/justadudewhohacks/face-api.js",
-      "stargazerCount": 17406,
+      "stargazerCount": 17407,
       "description": "JavaScript API for face detection and face recognition in the browser and nodejs with tensorflow.js",
       "primaryLanguage": "TypeScript",
       "starredAt": "2018-07-04T00:30:33Z"
@@ -14337,7 +14338,7 @@
     {
       "nameWithOwner": "flutter/flutter",
       "url": "https://github.com/flutter/flutter",
-      "stargazerCount": 171647,
+      "stargazerCount": 171646,
       "description": "Flutter makes it easy and fast to build beautiful apps for mobile and beyond",
       "primaryLanguage": "Dart",
       "starredAt": "2018-02-28T18:41:23Z"
@@ -14921,7 +14922,7 @@
     {
       "nameWithOwner": "amark/gun",
       "url": "https://github.com/amark/gun",
-      "stargazerCount": 18523,
+      "stargazerCount": 18524,
       "description": "An open source cybersecurity protocol for syncing decentralized graph data.",
       "primaryLanguage": "JavaScript",
       "starredAt": "2018-01-25T01:23:56Z"
@@ -16201,7 +16202,7 @@
     {
       "nameWithOwner": "tonsky/FiraCode",
       "url": "https://github.com/tonsky/FiraCode",
-      "stargazerCount": 79758,
+      "stargazerCount": 79759,
       "description": "Free monospaced font with programming ligatures",
       "primaryLanguage": "Clojure",
       "starredAt": "2017-10-21T12:10:01Z"
@@ -17617,7 +17618,7 @@
     {
       "nameWithOwner": "ai/nanoid",
       "url": "https://github.com/ai/nanoid",
-      "stargazerCount": 25949,
+      "stargazerCount": 25950,
       "description": "A tiny (124 bytes), secure, URL-friendly, unique string ID generator for JavaScript",
       "primaryLanguage": "JavaScript",
       "starredAt": "2017-09-07T04:50:22Z"
@@ -17985,7 +17986,7 @@
     {
       "nameWithOwner": "torvalds/linux",
       "url": "https://github.com/torvalds/linux",
-      "stargazerCount": 198863,
+      "stargazerCount": 198864,
       "description": "Linux kernel source tree",
       "primaryLanguage": "C",
       "starredAt": "2017-07-19T04:56:43Z"
@@ -18769,7 +18770,7 @@
     {
       "nameWithOwner": "sdmg15/Best-websites-a-programmer-should-visit",
       "url": "https://github.com/sdmg15/Best-websites-a-programmer-should-visit",
-      "stargazerCount": 72286,
+      "stargazerCount": 72287,
       "description": ":link: Some useful websites for programmers.",
       "primaryLanguage": null,
       "starredAt": "2017-06-07T01:35:13Z"
@@ -20001,7 +20002,7 @@
     {
       "nameWithOwner": "microsoft/vscode",
       "url": "https://github.com/microsoft/vscode",
-      "stargazerCount": 175267,
+      "stargazerCount": 175268,
       "description": "Visual Studio Code",
       "primaryLanguage": "TypeScript",
       "starredAt": "2017-03-02T04:47:25Z"
@@ -22153,7 +22154,7 @@
     {
       "nameWithOwner": "react-native-elements/react-native-elements",
       "url": "https://github.com/react-native-elements/react-native-elements",
-      "stargazerCount": 25514,
+      "stargazerCount": 25515,
       "description": "Cross-Platform React Native UI Toolkit",
       "primaryLanguage": "MDX",
       "starredAt": "2016-09-10T08:40:47Z"
@@ -23321,7 +23322,7 @@
     {
       "nameWithOwner": "freeCodeCamp/freeCodeCamp",
       "url": "https://github.com/freeCodeCamp/freeCodeCamp",
-      "stargazerCount": 424969,
+      "stargazerCount": 424970,
       "description": "freeCodeCamp.org's open-source codebase and curriculum. Learn math, programming, and computer science for free.",
       "primaryLanguage": "TypeScript",
       "starredAt": "2016-04-28T08:57:17Z"
@@ -23433,7 +23434,7 @@
     {
       "nameWithOwner": "kriasoft/react-starter-kit",
       "url": "https://github.com/kriasoft/react-starter-kit",
-      "stargazerCount": 23017,
+      "stargazerCount": 23018,
       "description": "Modern React starter kit with Bun, TypeScript, Tailwind CSS, tRPC, and Cloudflare Workers. Production-ready monorepo for building fast web apps.",
       "primaryLanguage": "TypeScript",
       "starredAt": "2016-04-22T07:24:54Z"
@@ -23777,7 +23778,7 @@
     {
       "nameWithOwner": "sindresorhus/awesome",
       "url": "https://github.com/sindresorhus/awesome",
-      "stargazerCount": 388446,
+      "stargazerCount": 388448,
       "description": "😎 Awesome lists about all kinds of interesting topics",
       "primaryLanguage": null,
       "starredAt": "2016-04-11T00:49:12Z"
@@ -24121,7 +24122,7 @@
     {
       "nameWithOwner": "certbot/certbot",
       "url": "https://github.com/certbot/certbot",
-      "stargazerCount": 32361,
+      "stargazerCount": 32362,
       "description": "Certbot is EFF's tool to obtain certs from Let's Encrypt and (optionally) auto-enable HTTPS on your server.  It can also act as a client for any other CA that uses the ACME protocol.",
       "primaryLanguage": "Python",
       "starredAt": "2016-03-03T01:49:29Z"
@@ -24417,7 +24418,7 @@
     {
       "nameWithOwner": "nodejs/node",
       "url": "https://github.com/nodejs/node",
-      "stargazerCount": 112494,
+      "stargazerCount": 112495,
       "description": "Node.js JavaScript runtime ✨🐢🚀✨",
       "primaryLanguage": "JavaScript",
       "starredAt": "2016-02-22T21:02:26Z"

--- a/src/pages/stars/[year].astro
+++ b/src/pages/stars/[year].astro
@@ -5,24 +5,30 @@ import Header from '../../components/Nav.astro'
 import Footer from '../../components/Footer.astro'
 import GitHubStars from '../../components/GitHubStars.astro'
 import StarsPagination from '../../components/StarsPagination.astro'
+import Search from 'astro-pagefind/components/Search'
 import { SITE_TITLE, SITE_DESCRIPTION } from '../../config'
 import starsData from '../../data/github-stars.json'
 
 export async function getStaticPaths() {
   const { stars } = starsData
-  
+
   // Group stars by year
-  const starsByYear = stars.reduce((acc, star) => {
-    const year = new Date(star.starredAt).getFullYear()
-    if (!acc[year]) {
-      acc[year] = []
-    }
-    acc[year].push(star)
-    return acc
-  }, {} as Record<number, typeof stars>)
+  const starsByYear = stars.reduce(
+    (acc, star) => {
+      const year = new Date(star.starredAt).getFullYear()
+      if (!acc[year]) {
+        acc[year] = []
+      }
+      acc[year].push(star)
+      return acc
+    },
+    {} as Record<number, typeof stars>
+  )
 
   // Get all years and sort them in descending order (most recent first)
-  const years = Object.keys(starsByYear).map(Number).sort((a, b) => b - a)
+  const years = Object.keys(starsByYear)
+    .map(Number)
+    .sort((a, b) => b - a)
 
   return years.map((year) => {
     const yearStars = starsByYear[year]
@@ -32,14 +38,13 @@ export async function getStaticPaths() {
         stars: yearStars,
         currentYear: year,
         years,
-        totalCount: stars.length,
         yearCount: yearStars.length,
       },
     }
   })
 }
 
-const { stars, currentYear, years, totalCount, yearCount } = Astro.props
+const { stars, currentYear, years, yearCount } = Astro.props
 
 if (import.meta.env.PROD) {
   // Set the Netlify on-demand builders TTL for this page to 24 hours
@@ -63,6 +68,19 @@ if (import.meta.env.PROD) {
         <div class="container skinny">
           <h2>Starred GitHub Repos ({currentYear})</h2>
           <p>{yearCount} repositories starred in {currentYear}</p>
+
+          <div class="textContainer">
+            <div class="search-container">
+              <Search
+                className="pagefind-ui"
+                uiOptions={{
+                  showImages: false,
+                  showSubResults: false,
+                  excerptLength: 30,
+                }}
+              />
+            </div>
+          </div>
 
           <StarsPagination currentYear={currentYear} years={years} />
 
@@ -103,6 +121,37 @@ if (import.meta.env.PROD) {
           border-radius: 50%;
           margin-right: 0.5rem;
           background-color: var(--language-color);
+        }
+      }
+
+      .search-container {
+        margin: 2rem 0;
+        border-radius: 8px;
+
+        --pagefind-ui-scale: 0.9;
+        --pagefind-ui-primary: var(--color-highlight);
+        --pagefind-ui-text: var(--color-text);
+        --pagefind-ui-background: var(--color-background);
+        --pagefind-ui-border: var(--color-lightGrey);
+        --pagefind-ui-tag: transparent;
+        --pagefind-ui-border-width: 1px;
+        --pagefind-ui-border-radius: 4px;
+        --pagefind-ui-image-border-radius: 4px;
+        --pagefind-ui-font: var(--font-system);
+        --pagefind-mark: var(--color-highlight);
+
+        .pagefind-ui__result {
+          padding: calc(10px * var(--pagefind-ui-scale)) 0
+            calc(10px * var(--pagefind-ui-scale));
+          border-top: none;
+        }
+
+        .pagefind-ui__result-title {
+          text-decoration: underline;
+        }
+        .pagefind-ui__result-excerpt mark {
+          background-color: var(--color-highlight-almost-transparent);
+          color: var(--color-highlight);
         }
       }
     </style>

--- a/src/pages/stars/[year].astro
+++ b/src/pages/stars/[year].astro
@@ -5,7 +5,7 @@ import Header from '../../components/Nav.astro'
 import Footer from '../../components/Footer.astro'
 import GitHubStars from '../../components/GitHubStars.astro'
 import StarsPagination from '../../components/StarsPagination.astro'
-import Search from 'astro-pagefind/components/Search'
+import StarsSearch from '../../components/StarsSearch.astro'
 import { SITE_TITLE, SITE_DESCRIPTION } from '../../config'
 import starsData from '../../data/github-stars.json'
 
@@ -69,18 +69,7 @@ if (import.meta.env.PROD) {
           <h2>Starred GitHub Repos ({currentYear})</h2>
           <p>{yearCount} repositories starred in {currentYear}</p>
 
-          <div class="textContainer">
-            <div class="search-container">
-              <Search
-                className="pagefind-ui"
-                uiOptions={{
-                  showImages: false,
-                  showSubResults: false,
-                  excerptLength: 30,
-                }}
-              />
-            </div>
-          </div>
+          <StarsSearch />
 
           <StarsPagination currentYear={currentYear} years={years} />
 
@@ -124,36 +113,6 @@ if (import.meta.env.PROD) {
         }
       }
 
-      .search-container {
-        margin: 2rem 0;
-        border-radius: 8px;
-
-        --pagefind-ui-scale: 0.9;
-        --pagefind-ui-primary: var(--color-highlight);
-        --pagefind-ui-text: var(--color-text);
-        --pagefind-ui-background: var(--color-background);
-        --pagefind-ui-border: var(--color-lightGrey);
-        --pagefind-ui-tag: transparent;
-        --pagefind-ui-border-width: 1px;
-        --pagefind-ui-border-radius: 4px;
-        --pagefind-ui-image-border-radius: 4px;
-        --pagefind-ui-font: var(--font-system);
-        --pagefind-mark: var(--color-highlight);
-
-        .pagefind-ui__result {
-          padding: calc(10px * var(--pagefind-ui-scale)) 0
-            calc(10px * var(--pagefind-ui-scale));
-          border-top: none;
-        }
-
-        .pagefind-ui__result-title {
-          text-decoration: underline;
-        }
-        .pagefind-ui__result-excerpt mark {
-          background-color: var(--color-highlight-almost-transparent);
-          color: var(--color-highlight);
-        }
-      }
     </style>
   </body>
 </html>

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -78,7 +78,8 @@ body {
   -webkit-font-smoothing: antialiased;
 }
 
-::selection {
+::selection,
+mark {
   background-color: var(--color-highlight);
   color: var(--black);
 }

--- a/tests/search.spec.ts
+++ b/tests/search.spec.ts
@@ -1,0 +1,83 @@
+import { expect, test } from '@playwright/test'
+
+test.describe('GitHub Stars Search', () => {
+  test('search functionality works on stars page', async ({ page }) => {
+    // Navigate to the current year stars page
+    await page.goto('/stars/2025/')
+
+    // Wait for the page to load and search component to be available
+    await page.waitForSelector('.search-container')
+
+    // Find the search input using getByPlaceholder for better user-facing selection
+    const searchInput = page.getByPlaceholder('Search')
+    await expect(searchInput).toBeVisible()
+
+    // Search for TypeScript repositories
+    await searchInput.fill('typescript')
+
+    // Wait a moment for search results to appear
+    await page.waitForTimeout(1000)
+
+    // Check that search results are displayed
+    const searchResults = page.locator('.pagefind-ui__results')
+    await expect(searchResults).toBeVisible()
+
+    // Verify that results contain expected TypeScript repositories
+    const resultItems = page.locator('.pagefind-ui__result')
+    const resultCount = await resultItems.count()
+    expect(resultCount).toBeGreaterThan(0)
+
+    // Check that at least one result contains TypeScript-related content
+    const firstResult = resultItems.first()
+    await expect(firstResult).toBeVisible()
+  })
+
+  test('search clears and resets properly', async ({ page }) => {
+    await page.goto('/stars/2025/')
+    await page.waitForSelector('.search-container')
+
+    const searchInput = page.getByPlaceholder('Search')
+
+    // Perform a search
+    await searchInput.fill('react')
+    await page.waitForTimeout(1000)
+
+    // Verify results appear
+    const searchResults = page.locator('.pagefind-ui__results')
+    await expect(searchResults).toBeVisible()
+
+    // Clear the search
+    await searchInput.clear()
+    await page.waitForTimeout(500)
+
+    // Verify search results are hidden/cleared
+    const resultItems = page.locator('.pagefind-ui__result')
+    await expect(resultItems).toHaveCount(0)
+  })
+
+  test('search works across different years', async ({ page }) => {
+    // Test search on 2024 stars page
+    await page.goto('/stars/2024/')
+    await page.waitForSelector('.search-container')
+
+    const searchInput = page.getByPlaceholder('Search')
+    await searchInput.fill('javascript')
+    await page.waitForTimeout(1000)
+
+    const searchResults = page.locator('.pagefind-ui__results')
+    await expect(searchResults).toBeVisible()
+
+    const resultItems = page.locator('.pagefind-ui__result')
+    const resultCount = await resultItems.count()
+    expect(resultCount).toBeGreaterThan(0)
+  })
+
+  test('search container is visible', async ({ page }) => {
+    await page.goto('/stars/2025/')
+    await page.waitForSelector('.search-container')
+
+    // Verify search input is accessible
+    const searchInput = page.getByPlaceholder('Search')
+    await expect(searchInput).toBeVisible()
+  })
+})


### PR DESCRIPTION
## Summary
- Add static search functionality for GitHub stars using Pagefind
- Custom Node.js indexing creates individual repository records
- Search UI integrates with existing theme system and dark/light mode

## Technical Changes
- Added Search component to stars pages with theme-aware styling
- Custom indexing script indexes 3,000+ repositories individually
- Updated build process to generate search index automatically
- Search UI uses existing CSS variables for consistent theming
- Improved GitHub stars cache staleness check using cacheTimestamp

## Test Plan
- [x] Search works across all repository years
- [x] Dark/light mode theming works correctly
- [x] Individual repository records prevent content overlap
- [x] Build process generates search index successfully
- [x] E2E tests verify search functionality, clearing behaviour, and cross-year compatibility